### PR TITLE
Implement hashcode and equals for some structures

### DIFF
--- a/minestom-patches/0012-Implement-equals-and-hashcode.patch
+++ b/minestom-patches/0012-Implement-equals-and-hashcode.patch
@@ -1,0 +1,58 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: theEvilReaper <steffenwx@gmail.com>
+Date: Mon, 17 Jul 2023 20:35:27 +0200
+Subject: [PATCH] Implement equals and hashcode
+
+
+diff --git a/src/main/java/net/minestom/server/entity/Entity.java b/src/main/java/net/minestom/server/entity/Entity.java
+index daf0ece5bc96be7862d265f89ae8edee6958fc13..ff0b45ffe8ac3ce607de0c4312b11451014a11a5 100644
+--- a/src/main/java/net/minestom/server/entity/Entity.java
++++ b/src/main/java/net/minestom/server/entity/Entity.java
+@@ -477,6 +477,21 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
+         return viewers;
+     }
+ 
++    //Microtus start - equals and hashcode
++    @Override
++    public boolean equals(Object o) {
++        if (this == o) return true;
++        if (o == null || getClass() != o.getClass()) return false;
++        Entity entity = (Entity) o;
++        return Objects.equals(uuid, entity.uuid);
++    }
++
++    @Override
++    public int hashCode() {
++        return Objects.hash(uuid);
++    }
++    //Microtus end - equals and hashcode
++
+     /**
+      * Gets if this entity's viewers (surrounding players) can be predicted from surrounding chunks.
+      */
+diff --git a/src/main/java/net/minestom/server/instance/Instance.java b/src/main/java/net/minestom/server/instance/Instance.java
+index b7c5affa63ebe29d30996718c3402d8348137f7d..d6dd0549db22ee58c4057012fcc46a3aba8f087b 100644
+--- a/src/main/java/net/minestom/server/instance/Instance.java
++++ b/src/main/java/net/minestom/server/instance/Instance.java
+@@ -451,6 +451,21 @@ public abstract class Instance implements Block.Getter, Block.Setter,
+         return new TimeUpdatePacket(worldAge, time);
+     }
+ 
++    //Microtus start - equals and hashcode
++    @Override
++    public boolean equals(Object o) {
++        if (this == o) return true;
++        if (o == null || getClass() != o.getClass()) return false;
++        Instance instance = (Instance) o;
++        return Objects.equals(uniqueId, instance.uniqueId);
++    }
++
++    @Override
++    public int hashCode() {
++        return Objects.hash(uniqueId);
++    }
++    //Microtus end - equals and hashcode
++
+     /**
+      * Gets the instance {@link WorldBorder};
+      *

--- a/minestom-patches/0012-Implement-equals-and-hashcode.patch
+++ b/minestom-patches/0012-Implement-equals-and-hashcode.patch
@@ -56,3 +56,44 @@ index b7c5affa63ebe29d30996718c3402d8348137f7d..d6dd0549db22ee58c4057012fcc46a3a
      /**
       * Gets the instance {@link WorldBorder};
       *
+diff --git a/src/test/java/net/minestom/server/entity/EntityEqualsTest.java b/src/test/java/net/minestom/server/entity/EntityEqualsTest.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..e11088a617e6da7b058b6c6a8a8ffb311ceebe48
+--- /dev/null
++++ b/src/test/java/net/minestom/server/entity/EntityEqualsTest.java
+@@ -0,0 +1,13 @@
++package net.minestom.server.entity;
++
++import org.junit.jupiter.api.Test;
++
++import static org.junit.jupiter.api.Assertions.*;
++
++class EntityEqualsTest {
++
++    @Test
++    void testEntityEquals() {
++        assertNotEquals(new Entity(EntityTypes.BEE), new Entity(EntityTypes.BEE));
++    }
++}
+diff --git a/src/test/java/net/minestom/server/instance/InstanceEqualsTest.java b/src/test/java/net/minestom/server/instance/InstanceEqualsTest.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..305be82a87d514f18510d13364f0574f193a093a
+--- /dev/null
++++ b/src/test/java/net/minestom/server/instance/InstanceEqualsTest.java
+@@ -0,0 +1,16 @@
++package net.minestom.server.instance;
++
++import net.minestom.testing.Env;
++import net.minestom.testing.EnvTest;
++import org.junit.jupiter.api.Test;
++
++import static org.junit.jupiter.api.Assertions.*;
++
++@EnvTest
++class InstanceEqualsTest {
++
++    @Test
++    void testInstanceEquals(Env env) {
++        assertNotEquals(env.createFlatInstance(), env.createFlatInstance());
++    }
++}


### PR DESCRIPTION
## Proposed changes

Sometimes, Minestom stores player and instance objects in sets or maps. However, the "equals" and "hashcode" methods were not overridden in these mentioned objects. The pull request implements these two methods, allowing the objects to work more effectively with the storage structures.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...