### PR TITLE
Improve entity position synchronisation

### DIFF
--- a/minestom-patches/0021-Improve-entity-position-synchronisation.patch
+++ b/minestom-patches/0021-Improve-entity-position-synchronisation.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: theEvilReaper <steffenwx@gmail.com>
+Date: Sat, 25 Nov 2023 19:53:19 +0100
+Subject: [PATCH] Improve entity position synchronisation
+
+
+diff --git a/src/main/java/net/minestom/server/entity/Entity.java b/src/main/java/net/minestom/server/entity/Entity.java
+index 8e7ad8420da6168ea2444dae90e5bc68bb32c176..3241e9577c38e301096cebf96cb72816d52bdcff 100644
+--- a/src/main/java/net/minestom/server/entity/Entity.java
++++ b/src/main/java/net/minestom/server/entity/Entity.java
+@@ -1340,7 +1340,10 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
+                     lastSyncedPosition, onGround), this);
+         } else if (viewChange) {
+             PacketUtils.prepareViewablePacket(chunk, new EntityHeadLookPacket(getEntityId(), position.yaw()), this);
+-            PacketUtils.prepareViewablePacket(chunk, new EntityRotationPacket(getEntityId(), position.yaw(), position.pitch(), onGround), this);
++            // Microtus start - position sync fix
++            PacketUtils.prepareViewablePacket(chunk, EntityPositionAndRotationPacket.getPacket(getEntityId(), position,
++                    lastSyncedPosition, isOnGround()), this);
++            // Microtus end - position sync fix
+         }
+         this.lastSyncedPosition = position;
+     }


### PR DESCRIPTION
## Proposed changes

In certain situations, the position of an entity is not properly synchronized, resulting in visual issues. To reproduce this behavior, it is sufficient to simply hide and then show players, causing them to no longer appear on the ground but instead hover slightly above it.

The pull request adds a fix for the mentioned problem. This PR was merged from [this](https://github.com/hollow-cube/minestom-ce/pull/72) 

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...