### PR TITLE
Add missing telemetry variable to the advancement

### DIFF
--- a/minestom-patches/0016-Add-missing-telemetry-boolean-to-the-advancement-str.patch
+++ b/minestom-patches/0016-Add-missing-telemetry-boolean-to-the-advancement-str.patch
@@ -1,0 +1,220 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: theEvilReaper <steffenwx@gmail.com>
+Date: Sun, 6 Aug 2023 16:27:41 +0200
+Subject: [PATCH] Add missing telemetry boolean to the advancement structure
+
+
+diff --git a/demo/src/main/java/net/minestom/demo/Main.java b/demo/src/main/java/net/minestom/demo/Main.java
+index 114b0f3c6ecbc267b91617655ebb02f1e96134dc..c9ac500c4626b6d9a6c2f77c020553b9e5b3dfc2 100644
+--- a/demo/src/main/java/net/minestom/demo/Main.java
++++ b/demo/src/main/java/net/minestom/demo/Main.java
+@@ -54,6 +54,7 @@ public class Main {
+         commandManager.register(new ExecuteCommand());
+         commandManager.register(new RedirectTestCommand());
+         commandManager.register(new DebugGridCommand());
++        commandManager.register(new NotificationCommand()); // Microtus - advancement telemetry fix
+ 
+         commandManager.setUnknownCommandCallback((sender, command) -> sender.sendMessage(Component.text("Unknown command", NamedTextColor.RED)));
+ 
+diff --git a/demo/src/main/java/net/minestom/demo/commands/NotificationCommand.java b/demo/src/main/java/net/minestom/demo/commands/NotificationCommand.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..ea041d3b6beef83a95a6baced289165a499e3067
+--- /dev/null
++++ b/demo/src/main/java/net/minestom/demo/commands/NotificationCommand.java
+@@ -0,0 +1,23 @@
++package net.minestom.demo.commands;
++
++import net.kyori.adventure.text.Component;
++import net.minestom.server.advancements.FrameType;
++import net.minestom.server.advancements.notifications.Notification;
++import net.minestom.server.advancements.notifications.NotificationCenter;
++import net.minestom.server.command.builder.Command;
++import net.minestom.server.entity.Player;
++import net.minestom.server.item.Material;
++
++// Microtus - advancement telemetry fix
++public final class NotificationCommand extends Command {
++    public NotificationCommand() {
++        super("notification");
++
++        setDefaultExecutor((sender, context) -> {
++            var player = (Player) sender;
++
++            var notification = new Notification(Component.text("Hello World!"), FrameType.GOAL, Material.DIAMOND_AXE);
++            NotificationCenter.send(notification, player);
++        });
++    }
++}
+diff --git a/src/main/java/net/minestom/server/advancements/Advancement.java b/src/main/java/net/minestom/server/advancements/Advancement.java
+index 092d46cb4e8d69b760db9b9dd3bdc86947dfb918..2cce46d539b289b78d51ad9b6cf55fb073faed36 100644
+--- a/src/main/java/net/minestom/server/advancements/Advancement.java
++++ b/src/main/java/net/minestom/server/advancements/Advancement.java
+@@ -17,44 +17,79 @@ import java.util.List;
+ public class Advancement {
+ 
+     protected AdvancementTab tab;
+-
+     private boolean achieved;
+-
+     private Component title;
+     private Component description;
+-
+     private ItemStack icon;
+-
+     private FrameType frameType;
+-
+     private String background; // Only on root
+     private boolean toast;
+     private boolean hidden;
+-
+-    private float x, y;
+-
++    private float x;
++    private float y;
++    private final boolean telemetryData; // Microtus - advancement telemetry fix
+     private String identifier;
+     private Advancement parent;
+ 
+     // Packet
+     private AdvancementsPacket.Criteria criteria;
+ 
++    // Microtus start - advancement telemetry fix
++    /**
++     * Creates a new object from the Advancement with disabled telemetry.
++     * @param title the title to show
++     * @param description the description to show
++     * @param icon the icon to show
++     * @param frameType the
++     * @param x the x position
++     * @param y the y position
++     */
++    public Advancement(@NotNull Component title, @NotNull Component description,
++                       @NotNull Material icon, @NotNull FrameType frameType,
++                       float x, float y) {
++        this(title, description, ItemStack.of(icon), frameType, x, y, false);
++    }
++
++    /**
++     * Creates a new object from the Advancement with disabled telemetry.
++     * @param title the title to show
++     * @param description the description to show
++     * @param icon the icon to show
++     * @param frameType the
++     * @param x the x position
++     * @param y the y position
++     */
+     public Advancement(@NotNull Component title, Component description,
+                        @NotNull ItemStack icon, @NotNull FrameType frameType,
+                        float x, float y) {
++        this(title, description, icon, frameType, x, y, false);
++    }
++
++
++    /**
++     * Creates a new object from the Advancement with the given values.
++     * Only this constructor has the option to set the telemetry boolean.
++     * Each other variant has this option set to false by default
++     * @param title the title to show
++     * @param description the description to show
++     * @param icon the icon to show
++     * @param frameType the
++     * @param x the x position
++     * @param y the y position
++     * @param telemetryData if the advancement sends telemetry data
++     */
++    public Advancement(@NotNull Component title, Component description,
++                       @NotNull ItemStack icon, @NotNull FrameType frameType,
++                       float x, float y, boolean telemetryData) {
+         this.title = title;
+         this.description = description;
+         this.icon = icon;
+         this.frameType = frameType;
+         this.x = x;
+         this.y = y;
++        this.telemetryData = telemetryData;
+     }
+-
+-    public Advancement(@NotNull Component title, @NotNull Component description,
+-                       @NotNull Material icon, @NotNull FrameType frameType,
+-                       float x, float y) {
+-        this(title, description, ItemStack.of(icon), frameType, x, y);
+-    }
++    // Microtus end - advancement telemetry fix
+ 
+     /**
+      * Gets if the advancement is achieved.
+@@ -301,7 +336,8 @@ public class Advancement {
+         final String parentIdentifier = parent != null ? parent.getIdentifier() : null;
+         AdvancementsPacket.Advancement adv = new AdvancementsPacket.Advancement(parentIdentifier, toDisplayData(),
+                 List.of(criteria.criterionIdentifier()),
+-                List.of(new AdvancementsPacket.Requirement(List.of(criteria.criterionIdentifier()))));
++                List.of(new AdvancementsPacket.Requirement(List.of(criteria.criterionIdentifier()))),
++                telemetryData);
+         return new AdvancementsPacket.AdvancementMapping(getIdentifier(), adv);
+     }
+ 
+diff --git a/src/main/java/net/minestom/server/advancements/notifications/NotificationCenter.java b/src/main/java/net/minestom/server/advancements/notifications/NotificationCenter.java
+index c9d38536ecf8e7ec0eebd9cf8b4eddb40596197e..e91776e889b8131cd4684c058ab5726448ae99b9 100644
+--- a/src/main/java/net/minestom/server/advancements/notifications/NotificationCenter.java
++++ b/src/main/java/net/minestom/server/advancements/notifications/NotificationCenter.java
+@@ -64,9 +64,13 @@ public final class NotificationCenter {
+         final var criteria = new AdvancementsPacket.Criteria("minestom:some_criteria",
+                 new AdvancementsPacket.CriterionProgress(System.currentTimeMillis()));
+ 
++        // Microtus start - advancement telemetry fix
+         final var advancement = new AdvancementsPacket.Advancement(null, displayData,
+                 List.of(criteria.criterionIdentifier()),
+-                List.of(new AdvancementsPacket.Requirement(List.of(criteria.criterionIdentifier()))));
++                List.of(new AdvancementsPacket.Requirement(List.of(criteria.criterionIdentifier()))),
++                false
++        );
++        // Microtus end - advancement telemetry fix
+ 
+         final var mapping = new AdvancementsPacket.AdvancementMapping(IDENTIFIER, advancement);
+         final var progressMapping = new AdvancementsPacket.ProgressMapping(IDENTIFIER,
+diff --git a/src/main/java/net/minestom/server/network/packet/server/play/AdvancementsPacket.java b/src/main/java/net/minestom/server/network/packet/server/play/AdvancementsPacket.java
+index 64ae00571d82181a85a0a482dc91e5dcdcebb7ba..dc0a0d12235944ae7154f5a756a67c3ca1b1a78b 100644
+--- a/src/main/java/net/minestom/server/network/packet/server/play/AdvancementsPacket.java
++++ b/src/main/java/net/minestom/server/network/packet/server/play/AdvancementsPacket.java
+@@ -100,7 +100,8 @@ public record AdvancementsPacket(boolean reset, @NotNull List<AdvancementMapping
+ 
+     public record Advancement(@Nullable String parentIdentifier, @Nullable DisplayData displayData,
+                               @NotNull List<String> criteria,
+-                              @NotNull List<Requirement> requirements) implements NetworkBuffer.Writer, ComponentHolder<Advancement> {
++                              @NotNull List<Requirement> requirements,
++                              boolean telemetryData) implements NetworkBuffer.Writer, ComponentHolder<Advancement> {
+         public Advancement {
+             criteria = List.copyOf(criteria);
+             requirements = List.copyOf(requirements);
+@@ -110,7 +111,9 @@ public record AdvancementsPacket(boolean reset, @NotNull List<AdvancementMapping
+             this(reader.read(BOOLEAN) ? reader.read(STRING) : null,
+                     reader.read(BOOLEAN) ? new DisplayData(reader) : null,
+                     reader.readCollection(STRING),
+-                    reader.readCollection(Requirement::new));
++                    reader.readCollection(Requirement::new),
++                    reader.read(BOOLEAN) // Microtus - advancement telemetry fix
++            );
+         }
+ 
+         @Override
+@@ -119,6 +122,7 @@ public record AdvancementsPacket(boolean reset, @NotNull List<AdvancementMapping
+             writer.writeOptional(displayData);
+             writer.writeCollection(STRING, criteria);
+             writer.writeCollection(requirements);
++            writer.write(BOOLEAN, telemetryData); // Microtus - advancement telemetry fix
+         }
+ 
+         @Override
+@@ -128,7 +132,11 @@ public record AdvancementsPacket(boolean reset, @NotNull List<AdvancementMapping
+ 
+         @Override
+         public @NotNull Advancement copyWithOperator(@NotNull UnaryOperator<Component> operator) {
+-            return this.displayData == null ? this : new Advancement(this.parentIdentifier, this.displayData.copyWithOperator(operator), this.criteria, this.requirements);
++            return this.displayData == null ? this : new Advancement(
++                    this.parentIdentifier,
++                    this.displayData.copyWithOperator(operator),
++                    this.criteria, this.requirements, this.telemetryData // Microtus - advancement telemetry fix
++            );
+         }
+     }
+ 


### PR DESCRIPTION
## Proposed changes

With the update to Minecraft version 1.19.4 or 1.20.1, a new boolean was added to the Advancement packet. However, it was not properly included, causing the notification function to kick the player from the server.

The missing value can be found here in the wiki under the advancement structure part: [Wiki.vg](https://wiki.vg/Protocol#Update_Advancements)

So this pull request resolves #29

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...