### PR TITLE
Deprecate inventory constructors which takes a string as parameter

### DIFF
--- a/minestom-patches/0015-Update-deprecated-methods.patch
+++ b/minestom-patches/0015-Update-deprecated-methods.patch
@@ -232,7 +232,7 @@ index 6108c4283fc1128fddd208914095cd7739524f0f..4667b7c3a3fe0a49c3b4e00210c10315
          return size;
      }
 diff --git a/src/main/java/net/minestom/server/inventory/type/AnvilInventory.java b/src/main/java/net/minestom/server/inventory/type/AnvilInventory.java
-index 8a7c9f2c154e22d3df90c8ee20856bb0b2f3d4de..e8b36d90398e88b220bc3e8a50a2572803658404 100644
+index 8a7c9f2c154e22d3df90c8ee20856bb0b2f3d4de..7ff6a34cb819f436c9965763fc08053019dd889e 100644
 --- a/src/main/java/net/minestom/server/inventory/type/AnvilInventory.java
 +++ b/src/main/java/net/minestom/server/inventory/type/AnvilInventory.java
 @@ -14,9 +14,17 @@ public class AnvilInventory extends Inventory {
@@ -242,7 +242,7 @@ index 8a7c9f2c154e22d3df90c8ee20856bb0b2f3d4de..e8b36d90398e88b220bc3e8a50a25728
 +    //Microtus start - Update deprecation status
 +    /**
 +     * Creates a new {@link AnvilInventory} reference with a given size and title.
-+     * The method is deprecated please use {@link AnvilInventory#(InventoryType, Component)} instead.
++     * The method is deprecated please use {@link AnvilInventory#(Component)} instead.
 +     * @param title the inventory title
 +     */
 +    @Deprecated(forRemoval = true, since = "1.1.3")
@@ -254,7 +254,7 @@ index 8a7c9f2c154e22d3df90c8ee20856bb0b2f3d4de..e8b36d90398e88b220bc3e8a50a25728
      /**
       * Gets the anvil repair cost.
 diff --git a/src/main/java/net/minestom/server/inventory/type/BeaconInventory.java b/src/main/java/net/minestom/server/inventory/type/BeaconInventory.java
-index 30551dae67cde1d869a4bd6b8645d0db317cf1a4..6d87a30775ae31f3036bbae9a04a4e3fcb110781 100644
+index 30551dae67cde1d869a4bd6b8645d0db317cf1a4..1f0fc8f8ed627efcd718b5b20009eea83192ad41 100644
 --- a/src/main/java/net/minestom/server/inventory/type/BeaconInventory.java
 +++ b/src/main/java/net/minestom/server/inventory/type/BeaconInventory.java
 @@ -17,9 +17,17 @@ public class BeaconInventory extends Inventory {
@@ -264,7 +264,7 @@ index 30551dae67cde1d869a4bd6b8645d0db317cf1a4..6d87a30775ae31f3036bbae9a04a4e3f
 +    //Microtus start - Update deprecation status
 +    /**
 +     * Creates a new {@link BeaconInventory} reference with a given size and title.
-+     * The method is deprecated please use {@link BeaconInventory#(InventoryType, Component)} instead.
++     * The method is deprecated please use {@link BeaconInventory#(Component)} instead.
 +     * @param title the inventory title
 +     */
 +    @Deprecated(forRemoval = true, since = "1.1.3")
@@ -276,7 +276,7 @@ index 30551dae67cde1d869a4bd6b8645d0db317cf1a4..6d87a30775ae31f3036bbae9a04a4e3f
      /**
       * Gets the beacon power level.
 diff --git a/src/main/java/net/minestom/server/inventory/type/BrewingStandInventory.java b/src/main/java/net/minestom/server/inventory/type/BrewingStandInventory.java
-index ed0bc7d783d17dcae72343138ffc3d36fad5b4d9..9b8536d92b6f86bb3636447dfb9ee52ad098f722 100644
+index ed0bc7d783d17dcae72343138ffc3d36fad5b4d9..4cd086fb91b82faa20ad58eed26feacb4295b0ba 100644
 --- a/src/main/java/net/minestom/server/inventory/type/BrewingStandInventory.java
 +++ b/src/main/java/net/minestom/server/inventory/type/BrewingStandInventory.java
 @@ -15,9 +15,17 @@ public class BrewingStandInventory extends Inventory {
@@ -286,7 +286,7 @@ index ed0bc7d783d17dcae72343138ffc3d36fad5b4d9..9b8536d92b6f86bb3636447dfb9ee52a
 +    //Microtus start - Update deprecation status
 +    /**
 +     * Creates a new {@link BrewingStandInventory} reference with a given size and title.
-+     * The method is deprecated please use {@link BrewingStandInventory#(InventoryType, Component)} instead.
++     * The method is deprecated please use {@link BrewingStandInventory#(Component)} instead.
 +     * @param title the inventory title
 +     */
 +    @Deprecated(forRemoval = true, since = "1.1.3")
@@ -298,7 +298,7 @@ index ed0bc7d783d17dcae72343138ffc3d36fad5b4d9..9b8536d92b6f86bb3636447dfb9ee52a
      /**
       * Gets the brewing stand brew time.
 diff --git a/src/main/java/net/minestom/server/inventory/type/EnchantmentTableInventory.java b/src/main/java/net/minestom/server/inventory/type/EnchantmentTableInventory.java
-index bd855c32a5171683627bf2729ab13ef0acebd934..3406dff2c0bf3f8fb8344d24d8a2af45700c288b 100644
+index bd855c32a5171683627bf2729ab13ef0acebd934..15f6ca069a34df26e1c28c5c5e3ec268df882646 100644
 --- a/src/main/java/net/minestom/server/inventory/type/EnchantmentTableInventory.java
 +++ b/src/main/java/net/minestom/server/inventory/type/EnchantmentTableInventory.java
 @@ -18,9 +18,17 @@ public class EnchantmentTableInventory extends Inventory {
@@ -308,7 +308,7 @@ index bd855c32a5171683627bf2729ab13ef0acebd934..3406dff2c0bf3f8fb8344d24d8a2af45
 +    //Microtus start - Update deprecation status
 +    /**
 +     * Creates a new {@link EnchantmentTableInventory} reference with a given size and title.
-+     * The method is deprecated please use {@link EnchantmentTableInventory#(InventoryType, Component)} instead.
++     * The method is deprecated please use {@link EnchantmentTableInventory#(Component)} instead.
 +     * @param title the inventory title
 +     */
 +    @Deprecated(forRemoval = true, since = "1.1.3")
@@ -320,7 +320,7 @@ index bd855c32a5171683627bf2729ab13ef0acebd934..3406dff2c0bf3f8fb8344d24d8a2af45
      /**
       * Gets the level requirement in a slot.
 diff --git a/src/main/java/net/minestom/server/inventory/type/FurnaceInventory.java b/src/main/java/net/minestom/server/inventory/type/FurnaceInventory.java
-index 9e357da9936b8eb3df5aa9e5d07ef6a39297a792..6af660d141332ab08e64de56f9cd60800249b030 100644
+index 9e357da9936b8eb3df5aa9e5d07ef6a39297a792..37d65b43f4c26d9001c444c633687654d53dfcdf 100644
 --- a/src/main/java/net/minestom/server/inventory/type/FurnaceInventory.java
 +++ b/src/main/java/net/minestom/server/inventory/type/FurnaceInventory.java
 @@ -17,9 +17,17 @@ public class FurnaceInventory extends Inventory {
@@ -330,7 +330,7 @@ index 9e357da9936b8eb3df5aa9e5d07ef6a39297a792..6af660d141332ab08e64de56f9cd6080
 +    //Microtus start - Update deprecation status
 +    /**
 +     * Creates a new {@link FurnaceInventory} reference with a given size and title.
-+     * The method is deprecated please use {@link FurnaceInventory#(InventoryType, Component)} instead.
++     * The method is deprecated please use {@link FurnaceInventory#(Component)} instead.
 +     * @param title the inventory title
 +     */
 +    @Deprecated(forRemoval = true, since = "1.1.3")
@@ -342,7 +342,7 @@ index 9e357da9936b8eb3df5aa9e5d07ef6a39297a792..6af660d141332ab08e64de56f9cd6080
      /**
       * Represents the amount of tick until the fire icon come empty.
 diff --git a/src/main/java/net/minestom/server/inventory/type/VillagerInventory.java b/src/main/java/net/minestom/server/inventory/type/VillagerInventory.java
-index 048fa58139363ac64588da40c50f25ebaa46eb0e..5c95004d2b09bb6906feb00d062add17369ffc7a 100644
+index 048fa58139363ac64588da40c50f25ebaa46eb0e..8df725464ca1965dda5a96bad3978e8c12b19a47 100644
 --- a/src/main/java/net/minestom/server/inventory/type/VillagerInventory.java
 +++ b/src/main/java/net/minestom/server/inventory/type/VillagerInventory.java
 @@ -24,9 +24,17 @@ public class VillagerInventory extends Inventory {
@@ -352,7 +352,7 @@ index 048fa58139363ac64588da40c50f25ebaa46eb0e..5c95004d2b09bb6906feb00d062add17
 +    //Microtus start - Update deprecation status
 +    /**
 +     * Creates a new {@link VillagerInventory} reference with a given size and title.
-+     * The method is deprecated please use {@link VillagerInventory#(InventoryType, Component)} instead.
++     * The method is deprecated please use {@link VillagerInventory#(Component)} instead.
 +     * @param title the inventory title
 +     */
 +    @Deprecated(forRemoval = true, since = "1.1.3")

--- a/minestom-patches/0015-Update-deprecated-methods.patch
+++ b/minestom-patches/0015-Update-deprecated-methods.patch
@@ -232,17 +232,19 @@ index 6108c4283fc1128fddd208914095cd7739524f0f..4667b7c3a3fe0a49c3b4e00210c10315
          return size;
      }
 diff --git a/src/main/java/net/minestom/server/inventory/type/AnvilInventory.java b/src/main/java/net/minestom/server/inventory/type/AnvilInventory.java
