### PR TITLE
Integrate world spawn position handling to the Instance class

### DIFF
--- a/minestom-patches/0016-Integrate-world-spawn-position-to-the-instance.patch
+++ b/minestom-patches/0016-Integrate-world-spawn-position-to-the-instance.patch
@@ -1,0 +1,207 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: theEvilReaper <steffenwx@gmail.com>
+Date: Wed, 13 Dec 2023 19:20:47 +0100
+Subject: [PATCH] Integrate world spawn position to the instance
+
+
+diff --git a/src/main/java/net/minestom/server/event/instance/InstanceWorldPositionChangeEvent.java b/src/main/java/net/minestom/server/event/instance/InstanceWorldPositionChangeEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..a2622652e77439199da40229edf97dea978cbd1e
+--- /dev/null
++++ b/src/main/java/net/minestom/server/event/instance/InstanceWorldPositionChangeEvent.java
+@@ -0,0 +1,59 @@
++package net.minestom.server.event.instance;
++
++import net.minestom.server.coordinate.Pos;
++import net.minestom.server.event.trait.InstanceEvent;
++import net.minestom.server.instance.Instance;
++import org.jetbrains.annotations.NotNull;
++
++//Microtus start - integrate world spawn position
++/**
++ *
++ * @author theEvilReaper
++ * @version 1.0.0
++ * @since 1.1.3
++ */
++public class InstanceWorldPositionChangeEvent implements InstanceEvent {
++
++    private final Instance instance;
++    private final Pos oldPosition;
++
++    /**
++     * Constructs a new {@code InstanceWorldPositionChangeEvent} with the specified parameters.
++     *
++     * @param instance      the involved instance
++     * @param oldPosition   the old position of the instance before the change
++     */
++    public InstanceWorldPositionChangeEvent(@NotNull Instance instance, @NotNull Pos oldPosition) {
++        this.instance = instance;
++        this.oldPosition = oldPosition;
++    }
++
++    /**
++     * Gets the new position of the instance after the change.
++     *
++     * @return the new position
++     */
++    public @NotNull Pos getNewPosition() {
++        return instance.getWorldSpawnPosition();
++    }
++
++    /**
++     * Gets the old position of the instance before the change.
++     *
++     * @return the old position
++     */
++    public @NotNull Pos getOldPosition() {
++        return oldPosition;
++    }
++
++    /**
++     * Gets the instance which received a world position change.
++     *
++     * @return the involved instance
++     */
++    @Override
++    public @NotNull Instance getInstance() {
++        return instance;
++    }
++}
++//Microtus end - integrate world spawn position
+\ No newline at end of file
+diff --git a/src/main/java/net/minestom/server/instance/Instance.java b/src/main/java/net/minestom/server/instance/Instance.java
+index d6dd0549db22ee58c4057012fcc46a3aba8f087b..e440c29bc7e55c1131bb3b5582a984acc8b43b0a 100644
+--- a/src/main/java/net/minestom/server/instance/Instance.java
++++ b/src/main/java/net/minestom/server/instance/Instance.java
+@@ -8,6 +8,7 @@ import net.minestom.server.ServerProcess;
+ import net.minestom.server.Tickable;
+ import net.minestom.server.adventure.audience.PacketGroupingAudience;
+ import net.minestom.server.coordinate.Point;
++import net.minestom.server.coordinate.Pos;
+ import net.minestom.server.entity.Entity;
+ import net.minestom.server.entity.EntityCreature;
+ import net.minestom.server.entity.ExperienceOrb;
+@@ -18,12 +19,14 @@ import net.minestom.server.event.EventFilter;
+ import net.minestom.server.event.EventHandler;
+ import net.minestom.server.event.EventNode;
+ import net.minestom.server.event.instance.InstanceTickEvent;
++import net.minestom.server.event.instance.InstanceWorldPositionChangeEvent;
+ import net.minestom.server.event.trait.InstanceEvent;
+ import net.minestom.server.instance.block.Block;
+ import net.minestom.server.instance.block.BlockFace;
+ import net.minestom.server.instance.block.BlockHandler;
+ import net.minestom.server.instance.generator.Generator;
+ import net.minestom.server.network.packet.server.play.BlockActionPacket;
++import net.minestom.server.network.packet.server.play.SpawnPositionPacket;
+ import net.minestom.server.network.packet.server.play.TimeUpdatePacket;
+ import net.minestom.server.snapshot.*;
+ import net.minestom.server.tag.TagHandler;
+@@ -103,6 +106,8 @@ public abstract class Instance implements Block.Getter, Block.Setter,
+     // Adventure
+     private final Pointers pointers;
+ 
++    private Pos worldSpawnPosition = Pos.ZERO;
++
+     /**
+      * Creates a new instance.
+      *
+@@ -362,6 +367,44 @@ public abstract class Instance implements Block.Getter, Block.Setter,
+         return worldAge;
+     }
+ 
++    //Microtus start - integrate world spawn position
++    /**
++     * Updates the spawn position of the instance.
++     * This method <STRONG>doesn't</STRONG> send the SpawnPositionPacket to the players.
++     * @param spawnPosition the new spawn position
++     */
++    public boolean setWorldSpawnPosition(@NotNull Pos spawnPosition) {
++        return this.setWorldSpawnPosition(spawnPosition, false);
++    }
++
++    /**
++     * Updates the spawn position of the instance.
++     * The underlying spawn position will only be updated if the new position is different from the current one.
++     * It sends the SpawnPositionPacket when the boolean option is true and the instance has players.
++     * @param spawnPosition the new spawn position
++     * @param sendPacket if true, the new spawn position will be sent to all players in the instance
++     */
++    public boolean setWorldSpawnPosition(@NotNull Pos spawnPosition, boolean sendPacket) {
++        if (this.worldSpawnPosition.samePoint(spawnPosition)) return false;
++        final Pos oldPosition = this.worldSpawnPosition;
++        this.worldSpawnPosition = spawnPosition;
++        EventDispatcher.call(new InstanceWorldPositionChangeEvent(this, oldPosition));
++        if (!sendPacket || getPlayers().isEmpty()) return false;
++        var spawnPositionPacket = new SpawnPositionPacket(spawnPosition, spawnPosition.yaw());
++        PacketUtils.sendGroupedPacket(getPlayers(), spawnPositionPacket);
++        return true;
++    }
++
++    /**
++     * Gets the spawn position of the instance.
++     * If the position is not set, it will return {@link Pos#ZERO}
++     * @return the spawn position of the instance
++     */
++    public @NotNull Pos getWorldSpawnPosition() {
++        return this.worldSpawnPosition;
++    }
++    //Microtus end - integrate world spawn position
++
+     /**
+      * Gets the current time in the instance (sun/moon).
+      *
+diff --git a/src/test/java/net/minestom/server/instance/InstanceWorldPositionIntegrationTest.java b/src/test/java/net/minestom/server/instance/InstanceWorldPositionIntegrationTest.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..ec35f8af0497b2279ac555d675134ac5d9e43164
+--- /dev/null
++++ b/src/test/java/net/minestom/server/instance/InstanceWorldPositionIntegrationTest.java
+@@ -0,0 +1,48 @@
++package net.minestom.server.instance;
++
++import net.minestom.server.coordinate.Pos;
++import net.minestom.server.event.instance.InstanceWorldPositionChangeEvent;
++import net.minestom.testing.Env;
++import net.minestom.testing.EnvTest;
++import org.jetbrains.annotations.NotNull;
++import org.junit.jupiter.api.Test;
++
++import static org.junit.jupiter.api.Assertions.*;
++
++//Microtus start - integrate world spawn position
++@EnvTest
++class InstanceWorldPositionIntegrationTest {
++
++    @Test
++    void testInstanceWorldPositionUpdate(@NotNull Env env) {
++        var instance = env.createFlatInstance();
++        assertEquals(Pos.ZERO, instance.getWorldSpawnPosition());
++        instance.setWorldSpawnPosition(new Pos(1, 2, 3));
++        assertNotEquals(Pos.ZERO, instance.getWorldSpawnPosition());
++        Pos newSpawnPosition = new Pos(100, 200, 35, 90, 0);
++        instance.setWorldSpawnPosition(newSpawnPosition);
++        assertEquals(newSpawnPosition, instance.getWorldSpawnPosition());
++        env.destroyInstance(instance);
++    }
++
++    @Test
++    void testCancelledWorldPositionUpdate(@NotNull Env env) {
++        var instance = env.createFlatInstance();
++        assertFalse(instance.setWorldSpawnPosition(Pos.ZERO));
++        env.destroyInstance(instance);
++    }
++
++    @Test
++    void testInstanceWorldPositionChangeEvent(@NotNull Env env) {
++        var instance = env.createFlatInstance();
++        var listener = env.listen(InstanceWorldPositionChangeEvent.class);
++        Pos newSpawnPosition = new Pos(100, 200, 35, 90, 0);
++        listener.followup(event -> {
++            assertEquals(Pos.ZERO, event.getOldPosition());
++            assertEquals(newSpawnPosition, event.getNewPosition());
++        });
++        instance.setWorldSpawnPosition(newSpawnPosition);
++        env.destroyInstance(instance);
++    }
++}
++//Microtus end - integrate world spawn position

--- a/minestom-patches/0016-Integrate-world-spawn-position-to-the-instance.patch
+++ b/minestom-patches/0016-Integrate-world-spawn-position-to-the-instance.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Integrate world spawn position to the instance
 
 diff --git a/src/main/java/net/minestom/server/event/instance/InstanceWorldPositionChangeEvent.java b/src/main/java/net/minestom/server/event/instance/InstanceWorldPositionChangeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a2622652e77439199da40229edf97dea978cbd1e
+index 0000000000000000000000000000000000000000..d7ef61eaed4232bc5303a5879a2d98590737ed36
 --- /dev/null
 +++ b/src/main/java/net/minestom/server/event/instance/InstanceWorldPositionChangeEvent.java
-@@ -0,0 +1,59 @@
+@@ -0,0 +1,60 @@
 +package net.minestom.server.event.instance;
 +
 +import net.minestom.server.coordinate.Pos;
@@ -19,7 +19,8 @@ index 0000000000000000000000000000000000000000..a2622652e77439199da40229edf97dea
 +
 +//Microtus start - integrate world spawn position
 +/**
-+ *
++ * The event is triggered by the server when an instance successfully changes its world spawn position.
++ * By implementing a listener for this event, developers can track changes to a world's spawn position initiated by instances during runtime.
 + * @author theEvilReaper
 + * @version 1.0.0
 + * @since 1.1.3


### PR DESCRIPTION
## Proposed changes

The level.dat file contains global information about the game world. Specifically, the data points `spawnX`, `spawnY` and `spawnZ` within this file define the world's spawn position, determining where players enter the game environment. Traditionally, these values are loaded during the world initialization process.

Currently, Minestom serves as a library for creating custom server software implementations, offering minimal logic to load essential data from a world. To enable the utilization of the spawn position from a world, we need to enhance the existing implementation of the Instance class.

## New methods in the Instance class:

```java
setWorldSpawnPosition(Pos position);
setWorldSpawnPosition(Pos position, boolean sendPacket);
Pos getWorldSpawn();
```

Both definitions of the `setWorldSpawnPosition` method provide the capability to define the world's position. The game logic initiates the transmission of a `ClientboundSetDefaultSpawnPositionPacket` packet to communicate the altered position information to the client.

To ensure the players receive this packet, utilize the method with two parameters and set the boolean to true. 

The `getWorldSpawn` function retrieves the current world position. Note: If the instance lacks a position, it returns the null-vector (0, 0, 0).

To monitor changes in the world position of an instance, implement a listener for the newly introduced `InstanceWorldPositionChangeEvent`. This event triggers when the position is successfully modified.

## What the patch doesn't do (for the moment):

When loading a world using the `AnvilLoader`, the world spawn values are not automatically loaded from the level.dat file. The absence of this behavior raises the question: why hasn't this functionality been implemented?

The `AnvilLoader` extends the `IChunkLoader` interface, and introducing a dedicated method to this interface raises concerns about breaking the established naming convention for this class. Loading the spawn position of a world is not inherently tied to managing chunks. In the interest of future improvements, it is necessary to reevaluate the current structure, either by refining naming conventions or introducing additional structure to facilitate the default loading of spawn positions.

If you still want to load this you can use this small pseudo code snippet:
```java
Instance instance = ....
instance.setChunkLoader(new AnvilLoader(path));
TagHandler tagHandler = container.tagHandler();
// Acess the neccessary data
instance.setWorldSpawnPosition(new Pos(x, y, z));
```

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...