-index 8a7c9f2c154e22d3df90c8ee20856bb0b2f3d4de..020caeb985f718be5e3e6f8b8ce0f450350d463c 100644
+index 8a7c9f2c154e22d3df90c8ee20856bb0b2f3d4de..abed7520439b9eecdd7e32eae7dac41e0c4de750 100644
 --- a/src/main/java/net/minestom/server/inventory/type/AnvilInventory.java
 +++ b/src/main/java/net/minestom/server/inventory/type/AnvilInventory.java
-@@ -14,9 +14,17 @@ public class AnvilInventory extends Inventory {
+@@ -14,9 +14,19 @@ public class AnvilInventory extends Inventory {
          super(InventoryType.ANVIL, title);
      }
  
 +    //Microtus start - Update deprecation status
++
 +    /**
 +     * Creates a new {@link AnvilInventory} reference with a given size and title.
-+     * The method is deprecated please use {@link AnvilInventory#AnvilInventory#(Component)} instead.
++     * Since the constructor is deprecated please use the constructor with the Component parameter instead.
++     *
 +     * @param title the inventory title
 +     */
 +    @Deprecated(forRemoval = true, since = "1.1.3")
@@ -254,17 +256,19 @@ index 8a7c9f2c154e22d3df90c8ee20856bb0b2f3d4de..020caeb985f718be5e3e6f8b8ce0f450
      /**
       * Gets the anvil repair cost.
 diff --git a/src/main/java/net/minestom/server/inventory/type/BeaconInventory.java b/src/main/java/net/minestom/server/inventory/type/BeaconInventory.java
-index 30551dae67cde1d869a4bd6b8645d0db317cf1a4..13cb91f658b6520aae66d58a28b0a40cda4e4a4e 100644
+index 30551dae67cde1d869a4bd6b8645d0db317cf1a4..74cb05b2d31f5867bb43c0987cb72be3e4c35733 100644
 --- a/src/main/java/net/minestom/server/inventory/type/BeaconInventory.java
 +++ b/src/main/java/net/minestom/server/inventory/type/BeaconInventory.java
-@@ -17,9 +17,17 @@ public class BeaconInventory extends Inventory {
+@@ -17,9 +17,19 @@ public class BeaconInventory extends Inventory {
          super(InventoryType.BEACON, title);
      }
  
 +    //Microtus start - Update deprecation status
++
 +    /**
 +     * Creates a new {@link BeaconInventory} reference with a given size and title.
-+     * The method is deprecated please use {@link BeaconInventory#BeaconInventory(Component)} instead.
++     * Since the constructor is deprecated please use the constructor with the Component parameter instead.
++     *
 +     * @param title the inventory title
 +     */
 +    @Deprecated(forRemoval = true, since = "1.1.3")
@@ -276,7 +280,7 @@ index 30551dae67cde1d869a4bd6b8645d0db317cf1a4..13cb91f658b6520aae66d58a28b0a40c
      /**
       * Gets the beacon power level.
 diff --git a/src/main/java/net/minestom/server/inventory/type/BrewingStandInventory.java b/src/main/java/net/minestom/server/inventory/type/BrewingStandInventory.java
-index ed0bc7d783d17dcae72343138ffc3d36fad5b4d9..54ebdcac1d1def8de513c800caae4f5194a93d99 100644
+index ed0bc7d783d17dcae72343138ffc3d36fad5b4d9..85edd69996e6645967ee0ee98dc8d38336191089 100644
 --- a/src/main/java/net/minestom/server/inventory/type/BrewingStandInventory.java
 +++ b/src/main/java/net/minestom/server/inventory/type/BrewingStandInventory.java
 @@ -15,9 +15,17 @@ public class BrewingStandInventory extends Inventory {
@@ -286,7 +290,7 @@ index ed0bc7d783d17dcae72343138ffc3d36fad5b4d9..54ebdcac1d1def8de513c800caae4f51
 +    //Microtus start - Update deprecation status
 +    /**
 +     * Creates a new {@link BrewingStandInventory} reference with a given size and title.
-+     * The method is deprecated please use {@link BrewingStandInventory#BrewingStandInventory#(Component)} instead.
++     * Since the constructor is deprecated please use the constructor with the Component parameter instead.
 +     * @param title the inventory title
 +     */
 +    @Deprecated(forRemoval = true, since = "1.1.3")
@@ -298,17 +302,18 @@ index ed0bc7d783d17dcae72343138ffc3d36fad5b4d9..54ebdcac1d1def8de513c800caae4f51
      /**
       * Gets the brewing stand brew time.
 diff --git a/src/main/java/net/minestom/server/inventory/type/EnchantmentTableInventory.java b/src/main/java/net/minestom/server/inventory/type/EnchantmentTableInventory.java
-index bd855c32a5171683627bf2729ab13ef0acebd934..fd0310689b388b539b60d1c6bf4cdf2bf25772af 100644
+index bd855c32a5171683627bf2729ab13ef0acebd934..ed4245d468d05c06c58d74731391daefbcc5807a 100644
 --- a/src/main/java/net/minestom/server/inventory/type/EnchantmentTableInventory.java
 +++ b/src/main/java/net/minestom/server/inventory/type/EnchantmentTableInventory.java
-@@ -18,9 +18,17 @@ public class EnchantmentTableInventory extends Inventory {
+@@ -18,9 +18,18 @@ public class EnchantmentTableInventory extends Inventory {
          super(InventoryType.ENCHANTMENT, title);
      }
  
 +    //Microtus start - Update deprecation status
 +    /**
 +     * Creates a new {@link EnchantmentTableInventory} reference with a given size and title.
-+     * The method is deprecated please use {@link EnchantmentTableInventory#EnchantmentTableInventory#(Component)} instead.
++     * Since the constructor is deprecated please use the constructor with the Component parameter instead.
++     *
 +     * @param title the inventory title
 +     */
 +    @Deprecated(forRemoval = true, since = "1.1.3")
@@ -320,17 +325,19 @@ index bd855c32a5171683627bf2729ab13ef0acebd934..fd0310689b388b539b60d1c6bf4cdf2b
      /**
       * Gets the level requirement in a slot.
 diff --git a/src/main/java/net/minestom/server/inventory/type/FurnaceInventory.java b/src/main/java/net/minestom/server/inventory/type/FurnaceInventory.java
-index 9e357da9936b8eb3df5aa9e5d07ef6a39297a792..51dd58daad32c00c702e47ef8bc77e638c248ba6 100644
+index 9e357da9936b8eb3df5aa9e5d07ef6a39297a792..21b76f1fc17f6bd3ac5aa9425731998d48b9010d 100644
 --- a/src/main/java/net/minestom/server/inventory/type/FurnaceInventory.java
 +++ b/src/main/java/net/minestom/server/inventory/type/FurnaceInventory.java
-@@ -17,9 +17,17 @@ public class FurnaceInventory extends Inventory {
+@@ -17,9 +17,19 @@ public class FurnaceInventory extends Inventory {
          super(InventoryType.FURNACE, title);
      }
  
 +    //Microtus start - Update deprecation status
++
 +    /**
 +     * Creates a new {@link FurnaceInventory} reference with a given size and title.
-+     * The method is deprecated please use {@link FurnaceInventory#FurnaceInventory(Component)} instead.
++     * Since the constructor is deprecated please use the constructor with the Component parameter instead.
++     *
 +     * @param title the inventory title
 +     */
 +    @Deprecated(forRemoval = true, since = "1.1.3")
@@ -342,17 +349,19 @@ index 9e357da9936b8eb3df5aa9e5d07ef6a39297a792..51dd58daad32c00c702e47ef8bc77e63
      /**
       * Represents the amount of tick until the fire icon come empty.
 diff --git a/src/main/java/net/minestom/server/inventory/type/VillagerInventory.java b/src/main/java/net/minestom/server/inventory/type/VillagerInventory.java
-index 048fa58139363ac64588da40c50f25ebaa46eb0e..8df725464ca1965dda5a96bad3978e8c12b19a47 100644
+index 048fa58139363ac64588da40c50f25ebaa46eb0e..2f1770281480f25a786bd15d216fe2457b228c1b 100644
 --- a/src/main/java/net/minestom/server/inventory/type/VillagerInventory.java
 +++ b/src/main/java/net/minestom/server/inventory/type/VillagerInventory.java
-@@ -24,9 +24,17 @@ public class VillagerInventory extends Inventory {
+@@ -24,9 +24,19 @@ public class VillagerInventory extends Inventory {
          super(InventoryType.MERCHANT, title);
      }
  
 +    //Microtus start - Update deprecation status
++
 +    /**
 +     * Creates a new {@link VillagerInventory} reference with a given size and title.
-+     * The method is deprecated please use {@link VillagerInventory#(Component)} instead.
++     * Since the constructor is deprecated please use the constructor with the Component parameter instead.
++     *
 +     * @param title the inventory title
 +     */
 +    @Deprecated(forRemoval = true, since = "1.1.3")

--- a/minestom-patches/0015-Update-deprecated-methods.patch
+++ b/minestom-patches/0015-Update-deprecated-methods.patch
@@ -232,7 +232,7 @@ index 6108c4283fc1128fddd208914095cd7739524f0f..4667b7c3a3fe0a49c3b4e00210c10315
          return size;
      }
 diff --git a/src/main/java/net/minestom/server/inventory/type/AnvilInventory.java b/src/main/java/net/minestom/server/inventory/type/AnvilInventory.java
-index 8a7c9f2c154e22d3df90c8ee20856bb0b2f3d4de..7ff6a34cb819f436c9965763fc08053019dd889e 100644
+index 8a7c9f2c154e22d3df90c8ee20856bb0b2f3d4de..020caeb985f718be5e3e6f8b8ce0f450350d463c 100644
 --- a/src/main/java/net/minestom/server/inventory/type/AnvilInventory.java
 +++ b/src/main/java/net/minestom/server/inventory/type/AnvilInventory.java
 @@ -14,9 +14,17 @@ public class AnvilInventory extends Inventory {
@@ -242,7 +242,7 @@ index 8a7c9f2c154e22d3df90c8ee20856bb0b2f3d4de..7ff6a34cb819f436c9965763fc080530
 +    //Microtus start - Update deprecation status
 +    /**
 +     * Creates a new {@link AnvilInventory} reference with a given size and title.
-+     * The method is deprecated please use {@link AnvilInventory#(Component)} instead.
++     * The method is deprecated please use {@link AnvilInventory#AnvilInventory#(Component)} instead.
 +     * @param title the inventory title
 +     */
 +    @Deprecated(forRemoval = true, since = "1.1.3")
@@ -254,7 +254,7 @@ index 8a7c9f2c154e22d3df90c8ee20856bb0b2f3d4de..7ff6a34cb819f436c9965763fc080530
      /**
       * Gets the anvil repair cost.
 diff --git a/src/main/java/net/minestom/server/inventory/type/BeaconInventory.java b/src/main/java/net/minestom/server/inventory/type/BeaconInventory.java
-index 30551dae67cde1d869a4bd6b8645d0db317cf1a4..1f0fc8f8ed627efcd718b5b20009eea83192ad41 100644
+index 30551dae67cde1d869a4bd6b8645d0db317cf1a4..13cb91f658b6520aae66d58a28b0a40cda4e4a4e 100644
 --- a/src/main/java/net/minestom/server/inventory/type/BeaconInventory.java
 +++ b/src/main/java/net/minestom/server/inventory/type/BeaconInventory.java
 @@ -17,9 +17,17 @@ public class BeaconInventory extends Inventory {
@@ -264,7 +264,7 @@ index 30551dae67cde1d869a4bd6b8645d0db317cf1a4..1f0fc8f8ed627efcd718b5b20009eea8
 +    //Microtus start - Update deprecation status
 +    /**
 +     * Creates a new {@link BeaconInventory} reference with a given size and title.
-+     * The method is deprecated please use {@link BeaconInventory#(Component)} instead.
++     * The method is deprecated please use {@link BeaconInventory#BeaconInventory(Component)} instead.
 +     * @param title the inventory title
 +     */
 +    @Deprecated(forRemoval = true, since = "1.1.3")
@@ -276,7 +276,7 @@ index 30551dae67cde1d869a4bd6b8645d0db317cf1a4..1f0fc8f8ed627efcd718b5b20009eea8
      /**
       * Gets the beacon power level.
 diff --git a/src/main/java/net/minestom/server/inventory/type/BrewingStandInventory.java b/src/main/java/net/minestom/server/inventory/type/BrewingStandInventory.java
-index ed0bc7d783d17dcae72343138ffc3d36fad5b4d9..4cd086fb91b82faa20ad58eed26feacb4295b0ba 100644
+index ed0bc7d783d17dcae72343138ffc3d36fad5b4d9..54ebdcac1d1def8de513c800caae4f5194a93d99 100644
 --- a/src/main/java/net/minestom/server/inventory/type/BrewingStandInventory.java
 +++ b/src/main/java/net/minestom/server/inventory/type/BrewingStandInventory.java
 @@ -15,9 +15,17 @@ public class BrewingStandInventory extends Inventory {
@@ -286,7 +286,7 @@ index ed0bc7d783d17dcae72343138ffc3d36fad5b4d9..4cd086fb91b82faa20ad58eed26feacb
 +    //Microtus start - Update deprecation status
 +    /**
 +     * Creates a new {@link BrewingStandInventory} reference with a given size and title.
-+     * The method is deprecated please use {@link BrewingStandInventory#(Component)} instead.
++     * The method is deprecated please use {@link BrewingStandInventory#BrewingStandInventory#(Component)} instead.
 +     * @param title the inventory title
 +     */
 +    @Deprecated(forRemoval = true, since = "1.1.3")
@@ -298,7 +298,7 @@ index ed0bc7d783d17dcae72343138ffc3d36fad5b4d9..4cd086fb91b82faa20ad58eed26feacb
      /**
       * Gets the brewing stand brew time.
 diff --git a/src/main/java/net/minestom/server/inventory/type/EnchantmentTableInventory.java b/src/main/java/net/minestom/server/inventory/type/EnchantmentTableInventory.java
-index bd855c32a5171683627bf2729ab13ef0acebd934..15f6ca069a34df26e1c28c5c5e3ec268df882646 100644
+index bd855c32a5171683627bf2729ab13ef0acebd934..fd0310689b388b539b60d1c6bf4cdf2bf25772af 100644
 --- a/src/main/java/net/minestom/server/inventory/type/EnchantmentTableInventory.java
 +++ b/src/main/java/net/minestom/server/inventory/type/EnchantmentTableInventory.java
 @@ -18,9 +18,17 @@ public class EnchantmentTableInventory extends Inventory {
@@ -308,7 +308,7 @@ index bd855c32a5171683627bf2729ab13ef0acebd934..15f6ca069a34df26e1c28c5c5e3ec268
 +    //Microtus start - Update deprecation status
 +    /**
 +     * Creates a new {@link EnchantmentTableInventory} reference with a given size and title.
-+     * The method is deprecated please use {@link EnchantmentTableInventory#(Component)} instead.
++     * The method is deprecated please use {@link EnchantmentTableInventory#EnchantmentTableInventory#(Component)} instead.
 +     * @param title the inventory title
 +     */
 +    @Deprecated(forRemoval = true, since = "1.1.3")
@@ -320,7 +320,7 @@ index bd855c32a5171683627bf2729ab13ef0acebd934..15f6ca069a34df26e1c28c5c5e3ec268
      /**
       * Gets the level requirement in a slot.
 diff --git a/src/main/java/net/minestom/server/inventory/type/FurnaceInventory.java b/src/main/java/net/minestom/server/inventory/type/FurnaceInventory.java
-index 9e357da9936b8eb3df5aa9e5d07ef6a39297a792..37d65b43f4c26d9001c444c633687654d53dfcdf 100644
+index 9e357da9936b8eb3df5aa9e5d07ef6a39297a792..51dd58daad32c00c702e47ef8bc77e638c248ba6 100644
 --- a/src/main/java/net/minestom/server/inventory/type/FurnaceInventory.java
 +++ b/src/main/java/net/minestom/server/inventory/type/FurnaceInventory.java
 @@ -17,9 +17,17 @@ public class FurnaceInventory extends Inventory {
@@ -330,7 +330,7 @@ index 9e357da9936b8eb3df5aa9e5d07ef6a39297a792..37d65b43f4c26d9001c444c633687654
 +    //Microtus start - Update deprecation status
 +    /**
 +     * Creates a new {@link FurnaceInventory} reference with a given size and title.
-+     * The method is deprecated please use {@link FurnaceInventory#(Component)} instead.
++     * The method is deprecated please use {@link FurnaceInventory#FurnaceInventory(Component)} instead.
 +     * @param title the inventory title
 +     */
 +    @Deprecated(forRemoval = true, since = "1.1.3")

--- a/minestom-patches/0015-Update-deprecated-methods.patch
+++ b/minestom-patches/0015-Update-deprecated-methods.patch
@@ -195,6 +195,29 @@ index 27de8eee60012568cfd85e612f9a7377085f9033..5511e29017aa54958b62f2e6f1fcfc53
      public @NotNull ItemStack getFoodItem() {
          return foodItem;
      }
+diff --git a/src/main/java/net/minestom/server/inventory/Inventory.java b/src/main/java/net/minestom/server/inventory/Inventory.java
+index 9d80f6331c1320603680411d1eff3d710c38e6c3..ab57e8814738acb22cd9bfc8565a449038f1c4d8 100644
+--- a/src/main/java/net/minestom/server/inventory/Inventory.java
++++ b/src/main/java/net/minestom/server/inventory/Inventory.java
+@@ -53,9 +53,18 @@ public non-sealed class Inventory extends AbstractInventory implements Viewable
+         this.offset = getSize();
+     }
+ 
++    //Microtus start - Update deprecation status
++    /**
++     * Creates a new Inventory reference with a given size and title.
++     * The method is deprecated please use {@link Inventory#Inventory(InventoryType, Component)} instead.
++     * @param inventoryType the inventory type
++     * @param title the inventory title
++     */
++    @Deprecated(forRemoval = true, since = "1.1.3")
+     public Inventory(@NotNull InventoryType inventoryType, @NotNull String title) {
+         this(inventoryType, Component.text(title));
+     }
++    //Microtus end - Update deprecation status
+ 
+     private static byte generateId() {
+         return (byte) ID_COUNTER.updateAndGet(i -> i + 1 >= 128 ? 1 : i + 1);
 diff --git a/src/main/java/net/minestom/server/inventory/InventoryType.java b/src/main/java/net/minestom/server/inventory/InventoryType.java
 index 6108c4283fc1128fddd208914095cd7739524f0f..4667b7c3a3fe0a49c3b4e00210c103155d85ea39 100644
 --- a/src/main/java/net/minestom/server/inventory/InventoryType.java
@@ -208,6 +231,138 @@ index 6108c4283fc1128fddd208914095cd7739524f0f..4667b7c3a3fe0a49c3b4e00210c10315
      public int getAdditionalSlot() {
          return size;
      }
+diff --git a/src/main/java/net/minestom/server/inventory/type/AnvilInventory.java b/src/main/java/net/minestom/server/inventory/type/AnvilInventory.java
+index 8a7c9f2c154e22d3df90c8ee20856bb0b2f3d4de..e8b36d90398e88b220bc3e8a50a2572803658404 100644
+--- a/src/main/java/net/minestom/server/inventory/type/AnvilInventory.java
++++ b/src/main/java/net/minestom/server/inventory/type/AnvilInventory.java
+@@ -14,9 +14,17 @@ public class AnvilInventory extends Inventory {
+         super(InventoryType.ANVIL, title);
+     }
+ 
++    //Microtus start - Update deprecation status
++    /**
++     * Creates a new {@link AnvilInventory} reference with a given size and title.
++     * The method is deprecated please use {@link AnvilInventory#(InventoryType, Component)} instead.
++     * @param title the inventory title
++     */
++    @Deprecated(forRemoval = true, since = "1.1.3")
+     public AnvilInventory(@NotNull String title) {
+         super(InventoryType.ANVIL, title);
+     }
++    //Microtus end - Update deprecation status
+ 
+     /**
+      * Gets the anvil repair cost.
+diff --git a/src/main/java/net/minestom/server/inventory/type/BeaconInventory.java b/src/main/java/net/minestom/server/inventory/type/BeaconInventory.java
+index 30551dae67cde1d869a4bd6b8645d0db317cf1a4..6d87a30775ae31f3036bbae9a04a4e3fcb110781 100644
+--- a/src/main/java/net/minestom/server/inventory/type/BeaconInventory.java
++++ b/src/main/java/net/minestom/server/inventory/type/BeaconInventory.java
+@@ -17,9 +17,17 @@ public class BeaconInventory extends Inventory {
+         super(InventoryType.BEACON, title);
+     }
+ 
++    //Microtus start - Update deprecation status
++    /**
++     * Creates a new {@link BeaconInventory} reference with a given size and title.
++     * The method is deprecated please use {@link BeaconInventory#(InventoryType, Component)} instead.
++     * @param title the inventory title
++     */
++    @Deprecated(forRemoval = true, since = "1.1.3")
+     public BeaconInventory(@NotNull String title) {
+         super(InventoryType.BEACON, title);
+     }
++    //Microtus end - Update deprecation status
+ 
+     /**
+      * Gets the beacon power level.
+diff --git a/src/main/java/net/minestom/server/inventory/type/BrewingStandInventory.java b/src/main/java/net/minestom/server/inventory/type/BrewingStandInventory.java
+index ed0bc7d783d17dcae72343138ffc3d36fad5b4d9..9b8536d92b6f86bb3636447dfb9ee52ad098f722 100644
+--- a/src/main/java/net/minestom/server/inventory/type/BrewingStandInventory.java
++++ b/src/main/java/net/minestom/server/inventory/type/BrewingStandInventory.java
+@@ -15,9 +15,17 @@ public class BrewingStandInventory extends Inventory {
+         super(InventoryType.BREWING_STAND, title);
+     }
+ 
++    //Microtus start - Update deprecation status
++    /**
++     * Creates a new {@link BrewingStandInventory} reference with a given size and title.
++     * The method is deprecated please use {@link BrewingStandInventory#(InventoryType, Component)} instead.
++     * @param title the inventory title
++     */
++    @Deprecated(forRemoval = true, since = "1.1.3")
+     public BrewingStandInventory(@NotNull String title) {
+         super(InventoryType.BREWING_STAND, title);
+     }
++    //Microtus end - Update deprecation status
+ 
+     /**
+      * Gets the brewing stand brew time.
+diff --git a/src/main/java/net/minestom/server/inventory/type/EnchantmentTableInventory.java b/src/main/java/net/minestom/server/inventory/type/EnchantmentTableInventory.java
+index bd855c32a5171683627bf2729ab13ef0acebd934..3406dff2c0bf3f8fb8344d24d8a2af45700c288b 100644
+--- a/src/main/java/net/minestom/server/inventory/type/EnchantmentTableInventory.java
++++ b/src/main/java/net/minestom/server/inventory/type/EnchantmentTableInventory.java
+@@ -18,9 +18,17 @@ public class EnchantmentTableInventory extends Inventory {
+         super(InventoryType.ENCHANTMENT, title);
+     }
+ 
++    //Microtus start - Update deprecation status
++    /**
++     * Creates a new {@link EnchantmentTableInventory} reference with a given size and title.
++     * The method is deprecated please use {@link EnchantmentTableInventory#(InventoryType, Component)} instead.
++     * @param title the inventory title
++     */
++    @Deprecated(forRemoval = true, since = "1.1.3")
+     public EnchantmentTableInventory(@NotNull String title) {
+         super(InventoryType.ENCHANTMENT, title);
+     }
++    //Microtus end - Update deprecation status
+ 
+     /**
+      * Gets the level requirement in a slot.
+diff --git a/src/main/java/net/minestom/server/inventory/type/FurnaceInventory.java b/src/main/java/net/minestom/server/inventory/type/FurnaceInventory.java
+index 9e357da9936b8eb3df5aa9e5d07ef6a39297a792..6af660d141332ab08e64de56f9cd60800249b030 100644
+--- a/src/main/java/net/minestom/server/inventory/type/FurnaceInventory.java
++++ b/src/main/java/net/minestom/server/inventory/type/FurnaceInventory.java
+@@ -17,9 +17,17 @@ public class FurnaceInventory extends Inventory {
+         super(InventoryType.FURNACE, title);
+     }
+ 
++    //Microtus start - Update deprecation status
++    /**
++     * Creates a new {@link FurnaceInventory} reference with a given size and title.
++     * The method is deprecated please use {@link FurnaceInventory#(InventoryType, Component)} instead.
++     * @param title the inventory title
++     */
++    @Deprecated(forRemoval = true, since = "1.1.3")
+     public FurnaceInventory(@NotNull String title) {
+         super(InventoryType.FURNACE, title);
+     }
++    //Microtus end - Update deprecation status
+ 
+     /**
+      * Represents the amount of tick until the fire icon come empty.
+diff --git a/src/main/java/net/minestom/server/inventory/type/VillagerInventory.java b/src/main/java/net/minestom/server/inventory/type/VillagerInventory.java
+index 048fa58139363ac64588da40c50f25ebaa46eb0e..5c95004d2b09bb6906feb00d062add17369ffc7a 100644
+--- a/src/main/java/net/minestom/server/inventory/type/VillagerInventory.java
++++ b/src/main/java/net/minestom/server/inventory/type/VillagerInventory.java
+@@ -24,9 +24,17 @@ public class VillagerInventory extends Inventory {
+         super(InventoryType.MERCHANT, title);
+     }
+ 
++    //Microtus start - Update deprecation status
++    /**
++     * Creates a new {@link VillagerInventory} reference with a given size and title.
++     * The method is deprecated please use {@link VillagerInventory#(InventoryType, Component)} instead.
++     * @param title the inventory title
++     */
++    @Deprecated(forRemoval = true, since = "1.1.3")
+     public VillagerInventory(@NotNull String title) {
+         super(InventoryType.MERCHANT, title);
+     }
++    //Microtus end - Update deprecation status
+ 
+     public List<TradeListPacket.Trade> getTrades() {
+         return Collections.unmodifiableList(trades);
 diff --git a/src/main/java/net/minestom/server/item/ItemStack.java b/src/main/java/net/minestom/server/item/ItemStack.java
 index 1642dbf93669d5c2b54bfb03741b4186ce5ff057..0e3f2a48d1a1c75368fc0c33905cc5b07cb27251 100644
 --- a/src/main/java/net/minestom/server/item/ItemStack.java


### PR DESCRIPTION
## Proposed changes

Some implementations of the `Inventory` takes a string as parameter. This pull request mark these constructors as deprecated to remove them in a later update.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...