### PR TITLE
Improve java keyword usage

### DIFF
--- a/minestom-patches/0015-Update-java-keyword-usage.patch
+++ b/minestom-patches/0015-Update-java-keyword-usage.patch
@@ -4,6 +4,304 @@ Date: Tue, 5 Dec 2023 13:06:18 +0100
 Subject: [PATCH] Update java keyword usage
 
 
+diff --git a/src/main/java/net/minestom/server/entity/metadata/EntityMeta.java b/src/main/java/net/minestom/server/entity/metadata/EntityMeta.java
+index 449b16bbbc863703e293606d3253d2b7c4f64078..c7f382df4b3826f68362170b0f4b8069a76b2f03 100644
+--- a/src/main/java/net/minestom/server/entity/metadata/EntityMeta.java
++++ b/src/main/java/net/minestom/server/entity/metadata/EntityMeta.java
+@@ -13,13 +13,13 @@ public class EntityMeta {
+     public static final byte OFFSET = 0;
+     public static final byte MAX_OFFSET = OFFSET + 8;
+ 
+-    private final static byte ON_FIRE_BIT = 0x01;
+-    private final static byte CROUCHING_BIT = 0x02;
+-    private final static byte SPRINTING_BIT = 0x08;
+-    private final static byte SWIMMING_BIT = 0x10;
+-    private final static byte INVISIBLE_BIT = 0x20;
+-    private final static byte HAS_GLOWING_EFFECT_BIT = 0x40;
+-    private final static byte FLYING_WITH_ELYTRA_BIT = (byte) 0x80;
++    private static final byte ON_FIRE_BIT = 0x01;
++    private static final byte CROUCHING_BIT = 0x02;
++    private static final byte SPRINTING_BIT = 0x08;
++    private static final byte SWIMMING_BIT = 0x10;
++    private static final byte INVISIBLE_BIT = 0x20;
++    private static final byte HAS_GLOWING_EFFECT_BIT = 0x40;
++    private static final byte FLYING_WITH_ELYTRA_BIT = (byte) 0x80;
+ 
+     private final WeakReference<Entity> entityRef;
+     protected final Metadata metadata;
+diff --git a/src/main/java/net/minestom/server/entity/metadata/LivingEntityMeta.java b/src/main/java/net/minestom/server/entity/metadata/LivingEntityMeta.java
+index 60d7102b205bc04a60678fecc2da0009ce56437a..692d0fa76b810258089c9462663ef4a431847759 100644
+--- a/src/main/java/net/minestom/server/entity/metadata/LivingEntityMeta.java
++++ b/src/main/java/net/minestom/server/entity/metadata/LivingEntityMeta.java
+@@ -11,9 +11,9 @@ public class LivingEntityMeta extends EntityMeta {
+     public static final byte OFFSET = EntityMeta.MAX_OFFSET;
+     public static final byte MAX_OFFSET = OFFSET + 7;
+ 
+-    private final static byte IS_HAND_ACTIVE_BIT = 0x01;
+-    private final static byte ACTIVE_HAND_BIT = 0x02;
+-    private final static byte IS_IN_SPIN_ATTACK_BIT = 0x04;
++    private static final byte IS_HAND_ACTIVE_BIT = 0x01;
++    private static final byte ACTIVE_HAND_BIT = 0x02;
++    private static final byte IS_IN_SPIN_ATTACK_BIT = 0x04;
+ 
+     protected LivingEntityMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
+         super(entity, metadata);
+diff --git a/src/main/java/net/minestom/server/entity/metadata/MobMeta.java b/src/main/java/net/minestom/server/entity/metadata/MobMeta.java
+index 98703d3d9ff9e7e5865dfe92341b9a38e9801e7d..877c4d668f429a9f1eaeb5d48a761dcd1505b485 100644
+--- a/src/main/java/net/minestom/server/entity/metadata/MobMeta.java
++++ b/src/main/java/net/minestom/server/entity/metadata/MobMeta.java
+@@ -8,9 +8,9 @@ public class MobMeta extends LivingEntityMeta {
+     public static final byte OFFSET = LivingEntityMeta.MAX_OFFSET;
+     public static final byte MAX_OFFSET = OFFSET + 1;
+ 
+-    private final static byte NO_AI_BIT = 0x01;
+-    private final static byte IS_LEFT_HANDED_BIT = 0x02;
+-    private final static byte IS_AGGRESSIVE_BIT = 0x04;
++    private static final byte NO_AI_BIT = 0x01;
++    private static final byte IS_LEFT_HANDED_BIT = 0x02;
++    private static final byte IS_AGGRESSIVE_BIT = 0x04;
+ 
+     protected MobMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
+         super(entity, metadata);
+diff --git a/src/main/java/net/minestom/server/entity/metadata/PlayerMeta.java b/src/main/java/net/minestom/server/entity/metadata/PlayerMeta.java
+index a0f7342bd6d7e50494ecc8a8a74281726ba99593..07de0b06e8ea685398006ab015e6d8be79835dab 100644
+--- a/src/main/java/net/minestom/server/entity/metadata/PlayerMeta.java
++++ b/src/main/java/net/minestom/server/entity/metadata/PlayerMeta.java
+@@ -12,13 +12,13 @@ public class PlayerMeta extends LivingEntityMeta {
+     public static final byte OFFSET = LivingEntityMeta.MAX_OFFSET;
+     public static final byte MAX_OFFSET = OFFSET + 1;
+ 
+-    private final static byte CAPE_BIT = 0x01;
+-    private final static byte JACKET_BIT = 0x02;
+-    private final static byte LEFT_SLEEVE_BIT = 0x04;
+-    private final static byte RIGHT_SLEEVE_BIT = 0x08;
+-    private final static byte LEFT_LEG_BIT = 0x10;
+-    private final static byte RIGHT_LEG_BIT = 0x20;
+-    private final static byte HAT_BIT = 0x40;
++    private static final byte CAPE_BIT = 0x01;
++    private static final byte JACKET_BIT = 0x02;
++    private static final byte LEFT_SLEEVE_BIT = 0x04;
++    private static final byte RIGHT_SLEEVE_BIT = 0x08;
++    private static final byte LEFT_LEG_BIT = 0x10;
++    private static final byte RIGHT_LEG_BIT = 0x20;
++    private static final byte HAT_BIT = 0x40;
+ 
+     public PlayerMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
+         super(entity, metadata);
+diff --git a/src/main/java/net/minestom/server/entity/metadata/ambient/BatMeta.java b/src/main/java/net/minestom/server/entity/metadata/ambient/BatMeta.java
+index badb44eb42716e011af4005841e4728f43f43ab0..0d56365f755f2f311854d3280e46731b4096759b 100644
+--- a/src/main/java/net/minestom/server/entity/metadata/ambient/BatMeta.java
++++ b/src/main/java/net/minestom/server/entity/metadata/ambient/BatMeta.java
+@@ -8,7 +8,7 @@ public class BatMeta extends AmbientCreatureMeta {
+     public static final byte OFFSET = AmbientCreatureMeta.MAX_OFFSET;
+     public static final byte MAX_OFFSET = OFFSET + 0;
+ 
+-    private final static byte IS_HANGING_BIT = 0x01;
++    private static final byte IS_HANGING_BIT = 0x01;
+ 
+     public BatMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
+         super(entity, metadata);
+diff --git a/src/main/java/net/minestom/server/entity/metadata/animal/AbstractHorseMeta.java b/src/main/java/net/minestom/server/entity/metadata/animal/AbstractHorseMeta.java
+index 4524ce8517ce4e28a75c7044cc9b956fbb6ef6a1..a63ee619de5a24838fdea0e6d81b3d11216cd4e2 100644
+--- a/src/main/java/net/minestom/server/entity/metadata/animal/AbstractHorseMeta.java
++++ b/src/main/java/net/minestom/server/entity/metadata/animal/AbstractHorseMeta.java
+@@ -10,12 +10,12 @@ public class AbstractHorseMeta extends AnimalMeta {
+     public static final byte OFFSET = AnimalMeta.MAX_OFFSET;
+     public static final byte MAX_OFFSET = OFFSET + 1; // Microtus - 1.19.4 update
+ 
+-    private final static byte TAMED_BIT = 0x02;
+-    private final static byte SADDLED_BIT = 0x04;
+-    private final static byte HAS_BRED_BIT = 0x08;
+-    private final static byte EATING_BIT = 0x10;
+-    private final static byte REARING_BIT = 0x20;
+-    private final static byte MOUTH_OPEN_BIT = 0x40;
++    private static final byte TAMED_BIT = 0x02;
++    private static final byte SADDLED_BIT = 0x04;
++    private static final byte HAS_BRED_BIT = 0x08;
++    private static final byte EATING_BIT = 0x10;
++    private static final byte REARING_BIT = 0x20;
++    private static final byte MOUTH_OPEN_BIT = 0x40;
+ 
+     protected AbstractHorseMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
+         super(entity, metadata);
+@@ -68,13 +68,5 @@ public class AbstractHorseMeta extends AnimalMeta {
+     public void setMouthOpen(boolean value) {
+         setMaskBit(OFFSET, MOUTH_OPEN_BIT, value);
+     }
+-    /* Microtus - 1.19.4 update
+-    public UUID getOwner() {
+-        return super.metadata.getIndex(OFFSET + 1, null);
+-    }
+ 
+-    public void setOwner(UUID value) {
+-        super.metadata.setIndex(OFFSET + 1, Metadata.OptUUID(value));
+-    }
+-    */
+ }
+diff --git a/src/main/java/net/minestom/server/entity/metadata/animal/BeeMeta.java b/src/main/java/net/minestom/server/entity/metadata/animal/BeeMeta.java
+index ff56fa14539db30131f595d12cdce19b0dad7515..e6fc1c21d674e0e852cb4cdce4f90bbcf9c1085a 100644
+--- a/src/main/java/net/minestom/server/entity/metadata/animal/BeeMeta.java
++++ b/src/main/java/net/minestom/server/entity/metadata/animal/BeeMeta.java
+@@ -8,9 +8,9 @@ public class BeeMeta extends AnimalMeta {
+     public static final byte OFFSET = AnimalMeta.MAX_OFFSET;
+     public static final byte MAX_OFFSET = OFFSET + 2;
+ 
+-    private final static byte ANGRY_BIT = 0x02;
+-    private final static byte HAS_STUNG_BIT = 0x04;
+-    private final static byte HAS_NECTAR_BIT = 0x08;
++    private static final byte ANGRY_BIT = 0x02;
++    private static final byte HAS_STUNG_BIT = 0x04;
++    private static final byte HAS_NECTAR_BIT = 0x08;
+ 
+     public BeeMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
+         super(entity, metadata);
+diff --git a/src/main/java/net/minestom/server/entity/metadata/animal/FoxMeta.java b/src/main/java/net/minestom/server/entity/metadata/animal/FoxMeta.java
+index 56e78d07664c0f7c49fda12a0de5ab2250863e72..fded09d40b9d99f459b413385d940f72775d27db 100644
+--- a/src/main/java/net/minestom/server/entity/metadata/animal/FoxMeta.java
++++ b/src/main/java/net/minestom/server/entity/metadata/animal/FoxMeta.java
+@@ -11,13 +11,13 @@ public class FoxMeta extends AnimalMeta {
+     public static final byte OFFSET = AnimalMeta.MAX_OFFSET;
+     public static final byte MAX_OFFSET = OFFSET + 4;
+ 
+-    private final static byte SITTING_BIT = 0x01;
+-    private final static byte CROUCHING_BIT = 0x04;
+-    private final static byte INTERESTED_BIT = 0x08;
+-    private final static byte POUNCING_BIT = 0x10;
+-    private final static byte SLEEPING_BIT = 0x20;
+-    private final static byte FACEPLANTED_BIT = 0x40;
+-    private final static byte DEFENDING_BIT = (byte) 0x80;
++    private static final byte SITTING_BIT = 0x01;
++    private static final byte CROUCHING_BIT = 0x04;
++    private static final byte INTERESTED_BIT = 0x08;
++    private static final byte POUNCING_BIT = 0x10;
++    private static final byte SLEEPING_BIT = 0x20;
++    private static final byte FACEPLANTED_BIT = 0x40;
++    private static final byte DEFENDING_BIT = (byte) 0x80;
+ 
+     public FoxMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
+         super(entity, metadata);
+diff --git a/src/main/java/net/minestom/server/entity/metadata/animal/PandaMeta.java b/src/main/java/net/minestom/server/entity/metadata/animal/PandaMeta.java
+index ae5641d210b87217d2bdf84ebfc0381cf7fc0f2c..7d7d4abeb9db2a137f5d7f4f8e85a688e7d1e8ad 100644
+--- a/src/main/java/net/minestom/server/entity/metadata/animal/PandaMeta.java
++++ b/src/main/java/net/minestom/server/entity/metadata/animal/PandaMeta.java
+@@ -8,10 +8,10 @@ public class PandaMeta extends AnimalMeta {
+     public static final byte OFFSET = AnimalMeta.MAX_OFFSET;
+     public static final byte MAX_OFFSET = OFFSET + 6;
+ 
+-    private final static byte SNEEZING_BIT = 0x02;
+-    private final static byte ROLLING_BIT = 0x04;
+-    private final static byte SITTING_BIT = 0x08;
+-    private final static byte ON_BACK_BIT = 0x10;
++    private static final byte SNEEZING_BIT = 0x02;
++    private static final byte ROLLING_BIT = 0x04;
++    private static final byte SITTING_BIT = 0x08;
++    private static final byte ON_BACK_BIT = 0x10;
+ 
+     public PandaMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
+         super(entity, metadata);
+diff --git a/src/main/java/net/minestom/server/entity/metadata/animal/SheepMeta.java b/src/main/java/net/minestom/server/entity/metadata/animal/SheepMeta.java
+index f256a3a44b189299b4608fe4c447290203f55b68..12e927a90d09ad0e741eb1a47ab5889844cfd128 100644
+--- a/src/main/java/net/minestom/server/entity/metadata/animal/SheepMeta.java
++++ b/src/main/java/net/minestom/server/entity/metadata/animal/SheepMeta.java
+@@ -8,8 +8,8 @@ public class SheepMeta extends AnimalMeta {
+     public static final byte OFFSET = AnimalMeta.MAX_OFFSET;
+     public static final byte MAX_OFFSET = OFFSET + 1;
+ 
+-    private final static byte COLOR_BITS = 0x0F;
+-    private final static byte SHEARED_BIT = 0x10;
++    private static final byte COLOR_BITS = 0x0F;
++    private static final byte SHEARED_BIT = 0x10;
+ 
+     public SheepMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
+         super(entity, metadata);
+diff --git a/src/main/java/net/minestom/server/entity/metadata/arrow/AbstractArrowMeta.java b/src/main/java/net/minestom/server/entity/metadata/arrow/AbstractArrowMeta.java
+index d2115dfb2371d79fe16e907a5a2e19ed7b27d73b..a114f62f6ee88e399ebbbfe95191c63b31cab89f 100644
+--- a/src/main/java/net/minestom/server/entity/metadata/arrow/AbstractArrowMeta.java
++++ b/src/main/java/net/minestom/server/entity/metadata/arrow/AbstractArrowMeta.java
+@@ -9,8 +9,8 @@ public class AbstractArrowMeta extends EntityMeta {
+     public static final byte OFFSET = EntityMeta.MAX_OFFSET;
+     public static final byte MAX_OFFSET = OFFSET + 2;
+ 
+-    private final static byte CRITICAL_BIT = 0x01;
+-    private final static byte NO_CLIP_BIT = 0x02;
++    private static final byte CRITICAL_BIT = 0x01;
++    private static final byte NO_CLIP_BIT = 0x02;
+ 
+     protected AbstractArrowMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
+         super(entity, metadata);
+diff --git a/src/main/java/net/minestom/server/entity/metadata/golem/IronGolemMeta.java b/src/main/java/net/minestom/server/entity/metadata/golem/IronGolemMeta.java
+index 9bbab19dceff737cac3c69738125e5b9d604057c..6e90878166490f01f81e1e178136faff79288da6 100644
+--- a/src/main/java/net/minestom/server/entity/metadata/golem/IronGolemMeta.java
++++ b/src/main/java/net/minestom/server/entity/metadata/golem/IronGolemMeta.java
+@@ -7,8 +7,7 @@ import org.jetbrains.annotations.NotNull;
+ public class IronGolemMeta extends AbstractGolemMeta {
+     public static final byte OFFSET = AbstractGolemMeta.MAX_OFFSET;
+     public static final byte MAX_OFFSET = OFFSET + 1;
+-
+-    private final static byte PLAYER_CREATED_BIT = 0x01;
++    private static final byte PLAYER_CREATED_BIT = 0x01;
+ 
+     public IronGolemMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
+         super(entity, metadata);
+diff --git a/src/main/java/net/minestom/server/entity/metadata/monster/BlazeMeta.java b/src/main/java/net/minestom/server/entity/metadata/monster/BlazeMeta.java
+index 3b01f13546ad1bf042aec0d0a6d951a30f2a443d..65bc392399bef70a5244235169b78064afa7add8 100644
+--- a/src/main/java/net/minestom/server/entity/metadata/monster/BlazeMeta.java
++++ b/src/main/java/net/minestom/server/entity/metadata/monster/BlazeMeta.java
+@@ -7,8 +7,7 @@ import org.jetbrains.annotations.NotNull;
+ public class BlazeMeta extends MonsterMeta {
+     public static final byte OFFSET = MonsterMeta.MAX_OFFSET;
+     public static final byte MAX_OFFSET = OFFSET + 1;
+-
+-    private final static byte ON_FIRE_BIT = 0x01;
++    private static final byte ON_FIRE_BIT = 0x01;
+ 
+     public BlazeMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
+         super(entity, metadata);
+diff --git a/src/main/java/net/minestom/server/entity/metadata/monster/SpiderMeta.java b/src/main/java/net/minestom/server/entity/metadata/monster/SpiderMeta.java
+index cc8c1828bb169f9f7118e69c1cb97a779482d88c..6b0a180322c9354e8ca04f4876b507ba96f419ed 100644
+--- a/src/main/java/net/minestom/server/entity/metadata/monster/SpiderMeta.java
++++ b/src/main/java/net/minestom/server/entity/metadata/monster/SpiderMeta.java
+@@ -8,7 +8,7 @@ public class SpiderMeta extends MonsterMeta {
+     public static final byte OFFSET = MonsterMeta.MAX_OFFSET;
+     public static final byte MAX_OFFSET = OFFSET + 1;
+ 
+-    private final static byte CLIMBING_BIT = 0x01;
++    private static final byte CLIMBING_BIT = 0x01;
+ 
+     public SpiderMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
+         super(entity, metadata);
+diff --git a/src/main/java/net/minestom/server/entity/metadata/monster/VexMeta.java b/src/main/java/net/minestom/server/entity/metadata/monster/VexMeta.java
+index d5c5d0469486d076acae5ccd46893f3eaea45bf8..3ee2ed091fda12915eee08079617a36db602ddec 100644
+--- a/src/main/java/net/minestom/server/entity/metadata/monster/VexMeta.java
++++ b/src/main/java/net/minestom/server/entity/metadata/monster/VexMeta.java
+@@ -8,7 +8,7 @@ public class VexMeta extends MonsterMeta {
+     public static final byte OFFSET = MonsterMeta.MAX_OFFSET;
+     public static final byte MAX_OFFSET = OFFSET + 1;
+ 
+-    private final static byte ATTACKING_BIT = 0x01;
++    private static final byte ATTACKING_BIT = 0x01;
+ 
+     public VexMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
+         super(entity, metadata);
+diff --git a/src/main/java/net/minestom/server/entity/metadata/other/ArmorStandMeta.java b/src/main/java/net/minestom/server/entity/metadata/other/ArmorStandMeta.java
+index 3203cdc0c07ffd9338a798ac26efd64b6eadf28a..292b2c0e20e4eddb11679f529460420bfe06ff6f 100644
+--- a/src/main/java/net/minestom/server/entity/metadata/other/ArmorStandMeta.java
++++ b/src/main/java/net/minestom/server/entity/metadata/other/ArmorStandMeta.java
+@@ -10,10 +10,10 @@ public class ArmorStandMeta extends LivingEntityMeta {
+     public static final byte OFFSET = LivingEntityMeta.MAX_OFFSET;
+     public static final byte MAX_OFFSET = OFFSET + 7;
+ 
+-    private final static byte IS_SMALL_BIT = 0x01;
+-    private final static byte HAS_ARMS_BIT = 0x04;
+-    private final static byte HAS_NO_BASE_PLATE_BIT = 0x08;
+-    private final static byte IS_MARKER_BIT = 0x10;
++    private static final byte IS_SMALL_BIT = 0x01;
++    private static final byte HAS_ARMS_BIT = 0x04;
++    private static final byte HAS_NO_BASE_PLATE_BIT = 0x08;
++    private static final byte IS_MARKER_BIT = 0x10;
+ 
+     public ArmorStandMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
+         super(entity, metadata);
 diff --git a/src/test/java/net/minestom/server/InsideTest.java b/src/test/java/net/minestom/server/InsideTest.java
 index 4fd8bc46ba32abc852398872bf8b63a30617408e..33c65cc23c0982d2e37eb12e40d844562bf85380 100644
 --- a/src/test/java/net/minestom/server/InsideTest.java

--- a/minestom-patches/0015-Update-java-keyword-usage.patch
+++ b/minestom-patches/0015-Update-java-keyword-usage.patch
@@ -5,20 +5,20 @@ Subject: [PATCH] Update java keyword usage
 
 
 diff --git a/src/main/java/net/minestom/server/adventure/AdventurePacketConvertor.java b/src/main/java/net/minestom/server/adventure/AdventurePacketConvertor.java
-index 04244d43a556e33b5ce9cb4cf727433f976af35b..f95e46f468b17bf2b6d20e8cab866b5a787ceb7e 100644
+index 04244d43a556e33b5ce9cb4cf727433f976af35b..4c8de4b9f8f48d59555c7118b46dcc0206466f3d 100644
 --- a/src/main/java/net/minestom/server/adventure/AdventurePacketConvertor.java
 +++ b/src/main/java/net/minestom/server/adventure/AdventurePacketConvertor.java
 @@ -46,6 +46,8 @@ public class AdventurePacketConvertor {
          NAMED_TEXT_COLOR_ID_MAP.put(NamedTextColor.WHITE, 15);
      }
  
-+    private AdventurePacketConvertor() { }
++    private AdventurePacketConvertor() { } //Microtus - update java keyword usage
 +
      /**
       * Gets the int value of a boss bar overlay.
       *
 diff --git a/src/main/java/net/minestom/server/command/builder/arguments/ArgumentEnum.java b/src/main/java/net/minestom/server/command/builder/arguments/ArgumentEnum.java
-index 3ac12d8d67644ef8fdbfe7fb0fbbd442907c04db..a104ebbe4934e4c3427e6f0588f856bc5bc416b5 100644
+index 3ac12d8d67644ef8fdbfe7fb0fbbd442907c04db..a4e0a096160198af918559875a55a31b8a6afcf7 100644
 --- a/src/main/java/net/minestom/server/command/builder/arguments/ArgumentEnum.java
 +++ b/src/main/java/net/minestom/server/command/builder/arguments/ArgumentEnum.java
 @@ -11,7 +11,7 @@ import java.util.function.UnaryOperator;
@@ -26,7 +26,7 @@ index 3ac12d8d67644ef8fdbfe7fb0fbbd442907c04db..a104ebbe4934e4c3427e6f0588f856bc
  public class ArgumentEnum<E extends Enum> extends Argument<E> {
  
 -    public final static int NOT_ENUM_VALUE_ERROR = 1;
-+    public static final int NOT_ENUM_VALUE_ERROR = 1;
++    public static final int NOT_ENUM_VALUE_ERROR = 1; //Microtus - update java keyword usage
  
      private final Class<E> enumClass;
      private final E[] values;
@@ -44,20 +44,23 @@ index cd15c02a785b35c3ef4f387958fd6cd80aea2e43..aaf19016451bf8ae361c7eded9f608b0
          this.min = min;
          this.max = max;
 diff --git a/src/main/java/net/minestom/server/command/builder/arguments/minecraft/registry/ArgumentRegistry.java b/src/main/java/net/minestom/server/command/builder/arguments/minecraft/registry/ArgumentRegistry.java
-index 83570542f3bce400238b45d067aad19444669b36..0f163c4448cef8116b6d7dc307e0b59b9cc9f262 100644
+index 83570542f3bce400238b45d067aad19444669b36..7c776a72a551667f6945b73e11256ac161a5a665 100644
 --- a/src/main/java/net/minestom/server/command/builder/arguments/minecraft/registry/ArgumentRegistry.java
 +++ b/src/main/java/net/minestom/server/command/builder/arguments/minecraft/registry/ArgumentRegistry.java
-@@ -8,7 +8,7 @@ public abstract class ArgumentRegistry<T> extends Argument<T> {
+@@ -8,9 +8,9 @@ public abstract class ArgumentRegistry<T> extends Argument<T> {
  
      public static final int INVALID_NAME = -2;
  
 -    public ArgumentRegistry(String id) {
 +    ArgumentRegistry(String id) {
          super(id);
-     }
+-    }
++    } //Microtus - update java keyword usage
+ 
+     public abstract T getRegistry(@NotNull String value);
  
 diff --git a/src/main/java/net/minestom/server/command/builder/arguments/relative/ArgumentRelativeVec.java b/src/main/java/net/minestom/server/command/builder/arguments/relative/ArgumentRelativeVec.java
-index 66400d55272e182692398aec8d509ce51f782744..d0814278cbc31332e529ba44ad42baa2a48fa901 100644
+index 66400d55272e182692398aec8d509ce51f782744..f891222f28b6bd2a13d16706030164126ff725f5 100644
 --- a/src/main/java/net/minestom/server/command/builder/arguments/relative/ArgumentRelativeVec.java
 +++ b/src/main/java/net/minestom/server/command/builder/arguments/relative/ArgumentRelativeVec.java
 @@ -27,7 +27,7 @@ abstract class ArgumentRelativeVec extends Argument<RelativeVec> {
@@ -65,12 +68,12 @@ index 66400d55272e182692398aec8d509ce51f782744..d0814278cbc31332e529ba44ad42baa2
      private final int numberCount;
  
 -    public ArgumentRelativeVec(@NotNull String id, int numberCount) {
-+    ArgumentRelativeVec(@NotNull String id, int numberCount) {
++    ArgumentRelativeVec(@NotNull String id, int numberCount) { //Microtus - update java keyword usage
          super(id, true);
          this.numberCount = numberCount;
      }
 diff --git a/src/main/java/net/minestom/server/entity/EntityProjectile.java b/src/main/java/net/minestom/server/entity/EntityProjectile.java
-index 82685ae08e5806f749995e293b63e7ac7f7223b7..e3080b8fc56ab8db6f0f5f36166ad62f8f1e67f0 100644
+index 82685ae08e5806f749995e293b63e7ac7f7223b7..37e645005bcef8dd8f663eeb709c73da0722ed31 100644
 --- a/src/main/java/net/minestom/server/entity/EntityProjectile.java
 +++ b/src/main/java/net/minestom/server/entity/EntityProjectile.java
 @@ -157,8 +157,8 @@ public class EntityProjectile extends Entity {
@@ -79,29 +82,37 @@ index 82685ae08e5806f749995e293b63e7ac7f7223b7..e3080b8fc56ab8db6f0f5f36166ad62f
                          .stream()
 -                        .filter(entity -> entity instanceof LivingEntity)
 -                        .map(entity -> (LivingEntity) entity)
-+                        .filter(LivingEntity.class::isInstance)
-+                        .map(LivingEntity.class::cast)
++                        .filter(LivingEntity.class::isInstance) //Microtus - update java keyword usage
++                        .map(LivingEntity.class::cast) //Microtus - update java keyword usage
                          .collect(Collectors.toSet());
              }
              final Point currentPos = pos;
 diff --git a/src/main/java/net/minestom/server/entity/ai/GoalSelector.java b/src/main/java/net/minestom/server/entity/ai/GoalSelector.java
-index e89698ad47e1e9255754832857d3e0b2cb0aa88b..5c1720fd51d7bdf2acdf6674c40dc7cff2a7b80e 100644
+index e89698ad47e1e9255754832857d3e0b2cb0aa88b..3c3e48fc33e68542fb237f3edb47eb927868cd1a 100644
 --- a/src/main/java/net/minestom/server/entity/ai/GoalSelector.java
 +++ b/src/main/java/net/minestom/server/entity/ai/GoalSelector.java
-@@ -12,7 +12,7 @@ public abstract class GoalSelector {
+@@ -2,6 +2,7 @@ package net.minestom.server.entity.ai;
+ 
+ import net.minestom.server.entity.Entity;
+ import net.minestom.server.entity.EntityCreature;
++import net.minestom.server.entity.LivingEntity;
+ import org.jetbrains.annotations.NotNull;
+ import org.jetbrains.annotations.Nullable;
+ 
+@@ -12,7 +13,7 @@ public abstract class GoalSelector {
      private WeakReference<EntityAIGroup> aiGroupWeakReference;
      protected EntityCreature entityCreature;
  
 -    public GoalSelector(@NotNull EntityCreature entityCreature) {
-+    protected GoalSelector(@NotNull EntityCreature entityCreature) {
++    protected GoalSelector(@NotNull EntityCreature entityCreature) { //Microtus - update java keyword usage
          this.entityCreature = entityCreature;
      }
  
 diff --git a/src/main/java/net/minestom/server/entity/metadata/EntityMeta.java b/src/main/java/net/minestom/server/entity/metadata/EntityMeta.java
-index 449b16bbbc863703e293606d3253d2b7c4f64078..c7f382df4b3826f68362170b0f4b8069a76b2f03 100644
+index 449b16bbbc863703e293606d3253d2b7c4f64078..c1a4ae454e23bb8a58596089c1cb532880484a1d 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/EntityMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/EntityMeta.java
-@@ -13,13 +13,13 @@ public class EntityMeta {
+@@ -13,13 +13,15 @@ public class EntityMeta {
      public static final byte OFFSET = 0;
      public static final byte MAX_OFFSET = OFFSET + 8;
  
@@ -112,6 +123,7 @@ index 449b16bbbc863703e293606d3253d2b7c4f64078..c7f382df4b3826f68362170b0f4b8069
 -    private final static byte INVISIBLE_BIT = 0x20;
 -    private final static byte HAS_GLOWING_EFFECT_BIT = 0x40;
 -    private final static byte FLYING_WITH_ELYTRA_BIT = (byte) 0x80;
++    //Microtus start - update java keyword usage
 +    private static final byte ON_FIRE_BIT = 0x01;
 +    private static final byte CROUCHING_BIT = 0x02;
 +    private static final byte SPRINTING_BIT = 0x08;
@@ -119,48 +131,53 @@ index 449b16bbbc863703e293606d3253d2b7c4f64078..c7f382df4b3826f68362170b0f4b8069
 +    private static final byte INVISIBLE_BIT = 0x20;
 +    private static final byte HAS_GLOWING_EFFECT_BIT = 0x40;
 +    private static final byte FLYING_WITH_ELYTRA_BIT = (byte) 0x80;
++    //Microtus end - update java keyword usage
  
      private final WeakReference<Entity> entityRef;
      protected final Metadata metadata;
 diff --git a/src/main/java/net/minestom/server/entity/metadata/LivingEntityMeta.java b/src/main/java/net/minestom/server/entity/metadata/LivingEntityMeta.java
-index 60d7102b205bc04a60678fecc2da0009ce56437a..692d0fa76b810258089c9462663ef4a431847759 100644
+index 60d7102b205bc04a60678fecc2da0009ce56437a..1640a25fa4f17b0f49e20621f858d74436c9ea5e 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/LivingEntityMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/LivingEntityMeta.java
-@@ -11,9 +11,9 @@ public class LivingEntityMeta extends EntityMeta {
+@@ -11,9 +11,11 @@ public class LivingEntityMeta extends EntityMeta {
      public static final byte OFFSET = EntityMeta.MAX_OFFSET;
      public static final byte MAX_OFFSET = OFFSET + 7;
  
 -    private final static byte IS_HAND_ACTIVE_BIT = 0x01;
 -    private final static byte ACTIVE_HAND_BIT = 0x02;
 -    private final static byte IS_IN_SPIN_ATTACK_BIT = 0x04;
++    //Microtus start - update java keyword usage
 +    private static final byte IS_HAND_ACTIVE_BIT = 0x01;
 +    private static final byte ACTIVE_HAND_BIT = 0x02;
 +    private static final byte IS_IN_SPIN_ATTACK_BIT = 0x04;
++    //Microtus end - update java keyword usage
  
      protected LivingEntityMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
          super(entity, metadata);
 diff --git a/src/main/java/net/minestom/server/entity/metadata/MobMeta.java b/src/main/java/net/minestom/server/entity/metadata/MobMeta.java
-index 98703d3d9ff9e7e5865dfe92341b9a38e9801e7d..877c4d668f429a9f1eaeb5d48a761dcd1505b485 100644
+index 98703d3d9ff9e7e5865dfe92341b9a38e9801e7d..bb823ab1ad03f4af5f3295ca323db4f0dd012b1b 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/MobMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/MobMeta.java
-@@ -8,9 +8,9 @@ public class MobMeta extends LivingEntityMeta {
+@@ -8,9 +8,11 @@ public class MobMeta extends LivingEntityMeta {
      public static final byte OFFSET = LivingEntityMeta.MAX_OFFSET;
      public static final byte MAX_OFFSET = OFFSET + 1;
  
 -    private final static byte NO_AI_BIT = 0x01;
 -    private final static byte IS_LEFT_HANDED_BIT = 0x02;
 -    private final static byte IS_AGGRESSIVE_BIT = 0x04;
++    //Microtus start - update java keyword usage
 +    private static final byte NO_AI_BIT = 0x01;
 +    private static final byte IS_LEFT_HANDED_BIT = 0x02;
 +    private static final byte IS_AGGRESSIVE_BIT = 0x04;
++    //Microtus end - update java keyword usage
  
      protected MobMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
          super(entity, metadata);
 diff --git a/src/main/java/net/minestom/server/entity/metadata/PlayerMeta.java b/src/main/java/net/minestom/server/entity/metadata/PlayerMeta.java
-index a0f7342bd6d7e50494ecc8a8a74281726ba99593..07de0b06e8ea685398006ab015e6d8be79835dab 100644
+index a0f7342bd6d7e50494ecc8a8a74281726ba99593..9a4c3e8303ad7369e9f4cc53b28add7516438885 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/PlayerMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/PlayerMeta.java
-@@ -12,13 +12,13 @@ public class PlayerMeta extends LivingEntityMeta {
+@@ -12,13 +12,15 @@ public class PlayerMeta extends LivingEntityMeta {
      public static final byte OFFSET = LivingEntityMeta.MAX_OFFSET;
      public static final byte MAX_OFFSET = OFFSET + 1;
  
@@ -171,6 +188,7 @@ index a0f7342bd6d7e50494ecc8a8a74281726ba99593..07de0b06e8ea685398006ab015e6d8be
 -    private final static byte LEFT_LEG_BIT = 0x10;
 -    private final static byte RIGHT_LEG_BIT = 0x20;
 -    private final static byte HAT_BIT = 0x40;
++    //Microtus start - update java keyword usage
 +    private static final byte CAPE_BIT = 0x01;
 +    private static final byte JACKET_BIT = 0x02;
 +    private static final byte LEFT_SLEEVE_BIT = 0x04;
@@ -178,11 +196,12 @@ index a0f7342bd6d7e50494ecc8a8a74281726ba99593..07de0b06e8ea685398006ab015e6d8be
 +    private static final byte LEFT_LEG_BIT = 0x10;
 +    private static final byte RIGHT_LEG_BIT = 0x20;
 +    private static final byte HAT_BIT = 0x40;
++    //Microtus end - update java keyword usage
  
      public PlayerMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
          super(entity, metadata);
 diff --git a/src/main/java/net/minestom/server/entity/metadata/ambient/BatMeta.java b/src/main/java/net/minestom/server/entity/metadata/ambient/BatMeta.java
-index badb44eb42716e011af4005841e4728f43f43ab0..0d56365f755f2f311854d3280e46731b4096759b 100644
+index badb44eb42716e011af4005841e4728f43f43ab0..e722b13e9900206bef438cf31f46ee9738019113 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/ambient/BatMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/ambient/BatMeta.java
 @@ -8,7 +8,7 @@ public class BatMeta extends AmbientCreatureMeta {
@@ -190,15 +209,15 @@ index badb44eb42716e011af4005841e4728f43f43ab0..0d56365f755f2f311854d3280e46731b
      public static final byte MAX_OFFSET = OFFSET + 0;
  
 -    private final static byte IS_HANGING_BIT = 0x01;
-+    private static final byte IS_HANGING_BIT = 0x01;
++    private static final byte IS_HANGING_BIT = 0x01; //Microtus - update java keyword usage
  
      public BatMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
          super(entity, metadata);
 diff --git a/src/main/java/net/minestom/server/entity/metadata/animal/AbstractHorseMeta.java b/src/main/java/net/minestom/server/entity/metadata/animal/AbstractHorseMeta.java
-index 4524ce8517ce4e28a75c7044cc9b956fbb6ef6a1..a63ee619de5a24838fdea0e6d81b3d11216cd4e2 100644
+index 4524ce8517ce4e28a75c7044cc9b956fbb6ef6a1..bc2b06fb6652b8de3e9357bec939d62082319998 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/animal/AbstractHorseMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/animal/AbstractHorseMeta.java
-@@ -10,12 +10,12 @@ public class AbstractHorseMeta extends AnimalMeta {
+@@ -10,12 +10,14 @@ public class AbstractHorseMeta extends AnimalMeta {
      public static final byte OFFSET = AnimalMeta.MAX_OFFSET;
      public static final byte MAX_OFFSET = OFFSET + 1; // Microtus - 1.19.4 update
  
@@ -208,16 +227,18 @@ index 4524ce8517ce4e28a75c7044cc9b956fbb6ef6a1..a63ee619de5a24838fdea0e6d81b3d11
 -    private final static byte EATING_BIT = 0x10;
 -    private final static byte REARING_BIT = 0x20;
 -    private final static byte MOUTH_OPEN_BIT = 0x40;
++    //Microtus start - update java keyword usage
 +    private static final byte TAMED_BIT = 0x02;
 +    private static final byte SADDLED_BIT = 0x04;
 +    private static final byte HAS_BRED_BIT = 0x08;
 +    private static final byte EATING_BIT = 0x10;
 +    private static final byte REARING_BIT = 0x20;
 +    private static final byte MOUTH_OPEN_BIT = 0x40;
++    //Microtus end - update java keyword usage
  
      protected AbstractHorseMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
          super(entity, metadata);
-@@ -68,13 +68,5 @@ public class AbstractHorseMeta extends AnimalMeta {
+@@ -68,13 +70,5 @@ public class AbstractHorseMeta extends AnimalMeta {
      public void setMouthOpen(boolean value) {
          setMaskBit(OFFSET, MOUTH_OPEN_BIT, value);
      }
@@ -232,27 +253,29 @@ index 4524ce8517ce4e28a75c7044cc9b956fbb6ef6a1..a63ee619de5a24838fdea0e6d81b3d11
 -    */
  }
 diff --git a/src/main/java/net/minestom/server/entity/metadata/animal/BeeMeta.java b/src/main/java/net/minestom/server/entity/metadata/animal/BeeMeta.java
-index ff56fa14539db30131f595d12cdce19b0dad7515..e6fc1c21d674e0e852cb4cdce4f90bbcf9c1085a 100644
+index ff56fa14539db30131f595d12cdce19b0dad7515..957f5dd479b8b13f21c24d7045dcde8078cb23b8 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/animal/BeeMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/animal/BeeMeta.java
-@@ -8,9 +8,9 @@ public class BeeMeta extends AnimalMeta {
+@@ -8,9 +8,11 @@ public class BeeMeta extends AnimalMeta {
      public static final byte OFFSET = AnimalMeta.MAX_OFFSET;
      public static final byte MAX_OFFSET = OFFSET + 2;
  
 -    private final static byte ANGRY_BIT = 0x02;
 -    private final static byte HAS_STUNG_BIT = 0x04;
 -    private final static byte HAS_NECTAR_BIT = 0x08;
++    //Microtus start - update java keyword usage
 +    private static final byte ANGRY_BIT = 0x02;
 +    private static final byte HAS_STUNG_BIT = 0x04;
 +    private static final byte HAS_NECTAR_BIT = 0x08;
++    //Microtus end - update java keyword usage
  
      public BeeMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
          super(entity, metadata);
 diff --git a/src/main/java/net/minestom/server/entity/metadata/animal/FoxMeta.java b/src/main/java/net/minestom/server/entity/metadata/animal/FoxMeta.java
-index 56e78d07664c0f7c49fda12a0de5ab2250863e72..c95c2cbcc15a11c1d6ed27baa974de345ba892de 100644
+index 56e78d07664c0f7c49fda12a0de5ab2250863e72..8f58b2e370a042eb0d082d42b20ecb432516e10b 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/animal/FoxMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/animal/FoxMeta.java
-@@ -11,13 +11,13 @@ public class FoxMeta extends AnimalMeta {
+@@ -11,13 +11,15 @@ public class FoxMeta extends AnimalMeta {
      public static final byte OFFSET = AnimalMeta.MAX_OFFSET;
      public static final byte MAX_OFFSET = OFFSET + 4;
  
@@ -263,6 +286,7 @@ index 56e78d07664c0f7c49fda12a0de5ab2250863e72..c95c2cbcc15a11c1d6ed27baa974de34
 -    private final static byte SLEEPING_BIT = 0x20;
 -    private final static byte FACEPLANTED_BIT = 0x40;
 -    private final static byte DEFENDING_BIT = (byte) 0x80;
++    //Microtus start - update java keyword usage
 +    private static final byte SITTING_BIT = 0x01;
 +    private static final byte CROUCHING_BIT = 0x04;
 +    private static final byte INTERESTED_BIT = 0x08;
@@ -270,10 +294,11 @@ index 56e78d07664c0f7c49fda12a0de5ab2250863e72..c95c2cbcc15a11c1d6ed27baa974de34
 +    private static final byte SLEEPING_BIT = 0x20;
 +    private static final byte FACEPLANTED_BIT = 0x40;
 +    private static final byte DEFENDING_BIT = (byte) 0x80;
++    //Microtus end - update java keyword usage
  
      public FoxMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
          super(entity, metadata);
-@@ -110,7 +110,7 @@ public class FoxMeta extends AnimalMeta {
+@@ -110,7 +112,7 @@ public class FoxMeta extends AnimalMeta {
          RED,
          SNOW;
  
@@ -283,7 +308,7 @@ index 56e78d07664c0f7c49fda12a0de5ab2250863e72..c95c2cbcc15a11c1d6ed27baa974de34
  
  }
 diff --git a/src/main/java/net/minestom/server/entity/metadata/animal/HorseMeta.java b/src/main/java/net/minestom/server/entity/metadata/animal/HorseMeta.java
-index b228164c4089328587b54e8d243c5585804fd2ec..940b77543aad8e73aeeb0727941fa57fbc0a39b4 100644
+index b228164c4089328587b54e8d243c5585804fd2ec..12d816e5e24f2479582ab87fb05bf4e3dd4ea6a6 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/animal/HorseMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/animal/HorseMeta.java
 @@ -68,7 +68,7 @@ public class HorseMeta extends AbstractHorseMeta {
@@ -291,37 +316,37 @@ index b228164c4089328587b54e8d243c5585804fd2ec..940b77543aad8e73aeeb0727941fa57f
          BLACK_DOTS;
  
 -        private final static Marking[] VALUES = values();
-+        private static final Marking[] VALUES = values();
++        private static final Marking[] VALUES = values(); //Microtus - update java keyword usage
      }
  
      public enum Color {
-@@ -80,7 +80,7 @@ public class HorseMeta extends AbstractHorseMeta {
+@@ -80,7 +80,6 @@ public class HorseMeta extends AbstractHorseMeta {
          GRAY,
          DARK_BROWN;
  
 -        private final static Color[] VALUES = values();
-+        private static final Color[] VALUES = values();
++        private static final Color[] VALUES = values(); //Microtus - update java keyword usage
      }
- 
+-
  }
 diff --git a/src/main/java/net/minestom/server/entity/metadata/animal/LlamaMeta.java b/src/main/java/net/minestom/server/entity/metadata/animal/LlamaMeta.java
-index dd9a4dba47357d3877a22489e3ecfca8c2cf2ca7..a9b74a5b87d094847bed5d69cb604a7224a0079b 100644
+index dd9a4dba47357d3877a22489e3ecfca8c2cf2ca7..e506582b0c62d405310c8961fd3d66ea2da24984 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/animal/LlamaMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/animal/LlamaMeta.java
-@@ -42,7 +42,7 @@ public class LlamaMeta extends ChestedHorseMeta {
+@@ -42,7 +42,6 @@ public class LlamaMeta extends ChestedHorseMeta {
          BROWN,
          GRAY;
  
 -        private final static Variant[] VALUES = values();
-+        private static final Variant[] VALUES = values();
++        private static final Variant[] VALUES = values(); //Microtus - update java keyword usage
      }
- 
+-
  }
 diff --git a/src/main/java/net/minestom/server/entity/metadata/animal/PandaMeta.java b/src/main/java/net/minestom/server/entity/metadata/animal/PandaMeta.java
-index ae5641d210b87217d2bdf84ebfc0381cf7fc0f2c..7d7d4abeb9db2a137f5d7f4f8e85a688e7d1e8ad 100644
+index ae5641d210b87217d2bdf84ebfc0381cf7fc0f2c..f18666a67d03b967dc3c7afc25f2e5a4ac13d182 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/animal/PandaMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/animal/PandaMeta.java
-@@ -8,10 +8,10 @@ public class PandaMeta extends AnimalMeta {
+@@ -8,10 +8,12 @@ public class PandaMeta extends AnimalMeta {
      public static final byte OFFSET = AnimalMeta.MAX_OFFSET;
      public static final byte MAX_OFFSET = OFFSET + 6;
  
@@ -329,45 +354,51 @@ index ae5641d210b87217d2bdf84ebfc0381cf7fc0f2c..7d7d4abeb9db2a137f5d7f4f8e85a688
 -    private final static byte ROLLING_BIT = 0x04;
 -    private final static byte SITTING_BIT = 0x08;
 -    private final static byte ON_BACK_BIT = 0x10;
++    //Microtus start - update java keyword usage
 +    private static final byte SNEEZING_BIT = 0x02;
 +    private static final byte ROLLING_BIT = 0x04;
 +    private static final byte SITTING_BIT = 0x08;
 +    private static final byte ON_BACK_BIT = 0x10;
++    //Microtus end - update java keyword usage
  
      public PandaMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
          super(entity, metadata);
 diff --git a/src/main/java/net/minestom/server/entity/metadata/animal/SheepMeta.java b/src/main/java/net/minestom/server/entity/metadata/animal/SheepMeta.java
-index f256a3a44b189299b4608fe4c447290203f55b68..12e927a90d09ad0e741eb1a47ab5889844cfd128 100644
+index f256a3a44b189299b4608fe4c447290203f55b68..bc6bd54c017665e52a63b87ed30c1ca9b1097fd1 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/animal/SheepMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/animal/SheepMeta.java
-@@ -8,8 +8,8 @@ public class SheepMeta extends AnimalMeta {
+@@ -8,8 +8,10 @@ public class SheepMeta extends AnimalMeta {
      public static final byte OFFSET = AnimalMeta.MAX_OFFSET;
      public static final byte MAX_OFFSET = OFFSET + 1;
  
 -    private final static byte COLOR_BITS = 0x0F;
 -    private final static byte SHEARED_BIT = 0x10;
++    //Microtus start - update java keyword usage
 +    private static final byte COLOR_BITS = 0x0F;
 +    private static final byte SHEARED_BIT = 0x10;
++    //Microtus end - update java keyword usage
  
      public SheepMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
          super(entity, metadata);
 diff --git a/src/main/java/net/minestom/server/entity/metadata/arrow/AbstractArrowMeta.java b/src/main/java/net/minestom/server/entity/metadata/arrow/AbstractArrowMeta.java
-index d2115dfb2371d79fe16e907a5a2e19ed7b27d73b..a114f62f6ee88e399ebbbfe95191c63b31cab89f 100644
+index d2115dfb2371d79fe16e907a5a2e19ed7b27d73b..28571c9e1ad982e0baa8b13f18f778ccfc43aa79 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/arrow/AbstractArrowMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/arrow/AbstractArrowMeta.java
-@@ -9,8 +9,8 @@ public class AbstractArrowMeta extends EntityMeta {
+@@ -9,8 +9,10 @@ public class AbstractArrowMeta extends EntityMeta {
      public static final byte OFFSET = EntityMeta.MAX_OFFSET;
      public static final byte MAX_OFFSET = OFFSET + 2;
  
 -    private final static byte CRITICAL_BIT = 0x01;
 -    private final static byte NO_CLIP_BIT = 0x02;
++    //Microtus start - update java keyword usage
 +    private static final byte CRITICAL_BIT = 0x01;
 +    private static final byte NO_CLIP_BIT = 0x02;
++    //Microtus end - update java keyword usage
  
      protected AbstractArrowMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
          super(entity, metadata);
 diff --git a/src/main/java/net/minestom/server/entity/metadata/display/AbstractDisplayMeta.java b/src/main/java/net/minestom/server/entity/metadata/display/AbstractDisplayMeta.java
-index fce02b850183964a964b9e342ae5ab0acf4648b0..76747449e0d1e410b35e30bb364310a46f0c0710 100644
+index fce02b850183964a964b9e342ae5ab0acf4648b0..f04a986b304ec2f38816103d1b516278279cdbf1 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/display/AbstractDisplayMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/display/AbstractDisplayMeta.java
 @@ -137,7 +137,6 @@ public class AbstractDisplayMeta extends EntityMeta {
@@ -375,25 +406,26 @@ index fce02b850183964a964b9e342ae5ab0acf4648b0..76747449e0d1e410b35e30bb364310a4
          CENTER;
  
 -        private final static BillboardConstraints[] VALUES = values();
-+        private static final BillboardConstraints[] VALUES = values();
++        private static final BillboardConstraints[] VALUES = values(); //Microtus - update java keyword usage
      }
 -
  }
 diff --git a/src/main/java/net/minestom/server/entity/metadata/display/ItemDisplayMeta.java b/src/main/java/net/minestom/server/entity/metadata/display/ItemDisplayMeta.java
-index f574b37d77df167e5dfebc4eb479ce49dfd049c2..9528acea84ce6c19ae5715185f8c62e436a2e987 100644
+index f574b37d77df167e5dfebc4eb479ce49dfd049c2..3ba49692a4369eae00749ab2cae146eff14ad686 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/display/ItemDisplayMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/display/ItemDisplayMeta.java
-@@ -42,7 +42,7 @@ public class ItemDisplayMeta extends AbstractDisplayMeta {
+@@ -42,8 +42,7 @@ public class ItemDisplayMeta extends AbstractDisplayMeta {
          GROUND,
          FIXED;
  
 -        private final static DisplayContext[] VALUES = values();
-+        private static final DisplayContext[] VALUES = values();
++        private static final DisplayContext[] VALUES = values(); //Microtus - update java keyword usage
  
      }
- 
+-
+ }
 diff --git a/src/main/java/net/minestom/server/entity/metadata/golem/IronGolemMeta.java b/src/main/java/net/minestom/server/entity/metadata/golem/IronGolemMeta.java
-index 9bbab19dceff737cac3c69738125e5b9d604057c..6e90878166490f01f81e1e178136faff79288da6 100644
+index 9bbab19dceff737cac3c69738125e5b9d604057c..a6c82357089ed26e6fac40833dfd0912859f2b7c 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/golem/IronGolemMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/golem/IronGolemMeta.java
 @@ -7,8 +7,7 @@ import org.jetbrains.annotations.NotNull;
@@ -402,12 +434,12 @@ index 9bbab19dceff737cac3c69738125e5b9d604057c..6e90878166490f01f81e1e178136faff
      public static final byte MAX_OFFSET = OFFSET + 1;
 -
 -    private final static byte PLAYER_CREATED_BIT = 0x01;
-+    private static final byte PLAYER_CREATED_BIT = 0x01;
++    private static final byte PLAYER_CREATED_BIT = 0x01; //Microtus - update java keyword usage
  
      public IronGolemMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
          super(entity, metadata);
 diff --git a/src/main/java/net/minestom/server/entity/metadata/monster/BlazeMeta.java b/src/main/java/net/minestom/server/entity/metadata/monster/BlazeMeta.java
-index 3b01f13546ad1bf042aec0d0a6d951a30f2a443d..65bc392399bef70a5244235169b78064afa7add8 100644
+index 3b01f13546ad1bf042aec0d0a6d951a30f2a443d..32cb10b6810ac16a75d1b670c021c01d7ed2711f 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/monster/BlazeMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/monster/BlazeMeta.java
 @@ -7,8 +7,7 @@ import org.jetbrains.annotations.NotNull;
@@ -416,41 +448,43 @@ index 3b01f13546ad1bf042aec0d0a6d951a30f2a443d..65bc392399bef70a5244235169b78064
      public static final byte MAX_OFFSET = OFFSET + 1;
 -
 -    private final static byte ON_FIRE_BIT = 0x01;
-+    private static final byte ON_FIRE_BIT = 0x01;
++    private static final byte ON_FIRE_BIT = 0x01; //Microtus - update java keyword usage
  
      public BlazeMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
          super(entity, metadata);
 diff --git a/src/main/java/net/minestom/server/entity/metadata/monster/SpiderMeta.java b/src/main/java/net/minestom/server/entity/metadata/monster/SpiderMeta.java
-index cc8c1828bb169f9f7118e69c1cb97a779482d88c..6b0a180322c9354e8ca04f4876b507ba96f419ed 100644
+index cc8c1828bb169f9f7118e69c1cb97a779482d88c..1b46fb30da57e90036b5006c3a303e629976284b 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/monster/SpiderMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/monster/SpiderMeta.java
-@@ -8,7 +8,7 @@ public class SpiderMeta extends MonsterMeta {
+@@ -7,8 +7,7 @@ import org.jetbrains.annotations.NotNull;
+ public class SpiderMeta extends MonsterMeta {
      public static final byte OFFSET = MonsterMeta.MAX_OFFSET;
      public static final byte MAX_OFFSET = OFFSET + 1;
- 
+-
 -    private final static byte CLIMBING_BIT = 0x01;
-+    private static final byte CLIMBING_BIT = 0x01;
++    private static final byte CLIMBING_BIT = 0x01; //Microtus - update java keyword usage
  
      public SpiderMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
          super(entity, metadata);
 diff --git a/src/main/java/net/minestom/server/entity/metadata/monster/VexMeta.java b/src/main/java/net/minestom/server/entity/metadata/monster/VexMeta.java
-index d5c5d0469486d076acae5ccd46893f3eaea45bf8..3ee2ed091fda12915eee08079617a36db602ddec 100644
+index d5c5d0469486d076acae5ccd46893f3eaea45bf8..f566c2369576fb102554aef166d16aa3de21d329 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/monster/VexMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/monster/VexMeta.java
-@@ -8,7 +8,7 @@ public class VexMeta extends MonsterMeta {
+@@ -7,8 +7,7 @@ import org.jetbrains.annotations.NotNull;
+ public class VexMeta extends MonsterMeta {
      public static final byte OFFSET = MonsterMeta.MAX_OFFSET;
      public static final byte MAX_OFFSET = OFFSET + 1;
- 
+-
 -    private final static byte ATTACKING_BIT = 0x01;
-+    private static final byte ATTACKING_BIT = 0x01;
++    private static final byte ATTACKING_BIT = 0x01;  //Microtus - update java keyword usage
  
      public VexMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
          super(entity, metadata);
 diff --git a/src/main/java/net/minestom/server/entity/metadata/other/ArmorStandMeta.java b/src/main/java/net/minestom/server/entity/metadata/other/ArmorStandMeta.java
-index 3203cdc0c07ffd9338a798ac26efd64b6eadf28a..292b2c0e20e4eddb11679f529460420bfe06ff6f 100644
+index 3203cdc0c07ffd9338a798ac26efd64b6eadf28a..a6c860cf6623417ae4e7d9ee0982e9caec0c34d7 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/other/ArmorStandMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/other/ArmorStandMeta.java
-@@ -10,10 +10,10 @@ public class ArmorStandMeta extends LivingEntityMeta {
+@@ -10,10 +10,12 @@ public class ArmorStandMeta extends LivingEntityMeta {
      public static final byte OFFSET = LivingEntityMeta.MAX_OFFSET;
      public static final byte MAX_OFFSET = OFFSET + 7;
  
@@ -458,28 +492,30 @@ index 3203cdc0c07ffd9338a798ac26efd64b6eadf28a..292b2c0e20e4eddb11679f529460420b
 -    private final static byte HAS_ARMS_BIT = 0x04;
 -    private final static byte HAS_NO_BASE_PLATE_BIT = 0x08;
 -    private final static byte IS_MARKER_BIT = 0x10;
++    //Microtus start - update java keyword usage
 +    private static final byte IS_SMALL_BIT = 0x01;
 +    private static final byte HAS_ARMS_BIT = 0x04;
 +    private static final byte HAS_NO_BASE_PLATE_BIT = 0x08;
 +    private static final byte IS_MARKER_BIT = 0x10;
++    //Microtus end - update java keyword usage
  
      public ArmorStandMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
          super(entity, metadata);
 diff --git a/src/main/java/net/minestom/server/entity/metadata/other/EnderDragonMeta.java b/src/main/java/net/minestom/server/entity/metadata/other/EnderDragonMeta.java
-index 7a9e49231bfe9b8f576e46f56ba22897a5e9a433..383fd9a0af6de3397097566eb8a1486f7b8ce658 100644
+index 7a9e49231bfe9b8f576e46f56ba22897a5e9a433..8e6603ef87d58e556f2f1ce508b77b8b75215c3e 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/other/EnderDragonMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/other/EnderDragonMeta.java
-@@ -35,7 +35,7 @@ public class EnderDragonMeta extends MobMeta {
+@@ -35,7 +35,6 @@ public class EnderDragonMeta extends MobMeta {
          FLYING_TO_THE_PORTAL_TO_DIE,
          HOVERING_WITHOUT_AI;
  
 -        private final static Phase[] VALUES = values();
-+        private static final Phase[] VALUES = values();
++        private static final Phase[] VALUES = values();  //Microtus - update java keyword usage
      }
- 
+-
  }
 diff --git a/src/main/java/net/minestom/server/entity/metadata/water/AxolotlMeta.java b/src/main/java/net/minestom/server/entity/metadata/water/AxolotlMeta.java
-index f162eb7de22edc949b17a89fcff4477bf1c3c0cf..af421c0aa1fddc76155af9ee92a7823f9967c7de 100644
+index f162eb7de22edc949b17a89fcff4477bf1c3c0cf..83539dd8658c79a7734b4fdbd917d08fda2c8feb 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/water/AxolotlMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/water/AxolotlMeta.java
 @@ -44,6 +44,6 @@ public class AxolotlMeta extends AnimalMeta {
@@ -487,16 +523,18 @@ index f162eb7de22edc949b17a89fcff4477bf1c3c0cf..af421c0aa1fddc76155af9ee92a7823f
          BLUE;
  
 -        private final static AxolotlMeta.Variant[] VALUES = values();
-+        private static final AxolotlMeta.Variant[] VALUES = values();
++        private static final AxolotlMeta.Variant[] VALUES = values();  //Microtus - update java keyword usage
      }
  }
 diff --git a/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java b/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
-index 1239990db6444176ad3fd83365e1ad010d367890..a68e8b3b2b4c5ac4608c84fa8865a5c2ffab50b7 100644
+index 1239990db6444176ad3fd83365e1ad010d367890..ec416c6c80e07ad8b89c97b180e5942f2b2f4ba6 100644
 --- a/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
 +++ b/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
-@@ -59,12 +59,12 @@ public final class DiscoveredExtension {
+@@ -58,13 +58,15 @@ public final class DiscoveredExtension {
+     /** The load status of this extension -- LOAD_SUCCESS is the only good one. */
      transient LoadStatus loadStatus = LoadStatus.LOAD_SUCCESS;
  
++    //Microtus start - update java keyword usage
      /** The original jar this is from. */
 -    transient private File originalJar;
 +    private transient File originalJar;
@@ -507,27 +545,31 @@ index 1239990db6444176ad3fd83365e1ad010d367890..a68e8b3b2b4c5ac4608c84fa8865a5c2
      /** The class loader that powers it. */
 -    transient private ExtensionClassLoader classLoader;
 +    private transient ExtensionClassLoader classLoader;
++    //Microtus end - update java keyword usage
  
      @NotNull
      public String getName() {
 diff --git a/src/main/java/net/minestom/server/extensions/ExtensionManager.java b/src/main/java/net/minestom/server/extensions/ExtensionManager.java
-index d664544c89eda8f4d4051dceeb7d8ee002ad33ac..667ed1f44fc8e2abf28fca492e87cb9b3292aa51 100644
+index d664544c89eda8f4d4051dceeb7d8ee002ad33ac..5d33898b0d7d1666fa6cc93fec0fbfe6014427df 100644
 --- a/src/main/java/net/minestom/server/extensions/ExtensionManager.java
 +++ b/src/main/java/net/minestom/server/extensions/ExtensionManager.java
-@@ -24,12 +24,10 @@ import java.util.zip.ZipFile;
+@@ -23,13 +23,12 @@ import java.util.zip.ZipEntry;
+ import java.util.zip.ZipFile;
  
  public class ExtensionManager {
- 
+-
 -    public final static Logger LOGGER = LoggerFactory.getLogger(ExtensionManager.class);
 -
 -    public final static String INDEV_CLASSES_FOLDER = "minestom.extension.indevfolder.classes";
 -    public final static String INDEV_RESOURCES_FOLDER = "minestom.extension.indevfolder.resources";
 -    private final static Gson GSON = new Gson();
 -
++    //Microtus start - update java keyword usage
 +    public static final Logger LOGGER = LoggerFactory.getLogger(ExtensionManager.class);
 +    public static final String INDEV_CLASSES_FOLDER = "minestom.extension.indevfolder.classes";
 +    public static final String INDEV_RESOURCES_FOLDER = "minestom.extension.indevfolder.resources";
 +    private static final Gson GSON = new Gson();
++    //Microtus end - update java keyword usage
      private final ServerProcess serverProcess;
  
      // LinkedHashMaps are HashMaps that preserve order
@@ -544,7 +586,7 @@ index 82884558daa9497aa4eafd429e053c43867667df..cb3f1333df0b6ef53c1cf0f7563c811b
  import org.jetbrains.annotations.Nullable;
  
 diff --git a/src/main/java/net/minestom/server/instance/Explosion.java b/src/main/java/net/minestom/server/instance/Explosion.java
-index 186be7a1da3202d2c25422e723b153baf3acf3f9..cf13e4a2851fb31c2cb76ba253f33de16a124ba6 100644
+index 186be7a1da3202d2c25422e723b153baf3acf3f9..c96f8c45a0becc4b1c89358bc5a70658b2061914 100644
 --- a/src/main/java/net/minestom/server/instance/Explosion.java
 +++ b/src/main/java/net/minestom/server/instance/Explosion.java
 @@ -19,7 +19,7 @@ public abstract class Explosion {
@@ -552,12 +594,12 @@ index 186be7a1da3202d2c25422e723b153baf3acf3f9..cf13e4a2851fb31c2cb76ba253f33de1
      private final float strength;
  
 -    public Explosion(float centerX, float centerY, float centerZ, float strength) {
-+    protected Explosion(float centerX, float centerY, float centerZ, float strength) {
++    protected Explosion(float centerX, float centerY, float centerZ, float strength) {  //Microtus - update java keyword usage
          this.centerX = centerX;
          this.centerY = centerY;
          this.centerZ = centerZ;
 diff --git a/src/main/java/net/minestom/server/instance/block/BlockManager.java b/src/main/java/net/minestom/server/instance/block/BlockManager.java
-index fd0243002b94167e1ba18c2c13a9705149933754..46d1baf7c462d98be25f18170c63b5edeebdea59 100644
+index fd0243002b94167e1ba18c2c13a9705149933754..d19f1c5043208e841be40d1b4cffdcbe13a79dd5 100644
 --- a/src/main/java/net/minestom/server/instance/block/BlockManager.java
 +++ b/src/main/java/net/minestom/server/instance/block/BlockManager.java
 @@ -17,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap;
@@ -565,36 +607,41 @@ index fd0243002b94167e1ba18c2c13a9705149933754..46d1baf7c462d98be25f18170c63b5ed
  
  public final class BlockManager {
 -    private final static Logger LOGGER = LoggerFactory.getLogger(BlockManager.class);
-+    private static final Logger LOGGER = LoggerFactory.getLogger(BlockManager.class);
++    private static final Logger LOGGER = LoggerFactory.getLogger(BlockManager.class);  //Microtus - update java keyword usage
      // Namespace -> handler supplier
      private final Map<String, Supplier<BlockHandler>> blockHandlerMap = new ConcurrentHashMap<>();
      // block id -> block placement rule
 diff --git a/src/main/java/net/minestom/server/instance/block/rule/BlockPlacementRule.java b/src/main/java/net/minestom/server/instance/block/rule/BlockPlacementRule.java
-index cb354931affb1364983728eb0946124fd390277c..c72d346c22dfa342e7700788c7ac5fb7ebbe5bda 100644
+index cb354931affb1364983728eb0946124fd390277c..e33450545966402c40a935962e2c7d0bb1ee5e98 100644
 --- a/src/main/java/net/minestom/server/instance/block/rule/BlockPlacementRule.java
 +++ b/src/main/java/net/minestom/server/instance/block/rule/BlockPlacementRule.java
-@@ -11,7 +11,7 @@ import org.jetbrains.annotations.Nullable;
+@@ -11,9 +11,9 @@ import org.jetbrains.annotations.Nullable;
  public abstract class BlockPlacementRule {
      private final Block block;
  
 -    public BlockPlacementRule(@NotNull Block block) {
 +    BlockPlacementRule(@NotNull Block block) {
          this.block = block;
-     }
+-    }
++    }  //Microtus - update java keyword usage
  
+     /**
+      * Called when the block state id can be updated (for instance if a neighbour block changed).
 diff --git a/src/main/java/net/minestom/server/inventory/AbstractInventory.java b/src/main/java/net/minestom/server/inventory/AbstractInventory.java
-index 99cfc2fb0d8d7c6da959a93dfe21ce28405956a7..21d13deaf3b4aa93725579394a82ddc3e1483e23 100644
+index 99cfc2fb0d8d7c6da959a93dfe21ce28405956a7..1d239416120bebb1bc30b5901289616aa9f56fbd 100644
 --- a/src/main/java/net/minestom/server/inventory/AbstractInventory.java
 +++ b/src/main/java/net/minestom/server/inventory/AbstractInventory.java
-@@ -23,7 +23,7 @@ import java.util.function.UnaryOperator;
+@@ -23,8 +23,8 @@ import java.util.function.UnaryOperator;
  /**
   * Represents an inventory where items can be modified/retrieved.
   */
 -public sealed abstract class AbstractInventory implements InventoryClickHandler, Taggable
+-        permits Inventory, PlayerInventory {
 +public abstract sealed class AbstractInventory implements InventoryClickHandler, Taggable
-         permits Inventory, PlayerInventory {
++        permits Inventory, PlayerInventory {  //Microtus - update java keyword usage
  
      private static final VarHandle ITEM_UPDATER = MethodHandles.arrayElementVarHandle(ItemStack[].class);
+ 
 diff --git a/src/main/java/net/minestom/server/listener/AdvancementTabListener.java b/src/main/java/net/minestom/server/listener/AdvancementTabListener.java
 index 3a8edbd121b8da1ee970ecdc106955d76508f514..a27c3f10dbd60190260e66012242f1c09b6c16d5 100644
 --- a/src/main/java/net/minestom/server/listener/AdvancementTabListener.java
@@ -622,7 +669,7 @@ index 42e249c73869e7c819a177f3144869c10bbe820a..11186e9470d129fefed2fb5f47dc736d
          final Player.Hand hand = packet.hand();
          final ItemStack itemStack = player.getItemInHand(hand);
 diff --git a/src/main/java/net/minestom/server/monitoring/BenchmarkManager.java b/src/main/java/net/minestom/server/monitoring/BenchmarkManager.java
-index 84c502629a38bc45f60dbf650eaf1b094d1d0df0..09970b507b49f85185b693ad8efe19e50491038c 100644
+index 84c502629a38bc45f60dbf650eaf1b094d1d0df0..50053284b349355092b9cc3f431ea08eb005751f 100644
 --- a/src/main/java/net/minestom/server/monitoring/BenchmarkManager.java
 +++ b/src/main/java/net/minestom/server/monitoring/BenchmarkManager.java
 @@ -34,7 +34,7 @@ import static net.minestom.server.MinecraftServer.THREAD_NAME_TICK_SCHEDULER;
@@ -630,12 +677,12 @@ index 84c502629a38bc45f60dbf650eaf1b094d1d0df0..09970b507b49f85185b693ad8efe19e5
   */
  public final class BenchmarkManager {
 -    private final static Logger LOGGER = LoggerFactory.getLogger(BenchmarkManager.class);
-+    private static final Logger LOGGER = LoggerFactory.getLogger(BenchmarkManager.class);
++    private static final Logger LOGGER = LoggerFactory.getLogger(BenchmarkManager.class);  //Microtus - update java keyword usage
      private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
      private static final List<String> THREADS = new ArrayList<>();
  
 diff --git a/src/main/java/net/minestom/server/thread/Acquirable.java b/src/main/java/net/minestom/server/thread/Acquirable.java
-index 4730006416bd9c4a7f1ff291feddb83c9ffedd6d..48336a9e3f5190431dd4e4b392fc83cf668b69d7 100644
+index 4730006416bd9c4a7f1ff291feddb83c9ffedd6d..00764c03932ecef0e5ac7f68762e4d1270573ed6 100644
 --- a/src/main/java/net/minestom/server/thread/Acquirable.java
 +++ b/src/main/java/net/minestom/server/thread/Acquirable.java
 @@ -26,8 +26,8 @@ public sealed interface Acquirable<T> permits AcquirableImpl {
@@ -644,8 +691,8 @@ index 4730006416bd9c4a7f1ff291feddb83c9ffedd6d..48336a9e3f5190431dd4e4b392fc83cf
                      .flatMap(partitionEntry -> partitionEntry.elements().stream())
 -                    .filter(tickable -> tickable instanceof Entity)
 -                    .map(tickable -> (Entity) tickable);
-+                    .filter(Entity.class::isInstance)
-+                    .map(Entity.class::cast);
++                    .filter(Entity.class::isInstance)  //Microtus - update java keyword usage
++                    .map(Entity.class::cast);  //Microtus - update java keyword usage
          }
          return Stream.empty();
      }

--- a/minestom-patches/0015-Update-java-keyword-usage.patch
+++ b/minestom-patches/0015-Update-java-keyword-usage.patch
@@ -1,0 +1,7560 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Joltras <MinnyMouseXD@gmail.com>
+Date: Tue, 5 Dec 2023 13:06:18 +0100
+Subject: [PATCH] Update java keyword usage
+
+
+diff --git a/src/test/java/net/minestom/server/InsideTest.java b/src/test/java/net/minestom/server/InsideTest.java
+index 4fd8bc46ba32abc852398872bf8b63a30617408e..33c65cc23c0982d2e37eb12e40d844562bf85380 100644
+--- a/src/test/java/net/minestom/server/InsideTest.java
++++ b/src/test/java/net/minestom/server/InsideTest.java
+@@ -5,9 +5,9 @@ import org.junit.jupiter.api.Test;
+ 
+ import static org.junit.jupiter.api.Assertions.assertTrue;
+ 
+-public class InsideTest {
++class InsideTest {
+     @Test
+-    public void inside() {
++    void inside() {
+         assertTrue(DebugUtils.INSIDE_TEST);
+     }
+ }
+diff --git a/src/test/java/net/minestom/server/ServerProcessTest.java b/src/test/java/net/minestom/server/ServerProcessTest.java
+index 96d1264f5efefc33cf125747b591a94dc0f5da57..c0c90d3e6fa722ca5e79d71955965b3f42fea33b 100644
+--- a/src/test/java/net/minestom/server/ServerProcessTest.java
++++ b/src/test/java/net/minestom/server/ServerProcessTest.java
+@@ -8,10 +8,10 @@ import java.util.concurrent.atomic.AtomicReference;
+ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+ import static org.junit.jupiter.api.Assertions.assertThrows;
+ 
+-public class ServerProcessTest {
++class ServerProcessTest {
+ 
+     @Test
+-    public void init() {
++    void init() {
+         AtomicReference<ServerProcess> process = new AtomicReference<>();
+         assertDoesNotThrow(() -> process.set(MinecraftServer.updateProcess()));
+         assertDoesNotThrow(() -> process.get().start(new InetSocketAddress("localhost", 25565)));
+@@ -20,7 +20,7 @@ public class ServerProcessTest {
+     }
+ 
+     @Test
+-    public void tick() {
++    void tick() {
+         var process = MinecraftServer.updateProcess();
+         process.start(new InetSocketAddress("localhost", 25565));
+         var ticker = process.ticker();
+diff --git a/src/test/java/net/minestom/server/advancements/AdvancementIntegrationTest.java b/src/test/java/net/minestom/server/advancements/AdvancementIntegrationTest.java
+index d74d97e8b826dbca100f31d830bba83b91ced040..2d317516f9e63cd732019b22b39d7c76d5861ec8 100644
+--- a/src/test/java/net/minestom/server/advancements/AdvancementIntegrationTest.java
++++ b/src/test/java/net/minestom/server/advancements/AdvancementIntegrationTest.java
+@@ -10,10 +10,10 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+ @EnvTest
+-public class AdvancementIntegrationTest {
++class AdvancementIntegrationTest {
+ 
+     @Test
+-    public void addAndRemoveViewer(Env env) {
++    void addAndRemoveViewer(Env env) {
+         var instance = env.createFlatInstance();
+         var player = env.createPlayer(instance, new Pos(0, 42, 0));
+ 
+@@ -46,7 +46,7 @@ public class AdvancementIntegrationTest {
+     }
+ 
+     @Test
+-    public void removeViewerOnDisconnect(Env env) {
++    void removeViewerOnDisconnect(Env env) {
+         var instance = env.createFlatInstance();
+         var player = env.createPlayer(instance, new Pos(0, 42, 0));
+ 
+diff --git a/src/test/java/net/minestom/server/adventure/provider/TranslationTest.java b/src/test/java/net/minestom/server/adventure/provider/TranslationTest.java
+index 6754317b80025d68e92e526ba8a4eab9fefbfe6a..fa2ea6380affb15c5e5e4cb94ccb478277a16a50 100644
+--- a/src/test/java/net/minestom/server/adventure/provider/TranslationTest.java
++++ b/src/test/java/net/minestom/server/adventure/provider/TranslationTest.java
+@@ -4,10 +4,10 @@ import net.kyori.adventure.text.Component;
+ import net.minestom.server.adventure.MinestomAdventure;
+ import org.junit.jupiter.api.Test;
+ 
+-public class TranslationTest {
++class TranslationTest {
+ 
+     @Test
+-    public void testUnregisteredTranslation() {
++    void testUnregisteredTranslation() {
+         MinestomAdventure.AUTOMATIC_COMPONENT_TRANSLATION = true;
+         try {
+             MinestomFlattenerProvider.INSTANCE.flatten(Component.translatable("key.unregistered"), text -> {
+diff --git a/src/test/java/net/minestom/server/collision/EntityBlockPhysicsIntegrationTest.java b/src/test/java/net/minestom/server/collision/EntityBlockPhysicsIntegrationTest.java
+index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a3b690598 100644
+--- a/src/test/java/net/minestom/server/collision/EntityBlockPhysicsIntegrationTest.java
++++ b/src/test/java/net/minestom/server/collision/EntityBlockPhysicsIntegrationTest.java
+@@ -17,7 +17,7 @@ import java.util.Map;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+ @EnvTest
+-public class EntityBlockPhysicsIntegrationTest {
++class EntityBlockPhysicsIntegrationTest {
+     private static final Point PRECISION = new Pos(0.01, 0.01, 0.01);
+ 
+     private static boolean checkPoints(Point expected, Point actual) {
+@@ -45,7 +45,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckCollision(Env env) {
++    void entityPhysicsCheckCollision(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(0, 43, 1, Block.STONE);
+ 
+@@ -58,7 +58,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckSlab(Env env) {
++    void entityPhysicsCheckSlab(Env env) {
+         var instance = env.createFlatInstance();
+ 
+         for (int i = -2; i <= 2; ++i)
+@@ -76,7 +76,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckShallowAngle(Env env) {
++    void entityPhysicsCheckShallowAngle(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(13, 99, 16, Block.STONE);
+ 
+@@ -91,7 +91,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckFallFence(Env env) {
++    void entityPhysicsCheckFallFence(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(0, 42, 0, Block.OAK_FENCE);
+ 
+@@ -104,7 +104,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckFallHitCarpet(Env env) {
++    void entityPhysicsCheckFallHitCarpet(Env env) {
+         var instance = env.createFlatInstance();
+ 
+         for (int i = -2; i <= 2; ++i)
+@@ -123,7 +123,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckFallHitFence(Env env) {
++    void entityPhysicsCheckFallHitFence(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(0, 42, 0, Block.OAK_FENCE);
+         instance.setBlock(0, 43, 0, Block.BROWN_CARPET);
+@@ -137,7 +137,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckHorizontalFence(Env env) {
++    void entityPhysicsCheckHorizontalFence(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(1, 42, 0, Block.OAK_FENCE);
+ 
+@@ -150,7 +150,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckMultipleBlocksPassFirst(Env env) {
++    void entityPhysicsCheckMultipleBlocksPassFirst(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(4, 40, -1, Block.SANDSTONE_STAIRS);
+         instance.setBlock(16, 40, 0, Block.STONE);
+@@ -164,7 +164,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckMultipleBlocksHitFirst(Env env) {
++    void entityPhysicsCheckMultipleBlocksHitFirst(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(4, 40, 0, Block.GRASS_BLOCK);
+         instance.setBlock(16, 40, 0, Block.STONE);
+@@ -181,7 +181,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckHorizontalCarpetedFence(Env env) {
++    void entityPhysicsCheckHorizontalCarpetedFence(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(1, 42, 0, Block.OAK_FENCE);
+         instance.setBlock(1, 43, 0, Block.BROWN_CARPET);
+@@ -195,7 +195,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckDiagonalCarpetedFenceX(Env env) {
++    void entityPhysicsCheckDiagonalCarpetedFenceX(Env env) {
+         var instance = env.createFlatInstance();
+ 
+         for (int i = -2; i <= 2; ++i)
+@@ -214,7 +214,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckDiagonalCarpetedFenceZ(Env env) {
++    void entityPhysicsCheckDiagonalCarpetedFenceZ(Env env) {
+         var instance = env.createFlatInstance();
+ 
+         for (int i = -2; i <= 2; ++i)
+@@ -233,7 +233,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckDiagonalCarpetedFenceXZ(Env env) {
++    void entityPhysicsCheckDiagonalCarpetedFenceXZ(Env env) {
+         var instance = env.createFlatInstance();
+ 
+         for (int i = -2; i <= 2; ++i)
+@@ -264,7 +264,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckFallHitFenceLongMove(Env env) {
++    void entityPhysicsCheckFallHitFenceLongMove(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(0, 42, 0, Block.OAK_FENCE);
+         instance.setBlock(0, 43, 0, Block.BROWN_CARPET);
+@@ -278,7 +278,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckFenceAboveHead(Env env) {
++    void entityPhysicsCheckFenceAboveHead(Env env) {
+         var instance = env.createFlatInstance();
+ 
+         instance.setBlock(0, 45, 0, Block.OAK_FENCE);
+@@ -292,7 +292,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckDiagonal(Env env) {
++    void entityPhysicsCheckDiagonal(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(1, 43, 1, Block.STONE);
+         instance.setBlock(1, 43, 2, Block.STONE);
+@@ -308,7 +308,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckDirectSlide(Env env) {
++    void entityPhysicsCheckDirectSlide(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(1, 43, 1, Block.STONE);
+         instance.setBlock(1, 43, 2, Block.STONE);
+@@ -322,7 +322,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckCorner(Env env) {
++    void entityPhysicsCheckCorner(Env env) {
+         var instance = env.createFlatInstance();
+         for (int i = -2; i <= 2; ++i)
+             for (int j = -2; j <= 2; ++j)
+@@ -341,7 +341,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckEnclosedHit(Env env) {
++    void entityPhysicsCheckEnclosedHit(Env env) {
+         var instance = env.createFlatInstance();
+         for (int i = -2; i <= 2; ++i)
+             for (int j = -2; j <= 2; ++j)
+@@ -363,7 +363,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckEnclosedHitSubBlock(Env env) {
++    void entityPhysicsCheckEnclosedHitSubBlock(Env env) {
+         var instance = env.createFlatInstance();
+         for (int i = -2; i <= 2; ++i)
+             for (int j = -2; j <= 2; ++j)
+@@ -385,7 +385,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckEnclosedMiss(Env env) {
++    void entityPhysicsCheckEnclosedMiss(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(11, 43, 11, Block.STONE);
+ 
+@@ -402,7 +402,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckEntityHit(Env env) {
++    void entityPhysicsCheckEntityHit() {
+         Point z1 = new Pos(0, 0, 0);
+         Point z2 = new Pos(15, 0, 0);
+         Point z3 = new Pos(11, 0, 0);
+@@ -420,7 +420,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckEdgeClip(Env env) {
++    void entityPhysicsCheckEdgeClip(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(1, 43, 1, Block.STONE);
+ 
+@@ -433,7 +433,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckEdgeClipSmall(Env env) {
++    void entityPhysicsCheckEdgeClipSmall(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(1, 42, 1, Block.STONE);
+ 
+@@ -447,7 +447,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckDoorSubBlockNorth(Env env) {
++    void entityPhysicsCheckDoorSubBlockNorth(Env env) {
+         var instance = env.createFlatInstance();
+         Block b = Block.ACACIA_TRAPDOOR.withProperties(Map.of("facing", "north", "open", "true"));
+ 
+@@ -462,7 +462,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckDoorSubBlockSouth(Env env) {
++    void entityPhysicsCheckDoorSubBlockSouth(Env env) {
+         var instance = env.createFlatInstance();
+         Block b = Block.ACACIA_TRAPDOOR.withProperties(Map.of("facing", "south", "open", "true"));
+ 
+@@ -477,7 +477,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckDoorSubBlockWest(Env env) {
++    void entityPhysicsCheckDoorSubBlockWest(Env env) {
+         var instance = env.createFlatInstance();
+         Block b = Block.ACACIA_TRAPDOOR.withProperties(Map.of("facing", "west", "open", "true"));
+ 
+@@ -492,7 +492,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckDoorSubBlockEast(Env env) {
++    void entityPhysicsCheckDoorSubBlockEast(Env env) {
+         var instance = env.createFlatInstance();
+         Block b = Block.ACACIA_TRAPDOOR.withProperties(Map.of("facing", "east", "open", "true"));
+ 
+@@ -507,7 +507,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckDoorSubBlockUp(Env env) {
++    void entityPhysicsCheckDoorSubBlockUp(Env env) {
+         var instance = env.createFlatInstance();
+         Block b = Block.ACACIA_TRAPDOOR.withProperties(Map.of("half", "top"));
+ 
+@@ -522,7 +522,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckDoorSubBlockDown(Env env) {
++    void entityPhysicsCheckDoorSubBlockDown(Env env) {
+         var instance = env.createFlatInstance();
+         Block b = Block.ACACIA_TRAPDOOR;
+ 
+@@ -537,7 +537,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckOnGround(Env env) {
++    void entityPhysicsCheckOnGround(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(0, 40, 0, Block.STONE);
+ 
+@@ -550,7 +550,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckStairTop(Env env) {
++    void entityPhysicsCheckStairTop(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(0, 42, 0, Block.ACACIA_STAIRS);
+ 
+@@ -563,7 +563,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckStairTopSmall(Env env) {
++    void entityPhysicsCheckStairTopSmall(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(0, 42, 0, Block.ACACIA_STAIRS);
+ 
+@@ -576,7 +576,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckNotOnGround(Env env) {
++    void entityPhysicsCheckNotOnGround(Env env) {
+         var instance = env.createFlatInstance();
+ 
+         for (int i = -2; i <= 2; ++i)
+@@ -592,7 +592,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckNotOnGroundHitUp(Env env) {
++    void entityPhysicsCheckNotOnGroundHitUp(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(0, 60, 0, Block.STONE);
+ 
+@@ -605,7 +605,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckSlide(Env env) {
++    void entityPhysicsCheckSlide(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(1, 43, 1, Block.STONE);
+         instance.setBlock(1, 43, 2, Block.STONE);
+@@ -620,7 +620,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsSmallMoveCollide(Env env) {
++    void entityPhysicsSmallMoveCollide(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(1, 43, 0, Block.STONE);
+ 
+@@ -634,7 +634,7 @@ public class EntityBlockPhysicsIntegrationTest {
+ 
+     // Checks C include all checks for crossing one intermediate block (3 block checks)
+     @Test
+-    public void entityPhysicsSmallMoveC0(Env env) {
++    void entityPhysicsSmallMoveC0(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(1, 42, 0, Block.STONE);
+ 
+@@ -649,7 +649,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsSmallMoveC1(Env env) {
++    void entityPhysicsSmallMoveC1(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(0, 42, 1, Block.STONE);
+ 
+@@ -664,7 +664,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsSmallMoveC2(Env env) {
++    void entityPhysicsSmallMoveC2(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(1, 42, 1, Block.STONE);
+ 
+@@ -679,7 +679,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsSmallMoveC3(Env env) {
++    void entityPhysicsSmallMoveC3(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(0, 42, 0, Block.STONE);
+ 
+@@ -694,7 +694,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsSmallMoveC4(Env env) {
++    void entityPhysicsSmallMoveC4(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(0, 42, 1, Block.STONE);
+ 
+@@ -709,7 +709,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsSmallMoveC5(Env env) {
++    void entityPhysicsSmallMoveC5(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(1, 42, 0, Block.STONE);
+ 
+@@ -724,7 +724,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsSmallMoveC6(Env env) {
++    void entityPhysicsSmallMoveC6(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(0, 42, 0, Block.STONE);
+ 
+@@ -739,7 +739,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsSmallMoveC7(Env env) {
++    void entityPhysicsSmallMoveC7(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(1, 42, 1, Block.STONE);
+ 
+@@ -755,7 +755,7 @@ public class EntityBlockPhysicsIntegrationTest {
+ 
+     // Checks CE include checks for crossing two intermediate block (4 block checks)
+     @Test
+-    public void entityPhysicsSmallMoveC0E(Env env) {
++    void entityPhysicsSmallMoveC0E(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(1, 43, 0, Block.STONE);
+ 
+@@ -770,7 +770,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsSmallMoveC1E(Env env) {
++    void entityPhysicsSmallMoveC1E(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(0, 43, 1, Block.STONE);
+ 
+@@ -785,7 +785,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsSmallMoveC2E(Env env) {
++    void entityPhysicsSmallMoveC2E(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(1, 43, 1, Block.STONE);
+ 
+@@ -801,7 +801,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckNoCollision(Env env) {
++    void entityPhysicsCheckNoCollision(Env env) {
+         var instance = env.createFlatInstance();
+ 
+         for (int i = -2; i <= 2; ++i)
+@@ -817,7 +817,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckBlockMiss(Env env) {
++    void entityPhysicsCheckBlockMiss(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(0, 43, 2, Block.STONE);
+         instance.setBlock(2, 43, 0, Block.STONE);
+@@ -831,7 +831,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckBlockDirections(Env env) {
++    void entityPhysicsCheckBlockDirections(Env env) {
+         var instance = env.createFlatInstance();
+ 
+         instance.setBlock(0, 43, 1, Block.STONE);
+@@ -865,7 +865,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckLargeVelocityMiss(Env env) {
++    void entityPhysicsCheckLargeVelocityMiss(Env env) {
+         var instance = env.createFlatInstance();
+         var entity = new Entity(EntityType.ZOMBIE);
+ 
+@@ -880,7 +880,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckLargeVelocityHit(Env env) {
++    void entityPhysicsCheckLargeVelocityHit(Env env) {
+         var instance = env.createFlatInstance();
+         var entity = new Entity(EntityType.ZOMBIE);
+ 
+@@ -897,7 +897,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckNoMove(Env env) {
++    void entityPhysicsCheckNoMove(Env env) {
+         var instance = env.createFlatInstance();
+         var entity = new Entity(EntityType.ZOMBIE);
+ 
+@@ -909,7 +909,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsRepeatedCollision(Env env) {
++    void entityPhysicsRepeatedCollision(Env env) {
+         var instance = env.createFlatInstance();
+         PhysicsResult previousResult = null;
+ 
+@@ -941,7 +941,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckNoMoveCache(Env env) {
++    void entityPhysicsCheckNoMoveCache(Env env) {
+         var instance = env.createFlatInstance();
+         var entity = new Entity(EntityType.ZOMBIE);
+ 
+@@ -955,7 +955,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckNoMoveLargeVelocityHit(Env env) {
++    void entityPhysicsCheckNoMoveLargeVelocityHit(Env env) {
+         var instance = env.createFlatInstance();
+         var entity = new Entity(EntityType.ZOMBIE);
+ 
+@@ -974,7 +974,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckLargeVelocityHitNoMove(Env env) {
++    void entityPhysicsCheckLargeVelocityHitNoMove(Env env) {
+         var instance = env.createFlatInstance();
+         var entity = new Entity(EntityType.ZOMBIE);
+ 
+@@ -993,7 +993,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckDoorSubBlockSouthRepeat(Env env) {
++    void entityPhysicsCheckDoorSubBlockSouthRepeat(Env env) {
+         var instance = env.createFlatInstance();
+         Block b = Block.ACACIA_TRAPDOOR.withProperties(Map.of("facing", "south", "open", "true"));
+ 
+@@ -1011,7 +1011,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckCollisionDownCache(Env env) {
++    void entityPhysicsCheckCollisionDownCache(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(0, 43, 1, Block.STONE);
+ 
+@@ -1031,7 +1031,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckGravityCached(Env env) {
++    void entityPhysicsCheckGravityCached(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(0, 43, 1, Block.STONE);
+ 
+@@ -1062,7 +1062,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityBlockPositionTestSlightlyAbove(Env env) {
++    void entityBlockPositionTestSlightlyAbove(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(0, 42, 0, Block.STONE);
+ 
+@@ -1077,7 +1077,7 @@ public class EntityBlockPhysicsIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityBlockPositionTestFarAbove(Env env) {
++    void entityBlockPositionTestFarAbove(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(0, 42, 0, Block.STONE);
+ 
+diff --git a/src/test/java/net/minestom/server/collision/EntityBlockTouchTickIntegrationTest.java b/src/test/java/net/minestom/server/collision/EntityBlockTouchTickIntegrationTest.java
+index f5fbb8a9b99720d4a5594e683e9fb3729aaaaf89..2160a817501fc61bb6273767012c9e7179e7b25e 100644
+--- a/src/test/java/net/minestom/server/collision/EntityBlockTouchTickIntegrationTest.java
++++ b/src/test/java/net/minestom/server/collision/EntityBlockTouchTickIntegrationTest.java
+@@ -20,9 +20,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertTrue;
+ 
+ @EnvTest
+-public class EntityBlockTouchTickIntegrationTest {
++class EntityBlockTouchTickIntegrationTest {
+     @Test
+-    public void entityPhysicsCheckTouchTick(Env env) {
++    void entityPhysicsCheckTouchTick(Env env) {
+         var instance = env.createFlatInstance();
+ 
+         Set<Point> positions = new HashSet<>();
+@@ -60,7 +60,7 @@ public class EntityBlockTouchTickIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckTouchTickFarZ(Env env) {
++    void entityPhysicsCheckTouchTickFarZ(Env env) {
+         var instance = env.createFlatInstance();
+         instance.loadChunk(new Pos(1000, 1000, 1000));
+ 
+@@ -100,7 +100,7 @@ public class EntityBlockTouchTickIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckTouchTickFarX(Env env) {
++    void entityPhysicsCheckTouchTickFarX(Env env) {
+         var instance = env.createFlatInstance();
+         instance.loadChunk(new Pos(1000, 1000, 1000));
+ 
+@@ -148,7 +148,7 @@ public class EntityBlockTouchTickIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckTouchTickFarNegative(Env env) {
++    void entityPhysicsCheckTouchTickFarNegative(Env env) {
+         var instance = env.createFlatInstance();
+         instance.loadChunk(new Pos(-1000, 44, -1000));
+ 
+diff --git a/src/test/java/net/minestom/server/collision/EntityProjectileCollisionIntegrationTest.java b/src/test/java/net/minestom/server/collision/EntityProjectileCollisionIntegrationTest.java
+index ee893bba4cc28ae29138eec0900dd89962d9fbfc..658ad566b1925008c5b2bf0ed26ea930f3dd899c 100644
+--- a/src/test/java/net/minestom/server/collision/EntityProjectileCollisionIntegrationTest.java
++++ b/src/test/java/net/minestom/server/collision/EntityProjectileCollisionIntegrationTest.java
+@@ -24,10 +24,10 @@ import java.util.concurrent.atomic.AtomicReference;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+ @EnvTest
+-public class EntityProjectileCollisionIntegrationTest {
++class EntityProjectileCollisionIntegrationTest {
+ 
+     @Test
+-    public void blockShootAndBlockRemoval(Env env) {
++    void blockShootAndBlockRemoval(Env env) {
+         final Instance instance = env.createFlatInstance();
+         instance.getWorldBorder().setDiameter(1000.0);
+ 
+@@ -71,7 +71,7 @@ public class EntityProjectileCollisionIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityShoot(Env env) {
++    void entityShoot(Env env) {
+         final Instance instance = env.createFlatInstance();
+         instance.getWorldBorder().setDiameter(1000.0);
+ 
+@@ -119,7 +119,7 @@ public class EntityProjectileCollisionIntegrationTest {
+     }
+ 
+     @Test
+-    public void entitySelfShoot(Env env) {
++    void entitySelfShoot(Env env) {
+         final Instance instance = env.createFlatInstance();
+         instance.getWorldBorder().setDiameter(1000.0);
+ 
+diff --git a/src/test/java/net/minestom/server/collision/PlacementCollisionIntegrationTest.java b/src/test/java/net/minestom/server/collision/PlacementCollisionIntegrationTest.java
+index 27a2f36c19fd8c2dce75f1bd1ff514dadd027b8a..f3e90e530f4b3487e50d83634b3e0351f5388437 100644
+--- a/src/test/java/net/minestom/server/collision/PlacementCollisionIntegrationTest.java
++++ b/src/test/java/net/minestom/server/collision/PlacementCollisionIntegrationTest.java
+@@ -12,30 +12,30 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+ @EnvTest
+-public class PlacementCollisionIntegrationTest {
++class PlacementCollisionIntegrationTest {
+ 
+     @Test
+-    public void empty(Env env) {
++    void empty(Env env) {
+         var instance = env.createFlatInstance();
+         assertNull(BlockCollision.canPlaceBlockAt(instance, new Vec(0, 40, 0), Block.STONE));
+     }
+ 
+     @Test
+-    public void entityBlock(Env env) {
++    void entityBlock(Env env) {
+         var instance = env.createFlatInstance();
+         new Entity(EntityType.ZOMBIE).setInstance(instance, new Pos(0, 40, 0)).join();
+         assertNotNull(BlockCollision.canPlaceBlockAt(instance, new Vec(0, 40, 0), Block.STONE));
+     }
+ 
+     @Test
+-    public void slab(Env env) {
++    void slab(Env env) {
+         var instance = env.createFlatInstance();
+         new Entity(EntityType.ZOMBIE).setInstance(instance, new Pos(0, 40.75, 0)).join();
+         assertNull(BlockCollision.canPlaceBlockAt(instance, new Vec(0, 40, 0), Block.STONE_SLAB));
+     }
+ 
+     @Test
+-    public void belowPlayer(Env env) {
++    void belowPlayer(Env env) {
+         var instance = env.createFlatInstance();
+         env.createPlayer(instance, new Pos(5.7, -8, 6.389));
+         assertNull(BlockCollision.canPlaceBlockAt(instance, new Vec(5, -9, 6), Block.STONE));
+diff --git a/src/test/java/net/minestom/server/command/ArgumentParserTest.java b/src/test/java/net/minestom/server/command/ArgumentParserTest.java
+index 232d55948303a74d35724c2d601ace10a8d98811..844f846afe976a4667a2743957d19b155a7d7a3f 100644
+--- a/src/test/java/net/minestom/server/command/ArgumentParserTest.java
++++ b/src/test/java/net/minestom/server/command/ArgumentParserTest.java
+@@ -11,10 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+ /**
+  * Test string version of arguments.
+  */
+-public class ArgumentParserTest {
++class ArgumentParserTest {
+ 
+     @Test
+-    public void testArgumentParser() {
++    void testArgumentParser() {
+         // Test each argument
+         assertParserEquals("Literal<example>", ArgumentType.Literal("example"));
+         assertParserEquals("Boolean<example>", ArgumentType.Boolean("example"));
+diff --git a/src/test/java/net/minestom/server/command/ArgumentTest.java b/src/test/java/net/minestom/server/command/ArgumentTest.java
+index 6aa58875c186549b658ef5a5277dc4fbd378df80..0c438d1230824e25352af1a53534a3b0e97234b3 100644
+--- a/src/test/java/net/minestom/server/command/ArgumentTest.java
++++ b/src/test/java/net/minestom/server/command/ArgumentTest.java
+@@ -11,16 +11,16 @@ import java.util.List;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class ArgumentTest {
++class ArgumentTest {
+ 
+     @Test
+-    public void testParseSelf() {
++    void testParseSelf() {
+         assertEquals("example", Argument.parse(ArgumentType.String("example")));
+         assertEquals(55, Argument.parse(ArgumentType.Integer("55")));
+     }
+ 
+     @Test
+-    public void testCallback() {
++    void testCallback() {
+         var arg = ArgumentType.String("id");
+ 
+         assertFalse(arg.hasErrorCallback());
+@@ -30,7 +30,7 @@ public class ArgumentTest {
+     }
+ 
+     @Test
+-    public void testDefaultValue() {
++    void testDefaultValue() {
+         var arg = ArgumentType.String("id");
+ 
+         assertFalse(arg.isOptional());
+@@ -40,7 +40,7 @@ public class ArgumentTest {
+     }
+ 
+     @Test
+-    public void testSuggestionCallback() {
++    void testSuggestionCallback() {
+         var arg = ArgumentType.String("id");
+ 
+         assertFalse(arg.hasSuggestion());
+diff --git a/src/test/java/net/minestom/server/command/ArgumentTypeTest.java b/src/test/java/net/minestom/server/command/ArgumentTypeTest.java
+index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec96243cbb963 100644
+--- a/src/test/java/net/minestom/server/command/ArgumentTypeTest.java
++++ b/src/test/java/net/minestom/server/command/ArgumentTypeTest.java
+@@ -16,7 +16,6 @@ import net.minestom.server.item.Enchantment;
+ import net.minestom.server.item.ItemStack;
+ import net.minestom.server.item.Material;
+ import net.minestom.server.particle.Particle;
+-import net.minestom.server.potion.PotionEffect;
+ import net.minestom.server.tag.Tag;
+ import net.minestom.server.utils.location.RelativeVec;
+ import net.minestom.server.utils.math.FloatRange;
+@@ -31,10 +30,10 @@ import java.util.UUID;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class ArgumentTypeTest {
++class ArgumentTypeTest {
+ 
+     @Test
+-    public void testArgumentEnchantment() {
++    void testArgumentEnchantment() {
+         var arg = ArgumentType.Enchantment("enchantment");
+         assertInvalidArg(arg, "minecraft:invalid_enchantment");
+         assertArg(arg, Enchantment.SWEEPING, Enchantment.SWEEPING.name());
+@@ -42,7 +41,7 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentEntityType() {
++    void testArgumentEntityType() {
+         var arg = ArgumentType.EntityType("entity_type");
+         assertInvalidArg(arg, "minecraft:invalid_entity_type");
+         assertArg(arg, EntityType.ARMOR_STAND, EntityType.ARMOR_STAND.name());
+@@ -50,7 +49,7 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentParticle() {
++    void testArgumentParticle() {
+         var arg = ArgumentType.Particle("particle");
+         assertInvalidArg(arg, "minecraft:invalid_particle");
+         assertArg(arg, Particle.BLOCK, Particle.BLOCK.name());
+@@ -58,7 +57,7 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentBlockState() {
++    void testArgumentBlockState() {
+         var arg = ArgumentType.BlockState("block_state");
+         assertInvalidArg(arg, "minecraft:invalid_block[invalid_property=invalid_key]");
+         assertInvalidArg(arg, "minecraft:stone[invalid_property=invalid_key]");
+@@ -69,7 +68,7 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentColor() {
++    void testArgumentColor() {
+         var arg = ArgumentType.Color("color");
+         assertInvalidArg(arg, "invalid_color");
+         assertArg(arg, Style.style(NamedTextColor.DARK_PURPLE), "dark_purple");
+@@ -77,7 +76,7 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentComponent() {
++    void testArgumentComponent() {
+         var arg = ArgumentType.Component("component");
+         var component1 = Component.text("Example text", NamedTextColor.DARK_AQUA);
+         var component2 = Component.text("Other example text", Style.style(TextDecoration.OBFUSCATED));
+@@ -90,7 +89,7 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentEntity() {
++    void testArgumentEntity() {
+         var arg = ArgumentType.Entity("entity");
+ 
+         assertValidArg(arg, "@a");
+@@ -127,7 +126,7 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentFloatRange() {
++    void testArgumentFloatRange() {
+         var arg = ArgumentType.FloatRange("float_range");
+         assertArg(arg, new FloatRange(0f, 50f), "0..50");
+         assertArg(arg, new FloatRange(0f, 0f), "0..0");
+@@ -142,7 +141,7 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentIntRange() {
++    void testArgumentIntRange() {
+         var arg = ArgumentType.IntRange("int_range");
+ 
+         assertArg(arg, new IntRange(0, 50), "0..50");
+@@ -161,14 +160,14 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentItemStack() {
++    void testArgumentItemStack() {
+         var arg = ArgumentType.ItemStack("item_stack");
+         assertArg(arg, ItemStack.AIR, "air");
+         assertArg(arg, ItemStack.of(Material.GLASS_PANE).withTag(Tag.String("tag"), "value"), "glass_pane{tag:value}");
+     }
+ 
+     @Test
+-    public void testArgumentNbtCompoundTag() {
++    void testArgumentNbtCompoundTag() {
+         var arg = ArgumentType.NbtCompound("nbt_compound");
+         assertArg(arg, NBT.Compound(mut -> mut.put("long_array", NBT.LongArray(12, 49, 119))), "{\"long_array\":[L;12L,49L,119L]}");
+         assertArg(arg, NBT.Compound(mut -> mut.put("nested", NBT.Compound(mut2 ->
+@@ -183,7 +182,7 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentNbtTag() {
++    void testArgumentNbtTag() {
+         var arg = ArgumentType.NBT("nbt");
+         assertArg(arg, NBT.String("string"), "string");
+         assertArg(arg, NBT.String("string"), "\"string\"");
+@@ -198,14 +197,14 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentResource() {
++    void testArgumentResource() {
+         var arg = ArgumentType.Resource("resource", "minecraft:block");
+         assertArg(arg, "minecraft:resource_example", "minecraft:resource_example");
+         assertInvalidArg(arg, "minecraft:invalid resource");
+     }
+ 
+     @Test
+-    public void testArgumentResourceLocation() {
++    void testArgumentResourceLocation() {
+         var arg = ArgumentType.ResourceLocation("resource_location");
+         assertArg(arg, "minecraft:resource_location_example", "minecraft:resource_location_example");
+         assertInvalidArg(arg, "minecraft:invalid resource location");
+@@ -213,14 +212,14 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentResourceOrTag() {
++    void testArgumentResourceOrTag() {
+         var arg = ArgumentType.ResourceOrTag("resource_or_tag", "data/minecraft/tags/blocks");
+         assertArg(arg, "minecraft:resource_or_tag_example", "minecraft:resource_or_tag_example");
+         assertInvalidArg(arg, "minecraft:invalid resource or tag");
+     }
+ 
+     @Test
+-    public void testArgumentTime() {
++    void testArgumentTime() {
+         var arg = ArgumentType.Time("time");
+         assertArg(arg, Duration.of(20, TimeUnit.SERVER_TICK), "20");
+         assertArg(arg, Duration.of(40, TimeUnit.SERVER_TICK), "40t");
+@@ -232,14 +231,14 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentUUID() {
++    void testArgumentUUID() {
+         var arg = ArgumentType.UUID("uuid");
+         assertInvalidArg(arg, "invalid_uuid");
+         assertArg(arg, UUID.fromString("10515090-26f2-49fa-b2ba-9594d4d0451f"), "10515090-26f2-49fa-b2ba-9594d4d0451f");
+     }
+ 
+     @Test
+-    public void testArgumentDouble() {
++    void testArgumentDouble() {
+         var arg = ArgumentType.Double("double");
+         assertArg(arg, 2564d, "2564");
+         assertArg(arg, -591.981d, "-591.981");
+@@ -248,7 +247,7 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentFloat() {
++    void testArgumentFloat() {
+         var arg = ArgumentType.Float("float");
+         assertArg(arg, 2564f, "2564");
+         assertArg(arg, -591.981f, "-591.981");
+@@ -257,7 +256,7 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentInteger() {
++    void testArgumentInteger() {
+         var arg = ArgumentType.Integer("integer");
+         assertArg(arg, 2564, "2564");
+         assertInvalidArg(arg, "256.4");
+@@ -265,15 +264,15 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentLong() {
++    void testArgumentLong() {
+         var arg = ArgumentType.Long("long");
+-        assertArg(arg, 2564l, "2564");
++        assertArg(arg, 2564L, "2564");
+         assertInvalidArg(arg, "256.4");
+         assertInvalidArg(arg, "9223372036854775808");
+     }
+ 
+     @Test
+-    public void testArgumentRelativeBlockPosition() {
++    void testArgumentRelativeBlockPosition() {
+         var arg = ArgumentType.RelativeBlockPosition("relative_block_position");
+         var vec = new Vec(-3, 14, 255);
+ 
+@@ -297,7 +296,7 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentRelativeVec2() {
++    void testArgumentRelativeVec2() {
+         var arg = ArgumentType.RelativeVec2("relative_vec_2");
+         var vec = new Vec(-3, 14.25);
+ 
+@@ -318,7 +317,7 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentRelativeVec3() {
++    void testArgumentRelativeVec3() {
+         var arg = ArgumentType.RelativeVec3("relative_vec_3");
+         var vec = new Vec(-3, 14.25, 255);
+ 
+@@ -339,7 +338,7 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentBoolean() {
++    void testArgumentBoolean() {
+         var arg = ArgumentType.Boolean("boolean");
+         assertArg(arg, true, "true");
+         assertArg(arg, false, "false");
+@@ -347,7 +346,7 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentEnum() {
++    void testArgumentEnum() {
+         enum ExampleEnum {FIRST, SECOND, Third, fourth}
+ 
+         var arg = ArgumentType.Enum("enum", ExampleEnum.class);
+@@ -375,7 +374,7 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentGroup() {
++    void testArgumentGroup() {
+         var arg = ArgumentType.Group("group", ArgumentType.Integer("integer"), ArgumentType.String("string"), ArgumentType.Double("double"));
+ 
+         // Test normal input
+@@ -401,7 +400,7 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentLiteral() {
++    void testArgumentLiteral() {
+         var arg = ArgumentType.Literal("literal");
+         assertArg(arg, "literal", "literal");
+         assertInvalidArg(arg, "not_literal");
+@@ -409,7 +408,7 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentLoop() {
++    void testArgumentLoop() {
+         var arg = ArgumentType.Loop("loop", ArgumentType.String("string"), ArgumentType.String("string2").map(s -> {
+             throw new IllegalArgumentException("This argument should never be triggered");
+         }));
+@@ -419,7 +418,7 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentString() {
++    void testArgumentString() {
+         var arg = ArgumentType.String("string");
+         assertArg(arg, "text", "text");
+         assertArg(arg, "more text", "\"more text\"");
+@@ -429,7 +428,7 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentStringArray() {
++    void testArgumentStringArray() {
+         var arg = ArgumentType.StringArray("string_array");
+         assertArrayArg(arg, new String[]{"example", "text"}, "example text");
+         assertArrayArg(arg, new String[]{"some", "more", "placeholder", "text"}, "some more placeholder text");
+@@ -439,7 +438,7 @@ public class ArgumentTypeTest {
+     }
+ 
+     @Test
+-    public void testArgumentWord() {
++    void testArgumentWord() {
+         var arg = ArgumentType.Word("word").from("word1", "word2", "word3");
+ 
+         assertArg(arg, "word1", "word1");
+diff --git a/src/test/java/net/minestom/server/command/CommandConditionTest.java b/src/test/java/net/minestom/server/command/CommandConditionTest.java
+index f7450b020c91807984e83b004774c916621d152f..362761f1da55b0a50e79959add8cb2f4cbd4dd5f 100644
+--- a/src/test/java/net/minestom/server/command/CommandConditionTest.java
++++ b/src/test/java/net/minestom/server/command/CommandConditionTest.java
+@@ -13,10 +13,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class CommandConditionTest {
++class CommandConditionTest {
+ 
+     @Test
+-    public void mainCondition() {
++    void mainCondition() {
+         var dispatcher = new CommandDispatcher();
+         assertNull(dispatcher.findCommand("name"));
+         var sender = new Sender();
+diff --git a/src/test/java/net/minestom/server/command/CommandManagerTest.java b/src/test/java/net/minestom/server/command/CommandManagerTest.java
+index 0c69902dc9870ed8de36f90955c184f1cfc2b952..8e9cd85c205e12b8d85ddb3d3f01847cb0fdf115 100644
+--- a/src/test/java/net/minestom/server/command/CommandManagerTest.java
++++ b/src/test/java/net/minestom/server/command/CommandManagerTest.java
+@@ -8,10 +8,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class CommandManagerTest {
++class CommandManagerTest {
+ 
+     @Test
+-    public void testCommandRegistration() {
++    void testCommandRegistration() {
+         var manager = new CommandManager();
+ 
+         var command = new Command("name1", "name2");
+@@ -30,7 +30,7 @@ public class CommandManagerTest {
+     }
+ 
+     @Test
+-    public void testUnknownCommandCallback() {
++    void testUnknownCommandCallback() {
+         var manager = new CommandManager();
+ 
+         AtomicBoolean check = new AtomicBoolean(false);
+diff --git a/src/test/java/net/minestom/server/command/CommandPacketFilteringTest.java b/src/test/java/net/minestom/server/command/CommandPacketFilteringTest.java
+index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..f1723d9525bbb6f7af06fe948efde4edeffc17aa 100644
+--- a/src/test/java/net/minestom/server/command/CommandPacketFilteringTest.java
++++ b/src/test/java/net/minestom/server/command/CommandPacketFilteringTest.java
+@@ -10,18 +10,18 @@ import java.util.Set;
+ import java.util.UUID;
+ 
+ @SuppressWarnings("ConstantConditions")
+-public class CommandPacketFilteringTest {
++class CommandPacketFilteringTest {
+     private static final Player PLAYER = new Player(UUID.randomUUID(), "", null);
+ 
+     @Test
+-    public void singleCommandFilteredFalse() {
++    void singleCommandFilteredFalse() {
+         final Command foo = new Command("foo");
+         foo.setCondition(((sender, commandString) -> false));
+         assertFiltering(foo, "");
+     }
+ 
+     @Test
+-    public void singleCommandFilteredTrue() {
++    void singleCommandFilteredTrue() {
+         final Command foo = new Command("foo");
+         foo.setCondition(((sender, commandString) -> true));
+         assertFiltering(foo, """
+@@ -31,7 +31,7 @@ public class CommandPacketFilteringTest {
+     }
+ 
+     @Test
+-    public void singleCommandUnfiltered() {
++    void singleCommandUnfiltered() {
+         final Command foo = new Command("foo");
+         assertFiltering(foo, """
+                 foo=%
+@@ -40,7 +40,7 @@ public class CommandPacketFilteringTest {
+     }
+ 
+     @Test
+-    public void singleCommandFilteredTrueWithFilteredSubcommandTrueWithFilteredSyntaxFalse() {
++    void singleCommandFilteredTrueWithFilteredSubcommandTrueWithFilteredSyntaxFalse() {
+         final Command foo = new Command("foo");
+         foo.setCondition((sender, commandString) -> true);
+         final Command bar = new Command("bar");
+@@ -55,7 +55,7 @@ public class CommandPacketFilteringTest {
+     }
+ 
+     @Test
+-    public void singleCommandFilteredTrueWithFilteredSubcommandFalse() {
++    void singleCommandFilteredTrueWithFilteredSubcommandFalse() {
+         final Command foo = new Command("foo");
+         foo.setCondition((sender, commandString) -> true);
+         final Command bar = new Command("bar");
+@@ -68,7 +68,7 @@ public class CommandPacketFilteringTest {
+     }
+ 
+     @Test
+-    public void singleCommandFilteredTrueWithFilteredSubcommandTrue() {
++    void singleCommandFilteredTrueWithFilteredSubcommandTrue() {
+         final Command foo = new Command("foo");
+         foo.setCondition((sender, commandString) -> true);
+         final Command bar = new Command("bar");
+@@ -82,7 +82,7 @@ public class CommandPacketFilteringTest {
+     }
+ 
+     @Test
+-    public void singleCommandFilteredTrueWithFilteredSubcommandTrueWithFilteredSyntaxBoth() {
++    void singleCommandFilteredTrueWithFilteredSubcommandTrueWithFilteredSyntaxBoth() {
+         final Command foo = new Command("foo");
+         foo.setCondition((sender, commandString) -> true);
+         final Command bar = new Command("bar");
+@@ -99,7 +99,7 @@ public class CommandPacketFilteringTest {
+     }
+ 
+     @Test
+-    public void singleCommandConditionalArgGroupTrue() {
++    void singleCommandConditionalArgGroupTrue() {
+         final Command foo = new Command("foo");
+         foo.addConditionalSyntax((sender, commandString) -> true, null, ArgumentType.Group("test", ArgumentType.Literal("bar")));
+         assertFiltering(foo, """
+@@ -110,7 +110,7 @@ public class CommandPacketFilteringTest {
+     }
+ 
+     @Test
+-    public void singleCommandConditionalArgGroupFalse() {
++    void singleCommandConditionalArgGroupFalse() {
+         final Command foo = new Command("foo");
+         foo.addConditionalSyntax((sender, commandString) -> false, null, ArgumentType.Group("test", ArgumentType.Literal("foo")));
+         assertFiltering(foo, """
+@@ -120,7 +120,7 @@ public class CommandPacketFilteringTest {
+     }
+ 
+     @Test
+-    public void singleCommandUnconditionalArgGroup() {
++    void singleCommandUnconditionalArgGroup() {
+         final Command foo = new Command("foo");
+         foo.addSyntax(null, ArgumentType.Group("test", ArgumentType.Literal("bar")));
+         assertFiltering(foo, """
+@@ -131,7 +131,7 @@ public class CommandPacketFilteringTest {
+     }
+ 
+     @Test
+-    public void singleCommandConditionalArgGroupTrue2() {
++    void singleCommandConditionalArgGroupTrue2() {
+         final Command foo = new Command("foo");
+         foo.addConditionalSyntax((sender, commandString) -> true, null, ArgumentType.Group("test", ArgumentType.Literal("bar"), ArgumentType.Literal("baz")));
+         assertFiltering(foo, """
+@@ -143,7 +143,7 @@ public class CommandPacketFilteringTest {
+     }
+ 
+     @Test
+-    public void singleCommandConditionalArgGroupFalse2() {
++    void singleCommandConditionalArgGroupFalse2() {
+         final Command foo = new Command("foo");
+         foo.addConditionalSyntax((sender, commandString) -> false, null, ArgumentType.Group("test", ArgumentType.Literal("foo"), ArgumentType.Literal("baz")));
+         assertFiltering(foo, """
+@@ -153,7 +153,7 @@ public class CommandPacketFilteringTest {
+     }
+ 
+     @Test
+-    public void singleCommandUnconditionalArgGroup2() {
++    void singleCommandUnconditionalArgGroup2() {
+         final Command foo = new Command("foo");
+         foo.addSyntax(null, ArgumentType.Group("test", ArgumentType.Literal("bar"), ArgumentType.Literal("baz")));
+         assertFiltering(foo, """
+@@ -165,7 +165,7 @@ public class CommandPacketFilteringTest {
+     }
+ 
+     @Test
+-    public void singleCommandUnconditionalArgLoop() {
++    void singleCommandUnconditionalArgLoop() {
+         final Command foo = new Command("foo");
+         foo.addSyntax(null, ArgumentType.Loop("test", ArgumentType.Literal("bar"), ArgumentType.Literal("baz")));
+         assertFiltering(foo, """
+@@ -177,7 +177,7 @@ public class CommandPacketFilteringTest {
+     }
+ 
+     @Test
+-    public void singleCommandConditionalArgLoopTrue() {
++    void singleCommandConditionalArgLoopTrue() {
+         final Command foo = new Command("foo");
+         foo.addConditionalSyntax((sender, commandString) -> true, null, ArgumentType.Loop("test", ArgumentType.Literal("bar"), ArgumentType.Literal("baz")));
+         assertFiltering(foo, """
+@@ -189,7 +189,7 @@ public class CommandPacketFilteringTest {
+     }
+ 
+     @Test
+-    public void singleCommandConditionalArgLoopFalse() {
++    void singleCommandConditionalArgLoopFalse() {
+         final Command foo = new Command("foo");
+         foo.addConditionalSyntax((sender, commandString) -> false, null, ArgumentType.Loop("test", ArgumentType.Literal("bar"), ArgumentType.Literal("baz")));
+         assertFiltering(foo, """
+diff --git a/src/test/java/net/minestom/server/command/CommandPacketTest.java b/src/test/java/net/minestom/server/command/CommandPacketTest.java
+index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..2b51669947330396da684b251e20e096138e1b36 100644
+--- a/src/test/java/net/minestom/server/command/CommandPacketTest.java
++++ b/src/test/java/net/minestom/server/command/CommandPacketTest.java
+@@ -9,9 +9,9 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertNotNull;
+ 
+-public class CommandPacketTest {
++class CommandPacketTest {
+     @Test
+-    public void singleCommandWithOneSyntax() {
++    void singleCommandWithOneSyntax() {
+         final Command foo = new Command("foo");
+         foo.addSyntax(CommandPacketTest::dummyExecutor, ArgumentType.Integer("bar"));
+ 
+@@ -34,7 +34,7 @@ public class CommandPacketTest {
+     }
+ 
+     @Test
+-    public void executeLike() {
++    void executeLike() {
+         enum Dimension {OVERWORLD, THE_NETHER, THE_END}
+         final Command execute = new Command("execute");
+         execute.addSyntax(CommandPacketTest::dummyExecutor, ArgumentType.Loop("params",
+@@ -62,7 +62,7 @@ public class CommandPacketTest {
+     }
+ 
+     @Test
+-    public void singleCommandTwoEnum() {
++    void singleCommandTwoEnum() {
+         var graph = Graph.builder(ArgumentType.Literal("foo"))
+                 .append(ArgumentType.Enum("bar", A.class), b -> b.append(ArgumentType.Enum("baz", B.class)))
+                 .build();
+@@ -76,7 +76,7 @@ public class CommandPacketTest {
+     }
+ 
+     @Test
+-    public void singleCommandRestrictedWord() {
++    void singleCommandRestrictedWord() {
+         var graph = Graph.builder(ArgumentType.Literal("foo"))
+                 .append(ArgumentType.Word("bar").from("A", "B", "C"))
+                 .build();
+@@ -89,7 +89,7 @@ public class CommandPacketTest {
+     }
+ 
+     @Test
+-    public void singleCommandWord() {
++    void singleCommandWord() {
+         var graph = Graph.builder(ArgumentType.Literal("foo"))
+                 .append(ArgumentType.Word("bar"))
+                 .build();
+@@ -102,7 +102,7 @@ public class CommandPacketTest {
+     }
+ 
+     @Test
+-    public void singleCommandCommandAfterEnum() {
++    void singleCommandCommandAfterEnum() {
+         var graph = Graph.builder(ArgumentType.Literal("foo"))
+                 .append(ArgumentType.Enum("bar", A.class), b -> b.append(ArgumentType.Command("baz")))
+                 .build();
+@@ -117,7 +117,7 @@ public class CommandPacketTest {
+     }
+ 
+     @Test
+-    public void twoCommandIntEnumInt() {
++    void twoCommandIntEnumInt() {
+         var graph = Graph.builder(ArgumentType.Literal("foo"))
+                 .append(ArgumentType.Integer("int1"), b -> b.append(ArgumentType.Enum("test", A.class), c -> c.append(ArgumentType.Integer("int2"))))
+                 .build();
+@@ -139,7 +139,7 @@ public class CommandPacketTest {
+     }
+ 
+     @Test
+-    public void singleCommandTwoGroupOfIntInt() {
++    void singleCommandTwoGroupOfIntInt() {
+         var graph = Graph.builder(ArgumentType.Literal("foo"))
+                 .append(ArgumentType.Group("1", ArgumentType.Integer("int1"), ArgumentType.Integer("int2")),
+                         b -> b.append(ArgumentType.Group("2", ArgumentType.Integer("int3"), ArgumentType.Integer("int4"))))
+@@ -155,7 +155,7 @@ public class CommandPacketTest {
+                 """, graph);
+     }
+     @Test
+-    public void twoEnumAndOneLiteralChild() {
++    void twoEnumAndOneLiteralChild() {
+         var graph = Graph.builder(ArgumentType.Literal("foo"))
+                 .append(ArgumentType.Enum("a", A.class))
+                 .append(ArgumentType.Literal("l"))
+@@ -170,7 +170,7 @@ public class CommandPacketTest {
+     }
+ 
+     @Test
+-    public void commandAliasWithoutArg() {
++    void commandAliasWithoutArg() {
+         var graph = Graph.builder(ArgumentType.Word("foo").from("foo", "bar"))
+                 .build();
+         assertPacketGraph("""
+@@ -180,7 +180,7 @@ public class CommandPacketTest {
+     }
+ 
+     @Test
+-    public void commandAliasWithArg() {
++    void commandAliasWithArg() {
+         var graph = Graph.builder(ArgumentType.Word("foo").from("foo", "bar"))
+                 .append(ArgumentType.Literal("l"))
+                 .build();
+@@ -192,7 +192,7 @@ public class CommandPacketTest {
+     }
+ 
+     @Test
+-    public void cmdArgShortcut() {
++    void cmdArgShortcut() {
+         var foo = Graph.builder(ArgumentType.Literal("foo"))
+                 .append(ArgumentType.String("msg"))
+                 .build();
+@@ -210,7 +210,7 @@ public class CommandPacketTest {
+     }
+ 
+     @Test
+-    public void cmdArgShortcutWithPartialArg() {
++    void cmdArgShortcutWithPartialArg() {
+         var foo = Graph.builder(ArgumentType.Literal("foo"))
+                 .append(ArgumentType.String("msg"))
+                 .build();
+diff --git a/src/test/java/net/minestom/server/command/CommandParseTest.java b/src/test/java/net/minestom/server/command/CommandParseTest.java
+index d2751fcfd67ca910f59f33e5dcf4bcd9a23f429a..0c5062a628f072d0dc1608d0df533404e79d92cc 100644
+--- a/src/test/java/net/minestom/server/command/CommandParseTest.java
++++ b/src/test/java/net/minestom/server/command/CommandParseTest.java
+@@ -11,16 +11,16 @@ import static net.minestom.server.command.builder.arguments.ArgumentType.Literal
+ import static net.minestom.server.command.builder.arguments.ArgumentType.Word;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class CommandParseTest {
++class CommandParseTest {
+ 
+     @Test
+-    public void emptyCommand() {
++    void emptyCommand() {
+         var graph = Graph.merge(Graph.builder(Literal("foo"), createExecutor(new AtomicBoolean())).build());
+         assertUnknown(graph, "");
+     }
+ 
+     @Test
+-    public void singleParameterlessCommand() {
++    void singleParameterlessCommand() {
+         final AtomicBoolean b = new AtomicBoolean();
+         var foo = Graph.merge(Graph.builder(Literal("foo"), createExecutor(b)).build());
+         assertValid(foo, "foo", b);
+@@ -29,7 +29,7 @@ public class CommandParseTest {
+     }
+ 
+     @Test
+-    public void twoParameterlessCommand() {
++    void twoParameterlessCommand() {
+         final AtomicBoolean b = new AtomicBoolean();
+         final AtomicBoolean b1 = new AtomicBoolean();
+         var graph = Graph.merge(
+@@ -44,7 +44,7 @@ public class CommandParseTest {
+     }
+ 
+     @Test
+-    public void singleCommandWithMultipleSyntax() {
++    void singleCommandWithMultipleSyntax() {
+         final AtomicBoolean add = new AtomicBoolean();
+         final AtomicBoolean action = new AtomicBoolean();
+         var foo = Graph.merge(Graph.builder(Literal("foo"))
+@@ -69,7 +69,7 @@ public class CommandParseTest {
+     }
+ 
+     @Test
+-    public void singleCommandOptionalArgs() {
++    void singleCommandOptionalArgs() {
+         final AtomicBoolean b = new AtomicBoolean();
+         final AtomicReference<String> expectedFirstArg = new AtomicReference<>("T");
+         var foo = Graph.merge(Graph.builder(Literal("foo"))
+@@ -92,7 +92,7 @@ public class CommandParseTest {
+     }
+ 
+     @Test
+-    public void singleCommandSingleEnumArg() {
++    void singleCommandSingleEnumArg() {
+         enum A {a, b}
+         final AtomicBoolean b = new AtomicBoolean();
+         var foo = Graph.merge(Graph.builder(Literal("foo"))
+@@ -105,7 +105,7 @@ public class CommandParseTest {
+     }
+ 
+     @Test
+-    public void aliasWithoutArgs() {
++    void aliasWithoutArgs() {
+         final AtomicBoolean b = new AtomicBoolean();
+         var foo = Graph.merge(Graph.builder(Word("").from("foo", "bar"), createExecutor(b))
+                 .build());
+@@ -115,7 +115,7 @@ public class CommandParseTest {
+     }
+ 
+     @Test
+-    public void aliasWithArgs() {
++    void aliasWithArgs() {
+         final AtomicBoolean b = new AtomicBoolean();
+         var foo = Graph.merge(Graph.builder(Word("").from("foo", "bar"))
+                 .append(ArgumentType.Integer("test"), createExecutor(b))
+diff --git a/src/test/java/net/minestom/server/command/CommandSenderTest.java b/src/test/java/net/minestom/server/command/CommandSenderTest.java
+index fe2b5186f3b90d46b465c0ca7fb319020f0b0286..a4ff2e54c1650dae3831c07072c0f54b803c5f20 100644
+--- a/src/test/java/net/minestom/server/command/CommandSenderTest.java
++++ b/src/test/java/net/minestom/server/command/CommandSenderTest.java
+@@ -16,10 +16,10 @@ import java.util.Set;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class CommandSenderTest {
++class CommandSenderTest {
+ 
+     @Test
+-    public void testSenderPermissions() {
++    void testSenderPermissions() {
+ 
+         CommandSender sender = new SenderTest();
+ 
+@@ -36,7 +36,7 @@ public class CommandSenderTest {
+     }
+ 
+     @Test
+-    public void testMessageSending() {
++    void testMessageSending() {
+         SenderTest sender = new SenderTest();
+ 
+         assertNull(sender.getMostRecentMessage());
+diff --git a/src/test/java/net/minestom/server/command/CommandSuggestionIntegrationTest.java b/src/test/java/net/minestom/server/command/CommandSuggestionIntegrationTest.java
+index fff2a33d02b9ed1cfe2e320fb1c758e0839da047..c54b9ba92b8576f625a421df8a8073474aec8bea 100644
+--- a/src/test/java/net/minestom/server/command/CommandSuggestionIntegrationTest.java
++++ b/src/test/java/net/minestom/server/command/CommandSuggestionIntegrationTest.java
+@@ -18,10 +18,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertNull;
+ 
+ @EnvTest
+-public class CommandSuggestionIntegrationTest {
++class CommandSuggestionIntegrationTest {
+ 
+     @Test
+-    public void suggestion(Env env) {
++    void suggestion(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var player = connection.connect(instance, new Pos(0, 42, 0)).join();
+@@ -52,7 +52,7 @@ public class CommandSuggestionIntegrationTest {
+     }
+ 
+     @Test
+-    public void suggestionWithDefaults(Env env) {
++    void suggestionWithDefaults(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var player = connection.connect(instance, new Pos(0, 42, 0)).join();
+@@ -64,20 +64,20 @@ public class CommandSuggestionIntegrationTest {
+ 
+         var command = new Command("foo");
+ 
+-        command.addSyntax((sender,context)->{}, suggestArg, defaultArg);
++        command.addSyntax((sender, context) -> {
++        }, suggestArg, defaultArg);
+         env.process().command().register(command);
+ 
+         var listener = connection.trackIncoming(TabCompletePacket.class);
+         player.addPacketToQueue(new ClientTabCompletePacket(1, "foo 1"));
+         player.interpretPacketQueue();
+ 
+-        listener.assertSingle(tabCompletePacket -> {
+-            assertEquals(List.of(new TabCompletePacket.Match("suggestion", null)), tabCompletePacket.matches());
+-        });
++        listener.assertSingle(tabCompletePacket ->
++                assertEquals(List.of(new TabCompletePacket.Match("suggestion", null)), tabCompletePacket.matches()));
+     }
+ 
+     @Test
+-    public void suggestionWithSubcommand(Env env) {
++    void suggestionWithSubcommand(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var player = connection.connect(instance, new Pos(0, 42, 0)).join();
+@@ -86,16 +86,16 @@ public class CommandSuggestionIntegrationTest {
+ 
+         var subCommand = new Command("bar");
+ 
+-        var wordArg1 = Word("wordArg1").setSuggestionCallback((sender, context, suggestion) -> {
+-            suggestion.addEntry(new SuggestionEntry("suggestionA"));
+-        });
+-        var wordArg2 = Word("wordArg2").setSuggestionCallback((sender, context, suggestion) -> {
+-                    suggestion.addEntry(new SuggestionEntry("suggestionB"));
+-                });
++        var wordArg1 = Word("wordArg1").setSuggestionCallback((sender, context, suggestion) ->
++                suggestion.addEntry(new SuggestionEntry("suggestionA")));
++        var wordArg2 = Word("wordArg2").setSuggestionCallback((sender, context, suggestion) ->
++                suggestion.addEntry(new SuggestionEntry("suggestionB")));
+ 
+-        subCommand.addSyntax((sender, context) -> {}, wordArg1, wordArg2);
++        subCommand.addSyntax((sender, context) -> {
++        }, wordArg1, wordArg2);
+ 
+-        command.addSyntax((sender,context)->{}, Literal("literal"), wordArg2);
++        command.addSyntax((sender, context) -> {
++        }, Literal("literal"), wordArg2);
+ 
+         command.addSubcommand(subCommand);
+ 
+@@ -105,29 +105,28 @@ public class CommandSuggestionIntegrationTest {
+         player.addPacketToQueue(new ClientTabCompletePacket(1, "foo bar "));
+         player.interpretPacketQueue();
+ 
+-        listener.assertSingle(tabCompletePacket -> {
+-            assertEquals(List.of(new TabCompletePacket.Match("suggestionA", null)), tabCompletePacket.matches());
+-        });
++        listener.assertSingle(tabCompletePacket ->
++                assertEquals(List.of(new TabCompletePacket.Match("suggestionA", null)), tabCompletePacket.matches()));
+     }
+ 
+     @Test
+-    public void suggestionWithTwoLiterals(Env env) {
++    void suggestionWithTwoLiterals(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var player = connection.connect(instance, new Pos(0, 42, 0)).join();
+ 
+         var command = new Command("foo");
+ 
+-        var wordArg1 = Word("wordArg1").setSuggestionCallback((sender, context, suggestion) -> {
+-            suggestion.addEntry(new SuggestionEntry("suggestionA"));
+-        });
+-        var wordArg2 = Word("wordArg2").setSuggestionCallback((sender, context, suggestion) -> {
+-            suggestion.addEntry(new SuggestionEntry("suggestionB"));
+-        });
++        var wordArg1 = Word("wordArg1").setSuggestionCallback((sender, context, suggestion) ->
++                suggestion.addEntry(new SuggestionEntry("suggestionA")));
++        var wordArg2 = Word("wordArg2").setSuggestionCallback((sender, context, suggestion) ->
++                suggestion.addEntry(new SuggestionEntry("suggestionB")));
+ 
+-        command.addSyntax((sender,context)->{}, Literal("literal1"), wordArg1);
++        command.addSyntax((sender, context) -> {
++        }, Literal("literal1"), wordArg1);
+ 
+-        command.addSyntax((sender,context)->{}, Literal("literal2"), wordArg2);
++        command.addSyntax((sender, context) -> {
++        }, Literal("literal2"), wordArg2);
+ 
+         env.process().command().register(command);
+ 
+@@ -135,9 +134,8 @@ public class CommandSuggestionIntegrationTest {
+         player.addPacketToQueue(new ClientTabCompletePacket(1, "foo literal2 "));
+         player.interpretPacketQueue();
+ 
+-        listener.assertSingle(tabCompletePacket -> {
+-            assertEquals(List.of(new TabCompletePacket.Match("suggestionB", null)), tabCompletePacket.matches());
+-        });
++        listener.assertSingle(tabCompletePacket ->
++                assertEquals(List.of(new TabCompletePacket.Match("suggestionB", null)), tabCompletePacket.matches()));
+     }
+ 
+ }
+diff --git a/src/test/java/net/minestom/server/command/CommandSyntaxMultiTest.java b/src/test/java/net/minestom/server/command/CommandSyntaxMultiTest.java
+index ca0fec6265f2373a96d63a7b4c402ab35aa0395e..063ad7f76714778b6e459db03e13066bb02bd13c 100644
+--- a/src/test/java/net/minestom/server/command/CommandSyntaxMultiTest.java
++++ b/src/test/java/net/minestom/server/command/CommandSyntaxMultiTest.java
+@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
+ import java.lang.String;
+ import java.util.List;
+ import java.util.Map;
+-import java.util.concurrent.atomic.AtomicBoolean;
+ import java.util.concurrent.atomic.AtomicReference;
+ 
+ import static net.minestom.server.command.builder.arguments.ArgumentType.Float;
+@@ -16,10 +15,10 @@ import static net.minestom.server.command.builder.arguments.ArgumentType.*;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.fail;
+ 
+-public class CommandSyntaxMultiTest {
++class CommandSyntaxMultiTest {
+ 
+     @Test
+-    public void integerFloat() {
++    void integerFloat() {
+         List<List<Argument<?>>> args = List.of(
+                 List.of(Literal("integer"), Integer("number")),
+                 List.of(Literal("float"), Float("number"))
+@@ -29,7 +28,7 @@ public class CommandSyntaxMultiTest {
+     }
+ 
+     @Test
+-    public void argPriority() {
++    void argPriority() {
+         List<List<Argument<?>>> args = List.of(
+                 List.of(Word("word")),
+                 List.of(Literal("literal"))
+@@ -38,7 +37,7 @@ public class CommandSyntaxMultiTest {
+     }
+ 
+     @Test
+-    public void similarArgs() {
++    void similarArgs() {
+         List<List<Argument<?>>> args = List.of(
+                 List.of(Word("a")),
+                 List.of(Word("b"), Word("a"))
+diff --git a/src/test/java/net/minestom/server/command/CommandSyntaxSingleTest.java b/src/test/java/net/minestom/server/command/CommandSyntaxSingleTest.java
+index 42cfa09255a0fb576f5db0edde46233252916f11..1a56d96f878ba6cab7234a7cfbb08f9e11927cf1 100644
+--- a/src/test/java/net/minestom/server/command/CommandSyntaxSingleTest.java
++++ b/src/test/java/net/minestom/server/command/CommandSyntaxSingleTest.java
+@@ -18,9 +18,9 @@ import static net.minestom.server.command.builder.arguments.ArgumentType.*;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.fail;
+ 
+-public class CommandSyntaxSingleTest {
++class CommandSyntaxSingleTest {
+     @Test
+-    public void singleInteger() {
++    void singleInteger() {
+         List<Argument<?>> args = List.of(Integer("number"));
+         assertSyntax(args, "5", ExpectedExecution.SYNTAX, Map.of("number", 5));
+         assertSyntax(args, "5 5", ExpectedExecution.DEFAULT);
+@@ -28,7 +28,7 @@ public class CommandSyntaxSingleTest {
+     }
+ 
+     @Test
+-    public void singleIntegerInteger() {
++    void singleIntegerInteger() {
+         List<Argument<?>> args = List.of(Integer("number"), Integer("number2"));
+         assertSyntax(args, "5", ExpectedExecution.DEFAULT);
+         assertSyntax(args, "5 6", ExpectedExecution.SYNTAX, Map.of("number", 5, "number2", 6));
+@@ -36,7 +36,7 @@ public class CommandSyntaxSingleTest {
+     }
+ 
+     @Test
+-    public void singleString() {
++    void singleString() {
+         List<Argument<?>> args = List.of(String("string"));
+         assertSyntax(args, """
+                 "value"
+@@ -46,7 +46,7 @@ public class CommandSyntaxSingleTest {
+     }
+ 
+     @Test
+-    public void singleStringString() {
++    void singleStringString() {
+         List<Argument<?>> args = List.of(String("string"), String("string2"));
+         assertSyntax(args, "test", ExpectedExecution.DEFAULT);
+         assertSyntax(args, """
+@@ -60,7 +60,7 @@ public class CommandSyntaxSingleTest {
+     }
+ 
+     @Test
+-    public void singleGroup() {
++    void singleGroup() {
+         List<Argument<?>> args = List.of(Group("loop", Integer("first"), Integer("second")));
+         // 1 2
+         {
+@@ -74,7 +74,7 @@ public class CommandSyntaxSingleTest {
+     }
+ 
+     @Test
+-    public void singleLoop() {
++    void singleLoop() {
+         List<Argument<?>> stringLoop = List.of(Loop("loop", String("value")));
+         assertSyntax(stringLoop, "one two three", ExpectedExecution.SYNTAX, Map.of("loop", List.of("one", "two", "three")));
+ 
+@@ -83,7 +83,7 @@ public class CommandSyntaxSingleTest {
+     }
+ 
+     @Test
+-    public void singleLoopGroup() {
++    void singleLoopGroup() {
+         List<Argument<?>> groupLoop = List.of(Loop("loop", Group("group", Integer("first"), Integer("second"))));
+         // 1 2
+         {
+@@ -112,7 +112,7 @@ public class CommandSyntaxSingleTest {
+     }
+ 
+     @Test
+-    public void singleLoopDoubleGroup() {
++    void singleLoopDoubleGroup() {
+         List<Argument<?>> groupLoop = List.of(
+                 Loop("loop",
+                         Group("group", BlockState("block"), Enchantment("enchant")),
+diff --git a/src/test/java/net/minestom/server/command/CommandTest.java b/src/test/java/net/minestom/server/command/CommandTest.java
+index 420530aa47c0de56de27e1aa55d1a29395ae1c5c..d56c151d1d296776b690790573b49690cb34875e 100644
+--- a/src/test/java/net/minestom/server/command/CommandTest.java
++++ b/src/test/java/net/minestom/server/command/CommandTest.java
+@@ -10,10 +10,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class CommandTest {
++class CommandTest {
+ 
+     @Test
+-    public void testNames() {
++    void testNames() {
+         Command command = new Command("name1", "name2", "name3");
+ 
+         assertEquals("name1", command.getName());
+@@ -27,7 +27,7 @@ public class CommandTest {
+     }
+ 
+     @Test
+-    public void testGlobalListener() {
++    void testGlobalListener() {
+         var manager = new CommandManager();
+ 
+         AtomicBoolean hasRun = new AtomicBoolean(false);
+diff --git a/src/test/java/net/minestom/server/command/GraphConversionExecutorTest.java b/src/test/java/net/minestom/server/command/GraphConversionExecutorTest.java
+index 55e5612f3e41096c6904dba1a5002af4ea2a0131..0bb5c4470c0093a8511f6e3c1d2862189eec662e 100644
+--- a/src/test/java/net/minestom/server/command/GraphConversionExecutorTest.java
++++ b/src/test/java/net/minestom/server/command/GraphConversionExecutorTest.java
+@@ -8,9 +8,9 @@ import org.junit.jupiter.api.Test;
+ import static net.minestom.server.command.builder.arguments.ArgumentType.Literal;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class GraphConversionExecutorTest {
++class GraphConversionExecutorTest {
+     @Test
+-    public void defaultCondition() {
++    void defaultCondition() {
+         final Command foo = new Command("foo");
+         // Constant true
+         {
+@@ -31,7 +31,7 @@ public class GraphConversionExecutorTest {
+     }
+ 
+     @Test
+-    public void emptySyntaxCondition() {
++    void emptySyntaxCondition() {
+         final Command foo = new Command("foo");
+         foo.addSyntax(GraphConversionExecutorTest::dummyExecutor, Literal("first"));
+ 
+@@ -44,7 +44,7 @@ public class GraphConversionExecutorTest {
+     }
+ 
+     @Test
+-    public void syntaxConditionTrue() {
++    void syntaxConditionTrue() {
+         final Command foo = new Command("foo");
+         foo.addConditionalSyntax((sender, context) -> true,
+                 GraphConversionExecutorTest::dummyExecutor, Literal("first"));
+@@ -57,7 +57,7 @@ public class GraphConversionExecutorTest {
+     }
+ 
+     @Test
+-    public void syntaxConditionFalse() {
++    void syntaxConditionFalse() {
+         final Command foo = new Command("foo");
+         foo.addConditionalSyntax((sender, context) -> false,
+                 GraphConversionExecutorTest::dummyExecutor, Literal("first"));
+@@ -70,7 +70,7 @@ public class GraphConversionExecutorTest {
+     }
+ 
+     @Test
+-    public void commandConditionFalse() {
++    void commandConditionFalse() {
+         final Command foo = new Command("foo");
+         foo.setCondition((sender, commandString) -> false);
+         final Graph graph = Graph.fromCommand(foo);
+diff --git a/src/test/java/net/minestom/server/command/GraphConversionTest.java b/src/test/java/net/minestom/server/command/GraphConversionTest.java
+index 7c294232ed4e25e457ab95ecfcc757c7b312b184..a429406c4713708ea76b82d576f990c88b8067db 100644
+--- a/src/test/java/net/minestom/server/command/GraphConversionTest.java
++++ b/src/test/java/net/minestom/server/command/GraphConversionTest.java
+@@ -9,16 +9,16 @@ import static net.minestom.server.command.builder.arguments.ArgumentType.Integer
+ import static net.minestom.server.command.builder.arguments.ArgumentType.*;
+ import static org.junit.jupiter.api.Assertions.assertTrue;
+ 
+-public class GraphConversionTest {
++class GraphConversionTest {
+     @Test
+-    public void empty() {
++    void empty() {
+         final Command foo = new Command("foo");
+         var graph = Graph.builder(Literal("foo")).build();
+         assertEqualsGraph(graph, foo);
+     }
+ 
+     @Test
+-    public void singleLiteral() {
++    void singleLiteral() {
+         final Command foo = new Command("foo");
+         var first = Literal("first");
+         foo.addSyntax(GraphConversionTest::dummyExecutor, first);
+@@ -28,7 +28,7 @@ public class GraphConversionTest {
+     }
+ 
+     @Test
+-    public void literalsPath() {
++    void literalsPath() {
+         final Command foo = new Command("foo");
+         var first = Literal("first");
+         var second = Literal("second");
+@@ -43,7 +43,7 @@ public class GraphConversionTest {
+     }
+ 
+     @Test
+-    public void doubleSyntax() {
++    void doubleSyntax() {
+         enum A {A, B, C, D, E}
+         final Command foo = new Command("foo");
+ 
+@@ -64,7 +64,7 @@ public class GraphConversionTest {
+     }
+ 
+     @Test
+-    public void doubleSyntaxMerge() {
++    void doubleSyntaxMerge() {
+         final Command foo = new Command("foo");
+ 
+         var bar = Literal("bar");
+@@ -81,7 +81,7 @@ public class GraphConversionTest {
+     }
+ 
+     @Test
+-    public void subcommand() {
++    void subcommand() {
+         final Command main = new Command("main");
+         final Command sub = new Command("sub");
+ 
+@@ -107,14 +107,14 @@ public class GraphConversionTest {
+     }
+ 
+     @Test
+-    public void alias() {
++    void alias() {
+         final Command main = new Command("main", "alias");
+         var graph = Graph.builder(Word("main").from("main", "alias")).build();
+         assertEqualsGraph(graph, main);
+     }
+ 
+     @Test
+-    public void aliases() {
++    void aliases() {
+         final Command main = new Command("main", "first", "second");
+         var graph = Graph.builder(Word("main").from("main", "first", "second")).build();
+         assertEqualsGraph(graph, main);
+diff --git a/src/test/java/net/minestom/server/command/GraphMergeTest.java b/src/test/java/net/minestom/server/command/GraphMergeTest.java
+index d257c0bd8881037ca13fd805931d94756b268e5b..bed954ced10cc69d96986be1eac7093e7492c395 100644
+--- a/src/test/java/net/minestom/server/command/GraphMergeTest.java
++++ b/src/test/java/net/minestom/server/command/GraphMergeTest.java
+@@ -8,10 +8,10 @@ import java.util.List;
+ import static net.minestom.server.command.builder.arguments.ArgumentType.Literal;
+ import static org.junit.jupiter.api.Assertions.assertTrue;
+ 
+-public class GraphMergeTest {
++class GraphMergeTest {
+ 
+     @Test
+-    public void commands() {
++    void commands() {
+         var foo = new Command("foo");
+         var bar = new Command("bar");
+         var result = Graph.builder(Literal(""))
+@@ -22,7 +22,7 @@ public class GraphMergeTest {
+     }
+ 
+     @Test
+-    public void empty() {
++    void empty() {
+         var graph1 = Graph.builder(Literal("foo")).build();
+         var graph2 = Graph.builder(Literal("bar")).build();
+         var result = Graph.builder(Literal(""))
+@@ -33,7 +33,7 @@ public class GraphMergeTest {
+     }
+ 
+     @Test
+-    public void literals() {
++    void literals() {
+         var graph1 = Graph.builder(Literal("foo")).append(Literal("1")).build();
+         var graph2 = Graph.builder(Literal("bar")).append(Literal("2")).build();
+         var result = Graph.builder(Literal(""))
+diff --git a/src/test/java/net/minestom/server/command/GraphTest.java b/src/test/java/net/minestom/server/command/GraphTest.java
+index 388768e3bb3eace4665eff42ff06270aa47fbdf3..91dff666e2c11c27b09406243c2b783560de3218 100644
+--- a/src/test/java/net/minestom/server/command/GraphTest.java
++++ b/src/test/java/net/minestom/server/command/GraphTest.java
+@@ -9,9 +9,9 @@ import java.util.List;
+ import static net.minestom.server.command.builder.arguments.ArgumentType.Literal;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class GraphTest {
++class GraphTest {
+     @Test
+-    public void empty() {
++    void empty() {
+         var result = Graph.builder(Literal(""))
+                 .build();
+         var node = result.root();
+@@ -20,7 +20,7 @@ public class GraphTest {
+     }
+ 
+     @Test
+-    public void next() {
++    void next() {
+         var result = Graph.builder(Literal(""))
+                 .append(Literal("foo"))
+                 .build();
+@@ -31,7 +31,7 @@ public class GraphTest {
+     }
+ 
+     @Test
+-    public void immutableNextBuilder() {
++    void immutableNextBuilder() {
+         var result = Graph.builder(Literal(""))
+                 .append(Literal("foo"))
+                 .append(Literal("bar"))
+@@ -42,7 +42,7 @@ public class GraphTest {
+     }
+ 
+     @Test
+-    public void immutableNextCommand() {
++    void immutableNextCommand() {
+         final Command foo = new Command("foo");
+         var first = Literal("first");
+         foo.addSyntax(GraphTest::dummyExecutor, first);
+@@ -54,7 +54,7 @@ public class GraphTest {
+     }
+ 
+     @Test
+-    public void immutableNextCommands() {
++    void immutableNextCommands() {
+         final Command foo, bar;
+ 
+         {
+diff --git a/src/test/java/net/minestom/server/command/SubcommandTest.java b/src/test/java/net/minestom/server/command/SubcommandTest.java
+index 6ed762fa232c741dbe0be886245e98d1515f9bd4..88968d428de85c144dafe1ed509edd30d808fa85 100644
+--- a/src/test/java/net/minestom/server/command/SubcommandTest.java
++++ b/src/test/java/net/minestom/server/command/SubcommandTest.java
+@@ -8,10 +8,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
+ import static org.junit.jupiter.api.Assertions.assertFalse;
+ import static org.junit.jupiter.api.Assertions.assertTrue;
+ 
+-public class SubcommandTest {
++class SubcommandTest {
+ 
+     @Test
+-    public void testSubCommands() {
++    void testSubCommands() {
+         var manager = new CommandManager();
+ 
+         var parent = new Command("parent");
+@@ -33,7 +33,7 @@ public class SubcommandTest {
+     }
+ 
+     @Test
+-    public void testSubCommandConditions() {
++    void testSubCommandConditions() {
+         var manager = new CommandManager();
+ 
+         var parent = new Command("parent");
+diff --git a/src/test/java/net/minestom/server/coordinate/CoordinateTest.java b/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
+index 560cf470c2ce9b12faf5af245f13b104a3a27a6e..2ebccae5928b3f66a8e1cb683342b4fc1a3131b1 100644
+--- a/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
++++ b/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
+@@ -11,10 +11,10 @@ import java.util.List;
+ import static net.minestom.server.utils.chunk.ChunkUtils.*;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class CoordinateTest {
++class CoordinateTest {
+ 
+     @Test
+-    public void chunkIndex() {
++    void chunkIndex() {
+         var index = getChunkIndex(2, 5);
+         assertEquals(2, getChunkCoordX(index));
+         assertEquals(5, getChunkCoordZ(index));
+@@ -29,7 +29,7 @@ public class CoordinateTest {
+     }
+ 
+     @Test
+-    public void chunkCoordinate() {
++    void chunkCoordinate() {
+         assertEquals(0, getChunkCoordinate(15));
+         assertEquals(1, getChunkCoordinate(16));
+         assertEquals(-1, getChunkCoordinate(-16));
+@@ -43,7 +43,7 @@ public class CoordinateTest {
+     }
+ 
+     @Test
+-    public void chunkCount() {
++    void chunkCount() {
+         assertEquals(289, getChunkCount(8));
+         assertEquals(169, getChunkCount(6));
+         assertEquals(121, getChunkCount(5));
+@@ -53,7 +53,7 @@ public class CoordinateTest {
+     }
+ 
+     @Test
+-    public void vecAddition() {
++    void vecAddition() {
+         Vec temp = Vec.ZERO;
+         assertEquals(0, temp.x());
+         assertEquals(0, temp.y());
+@@ -81,7 +81,7 @@ public class CoordinateTest {
+     }
+ 
+     @Test
+-    public void vecWith() {
++    void vecWith() {
+         Vec temp = Vec.ZERO.withX(1);
+         assertEquals(1, temp.x());
+         assertEquals(0, temp.y());
+@@ -94,7 +94,7 @@ public class CoordinateTest {
+     }
+ 
+     @Test
+-    public void toSectionRelativeCoordinate() {
++    void toSectionRelativeCoordinate() {
+         assertEquals(8, ChunkUtils.toSectionRelativeCoordinate(-40));
+         assertEquals(12, ChunkUtils.toSectionRelativeCoordinate(-20));
+         assertEquals(0, ChunkUtils.toSectionRelativeCoordinate(0));
+@@ -107,7 +107,7 @@ public class CoordinateTest {
+     }
+ 
+     @Test
+-    public void blockIndex() {
++    void blockIndex() {
+         // Test if the block index is correctly converted back and forth
+ 
+         List<Vec> tempEquals = List.of(
+@@ -151,7 +151,7 @@ public class CoordinateTest {
+     }
+ 
+     @Test
+-    public void blockIndexDuplicate() {
++    void blockIndexDuplicate() {
+         LongSet temp = new LongOpenHashSet();
+ 
+         for (int x = 0; x < Chunk.CHUNK_SIZE_X; x++) {
+diff --git a/src/test/java/net/minestom/server/coordinate/PosViewDirectionTest.java b/src/test/java/net/minestom/server/coordinate/PosViewDirectionTest.java
+index e0ae029f68f7ec614d69836fdc9b84542a5b4bd5..1072819aa016c8ce3d2c47031caa084fc246186f 100644
+--- a/src/test/java/net/minestom/server/coordinate/PosViewDirectionTest.java
++++ b/src/test/java/net/minestom/server/coordinate/PosViewDirectionTest.java
+@@ -4,11 +4,11 @@ import org.junit.jupiter.api.Test;
+ 
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+-public class PosViewDirectionTest {
++class PosViewDirectionTest {
+     private static final float EPSILON = 0.01f;
+ 
+     @Test
+-    public void withLookAtPos() {
++    void withLookAtPos() {
+         Pos initialPosition = new Pos(0, 40, 0);
+         Pos position;
+ 
+diff --git a/src/test/java/net/minestom/server/entity/EntityBoundingBoxIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityBoundingBoxIntegrationTest.java
+index dc20cd87d838a6b186180d94d7037c276fc9169c..01bbdd9065aa8e5966eaad3d788b13025455e738 100644
+--- a/src/test/java/net/minestom/server/entity/EntityBoundingBoxIntegrationTest.java
++++ b/src/test/java/net/minestom/server/entity/EntityBoundingBoxIntegrationTest.java
+@@ -13,9 +13,9 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+ @EnvTest
+-public class EntityBoundingBoxIntegrationTest {
++class EntityBoundingBoxIntegrationTest {
+     @Test
+-    public void pose(Env env) {
++    void pose(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var player = connection.connect(instance, new Pos(0, 42, 0)).join();
+@@ -36,7 +36,7 @@ public class EntityBoundingBoxIntegrationTest {
+     }
+ 
+     @Test
+-    public void eyeHeight(Env env) {
++    void eyeHeight(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var player = connection.connect(instance, new Pos(0, 42, 0)).join();
+@@ -54,7 +54,7 @@ public class EntityBoundingBoxIntegrationTest {
+     }
+ 
+     @Test
+-    public void pickupItem(Env env) {
++    void pickupItem(Env env) {
+         final var instance = env.createFlatInstance();
+         final var listener = env.listen(PickupItemEvent.class);
+         final var spawnPos = new Pos(0, 42, 0);
+diff --git a/src/test/java/net/minestom/server/entity/EntityInstanceIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityInstanceIntegrationTest.java
+index 5a9d128ef0d73a1726d6af1ed73ff1fee36a82a7..ba578f774f6787183606206ef9a435bbd147e6b3 100644
+--- a/src/test/java/net/minestom/server/entity/EntityInstanceIntegrationTest.java
++++ b/src/test/java/net/minestom/server/entity/EntityInstanceIntegrationTest.java
+@@ -11,10 +11,10 @@ import java.time.Duration;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+ @EnvTest
+-public class EntityInstanceIntegrationTest {
++class EntityInstanceIntegrationTest {
+ 
+     @Test
+-    public void entityJoin(Env env) {
++    void entityJoin(Env env) {
+         var instance = env.createFlatInstance();
+         var entity = new Entity(EntityTypes.ZOMBIE);
+         entity.setInstance(instance, new Pos(0, 42, 0)).join();
+@@ -23,7 +23,7 @@ public class EntityInstanceIntegrationTest {
+     }
+ 
+     @Test
+-    public void playerJoin(Env env) {
++    void playerJoin(Env env) {
+         var instance = env.createFlatInstance();
+         var player = env.createPlayer(instance, new Pos(0, 42, 0));
+         assertEquals(instance, player.getInstance());
+@@ -31,7 +31,7 @@ public class EntityInstanceIntegrationTest {
+     }
+ 
+     @Test
+-    public void playerSwitch(Env env) {
++    void playerSwitch(Env env) {
+         var instance = env.createFlatInstance();
+         var instance2 = env.createFlatInstance();
+         var connection = env.createConnection();
+diff --git a/src/test/java/net/minestom/server/entity/EntityLineOfSightIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityLineOfSightIntegrationTest.java
+index a6bb809294a39af40ab9d89a86299d37c5e15e00..eb4c8083d2517206c90a0c598e20fce700740f1b 100644
+--- a/src/test/java/net/minestom/server/entity/EntityLineOfSightIntegrationTest.java
++++ b/src/test/java/net/minestom/server/entity/EntityLineOfSightIntegrationTest.java
+@@ -9,9 +9,9 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+ @EnvTest
+-public class EntityLineOfSightIntegrationTest {
++class EntityLineOfSightIntegrationTest {
+     @Test
+-    public void entityPhysicsCheckLineOfSight(Env env) {
++    void entityPhysicsCheckLineOfSight(Env env) {
+         var instance = env.createFlatInstance();
+ 
+         var entity = new Entity(EntityTypes.ZOMBIE);
+@@ -35,7 +35,7 @@ public class EntityLineOfSightIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckLineOfSightBehind(Env env) {
++    void entityPhysicsCheckLineOfSightBehind(Env env) {
+         var instance = env.createFlatInstance();
+ 
+         var entity = new Entity(EntityTypes.ZOMBIE);
+@@ -59,7 +59,7 @@ public class EntityLineOfSightIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckLineOfSightNearMiss(Env env) {
++    void entityPhysicsCheckLineOfSightNearMiss(Env env) {
+         var instance = env.createFlatInstance();
+ 
+         var entity = new Entity(EntityTypes.ZOMBIE);
+@@ -83,7 +83,7 @@ public class EntityLineOfSightIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckLineOfSightNearHit(Env env) {
++    void entityPhysicsCheckLineOfSightNearHit(Env env) {
+         var instance = env.createFlatInstance();
+ 
+         var entity = new Entity(EntityTypes.ZOMBIE);
+@@ -109,7 +109,7 @@ public class EntityLineOfSightIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckLineOfSightCorrectOrder(Env env) {
++    void entityPhysicsCheckLineOfSightCorrectOrder(Env env) {
+         var instance = env.createFlatInstance();
+ 
+         var entity = new Entity(EntityTypes.ZOMBIE);
+@@ -130,7 +130,7 @@ public class EntityLineOfSightIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityPhysicsCheckLineOfSightBigMiss(Env env) {
++    void entityPhysicsCheckLineOfSightBigMiss(Env env) {
+         var instance = env.createFlatInstance();
+ 
+         var entity = new Entity(EntityTypes.ZOMBIE);
+@@ -145,7 +145,7 @@ public class EntityLineOfSightIntegrationTest {
+         assertTrue(entity.hasLineOfSight(entity2, false));
+     }
+     @Test
+-    public void entityPhysicsCheckLineOfSightLargeBoundingBox(Env env) {
++    void entityPhysicsCheckLineOfSightLargeBoundingBox(Env env) {
+         var instance = env.createFlatInstance();
+ 
+         var entity = new Entity(EntityTypes.ZOMBIE);
+diff --git a/src/test/java/net/minestom/server/entity/EntityMetaIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityMetaIntegrationTest.java
+index d4bc0029ea907166ea1e42cccc801828ad2829c9..570f9d13fd3795dbd8646d0803b422efa02004cf 100644
+--- a/src/test/java/net/minestom/server/entity/EntityMetaIntegrationTest.java
++++ b/src/test/java/net/minestom/server/entity/EntityMetaIntegrationTest.java
+@@ -14,10 +14,10 @@ import java.util.function.Consumer;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+ @EnvTest
+-public class EntityMetaIntegrationTest {
++class EntityMetaIntegrationTest {
+ 
+     @Test
+-    public void notifyAboutChanges(Env env) {
++    void notifyAboutChanges(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var otherPlayer = connection.connect(instance, new Pos(0, 42, 0)).join();
+@@ -79,7 +79,7 @@ public class EntityMetaIntegrationTest {
+     }
+ 
+     @Test
+-    public void customName(Env env) {
++    void customName(Env env) {
+         //Base things.
+         var connection = env.createConnection();
+         var instance = env.createFlatInstance();
+diff --git a/src/test/java/net/minestom/server/entity/EntityMetaTest.java b/src/test/java/net/minestom/server/entity/EntityMetaTest.java
+index fec36086a4cc442ab5b41fa38139011d803d8a60..3e14287168e35f62756493a12feb6a95aea34857 100644
+--- a/src/test/java/net/minestom/server/entity/EntityMetaTest.java
++++ b/src/test/java/net/minestom/server/entity/EntityMetaTest.java
+@@ -7,10 +7,10 @@ import java.util.List;
+ 
+ import static org.junit.jupiter.api.Assertions.assertTrue;
+ 
+-public class EntityMetaTest {
++class EntityMetaTest {
+ 
+     @Test
+-    public void ensureRegistration() throws IllegalAccessException {
++    void ensureRegistration() throws IllegalAccessException {
+         List<String> list = new ArrayList<>();
+         for (var field : EntityTypes.class.getDeclaredFields()) {
+             final EntityType entityType = (EntityType) field.get(this);
+diff --git a/src/test/java/net/minestom/server/entity/EntityProjectileIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityProjectileIntegrationTest.java
+index 814257ce83dcf9228df221f877bb521980e83b8a..d5f4bf0c9e56569a8b85ec8789f0fcda7240dd53 100644
+--- a/src/test/java/net/minestom/server/entity/EntityProjectileIntegrationTest.java
++++ b/src/test/java/net/minestom/server/entity/EntityProjectileIntegrationTest.java
+@@ -8,9 +8,9 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+ @EnvTest
+-public class EntityProjectileIntegrationTest {
++class EntityProjectileIntegrationTest {
+     @Test
+-    public void gravityVelocity(Env env) {
++    void gravityVelocity(Env env) {
+         var instance = env.createFlatInstance();
+         var shooter = new EntityCreature(EntityType.SKELETON);
+         shooter.setInstance(instance, new Pos(0, 42, 0)).join();
+@@ -42,7 +42,7 @@ public class EntityProjectileIntegrationTest {
+     }
+ 
+     @Test
+-    public void noGravityVelocity(Env env) {
++    void noGravityVelocity(Env env) {
+         var instance = env.createFlatInstance();
+         var shooter = new EntityCreature(EntityType.SKELETON);
+         shooter.setInstance(instance, new Pos(0, 42, 0)).join();
+diff --git a/src/test/java/net/minestom/server/entity/EntityRemovalIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityRemovalIntegrationTest.java
+index 42d6e2f23777010d59206346d9efa5158ca70dec..35387a6cdcd97079a9e6d896e305f952c15a3a1f 100644
+--- a/src/test/java/net/minestom/server/entity/EntityRemovalIntegrationTest.java
++++ b/src/test/java/net/minestom/server/entity/EntityRemovalIntegrationTest.java
+@@ -16,10 +16,10 @@ import static net.minestom.testing.TestUtils.waitUntilCleared;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+ @EnvTest
+-public class EntityRemovalIntegrationTest {
++class EntityRemovalIntegrationTest {
+ 
+     @Test
+-    public void destructionPacket(Env env) {
++    void destructionPacket(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         connection.connect(instance, new Pos(0, 40, 0)).join();
+@@ -33,7 +33,7 @@ public class EntityRemovalIntegrationTest {
+     }
+ 
+     @Test
+-    public void instanceRemoval(Env env) {
++    void instanceRemoval(Env env) {
+         var instance = env.createFlatInstance();
+         var entity = new Entity(EntityType.ZOMBIE);
+         entity.setInstance(instance, new Pos(0, 40, 0)).join();
+@@ -45,7 +45,7 @@ public class EntityRemovalIntegrationTest {
+     }
+ 
+     @Test
+-    public void tickTimedRemoval(Env env) throws InterruptedException {
++    void tickTimedRemoval(Env env) throws InterruptedException {
+         var instance = env.createFlatInstance();
+         var entity = new TestEntity(2, TimeUnit.SERVER_TICK);
+         entity.setInstance(instance, new Pos(0, 40, 0)).join();
+@@ -65,7 +65,7 @@ public class EntityRemovalIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityGC(Env env) {
++    void entityGC(Env env) {
+         // Ensure that entities do not stay in memory after they are removed
+         var instance = env.createFlatInstance();
+         var entity = new Entity(EntityType.ZOMBIE);
+@@ -80,7 +80,7 @@ public class EntityRemovalIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityNodeGC(Env env) {
++    void entityNodeGC(Env env) {
+         // Ensure that the entities GCed when a local listener is present
+         var node = env.process().eventHandler();
+         var entity = new Entity(EntityType.ZOMBIE);
+@@ -97,7 +97,7 @@ public class EntityRemovalIntegrationTest {
+     }
+ 
+     static final class TestEntity extends Entity {
+-        public TestEntity(long delay, TemporalUnit unit) {
++        TestEntity(long delay, TemporalUnit unit) {
+             super(EntityType.ZOMBIE);
+             scheduleRemove(delay, unit);
+         }
+diff --git a/src/test/java/net/minestom/server/entity/EntityTeleportIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityTeleportIntegrationTest.java
+index 22b32a5d5275ae3aca28bce8b87975aae4bd5f32..8eea5dcf24ebffc832af63308b6d6435913732a2 100644
+--- a/src/test/java/net/minestom/server/entity/EntityTeleportIntegrationTest.java
++++ b/src/test/java/net/minestom/server/entity/EntityTeleportIntegrationTest.java
+@@ -11,10 +11,10 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+ @EnvTest
+-public class EntityTeleportIntegrationTest {
++class EntityTeleportIntegrationTest {
+ 
+     @Test
+-    public void entityChunkTeleport(Env env) {
++    void entityChunkTeleport(Env env) {
+         var instance = env.createFlatInstance();
+         var entity = new Entity(EntityTypes.ZOMBIE);
+         entity.setInstance(instance, new Pos(0, 42, 0)).join();
+@@ -26,7 +26,7 @@ public class EntityTeleportIntegrationTest {
+     }
+ 
+     @Test
+-    public void entityTeleport(Env env) {
++    void entityTeleport(Env env) {
+         var instance = env.createFlatInstance();
+         var entity = new Entity(EntityTypes.ZOMBIE);
+         entity.setInstance(instance, new Pos(0, 42, 0)).join();
+@@ -38,7 +38,7 @@ public class EntityTeleportIntegrationTest {
+     }
+ 
+     @Test
+-    public void playerChunkTeleport(Env env) {
++    void playerChunkTeleport(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var player = connection.connect(instance, new Pos(0, 40, 0)).join();
+@@ -65,7 +65,7 @@ public class EntityTeleportIntegrationTest {
+     }
+ 
+     @Test
+-    public void playerTeleport(Env env) {
++    void playerTeleport(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var player = connection.connect(instance, new Pos(0, 40, 0)).join();
+diff --git a/src/test/java/net/minestom/server/entity/EntityVelocityIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityVelocityIntegrationTest.java
+index 2ee0bd4296cd18e9a0c243cf5606ab6ced6f81cb..b417ccc6e678d5233e5c2caf8b4c364793f2100d 100644
+--- a/src/test/java/net/minestom/server/entity/EntityVelocityIntegrationTest.java
++++ b/src/test/java/net/minestom/server/entity/EntityVelocityIntegrationTest.java
+@@ -15,9 +15,9 @@ import java.util.function.BooleanSupplier;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+ @EnvTest
+-public class EntityVelocityIntegrationTest {
++class EntityVelocityIntegrationTest {
+     @Test
+-    public void gravity(Env env) {
++    void gravity(Env env) {
+         var instance = env.createFlatInstance();
+         loadChunks(instance);
+ 
+@@ -36,7 +36,7 @@ public class EntityVelocityIntegrationTest {
+     }
+ 
+     @Test
+-    public void singleKnockback(Env env) {
++    void singleKnockback(Env env) {
+         var instance = env.createFlatInstance();
+         loadChunks(instance);
+ 
+@@ -67,7 +67,7 @@ public class EntityVelocityIntegrationTest {
+     }
+ 
+     @Test
+-    public void doubleKnockback(Env env) {
++    void doubleKnockback(Env env) {
+         var instance = env.createFlatInstance();
+         loadChunks(instance);
+ 
+@@ -102,7 +102,7 @@ public class EntityVelocityIntegrationTest {
+     }
+ 
+     @Test
+-    public void flyingVelocity(Env env) {
++    void flyingVelocity(Env env) {
+         var instance = env.createFlatInstance();
+         loadChunks(instance);
+ 
+@@ -127,7 +127,7 @@ public class EntityVelocityIntegrationTest {
+     }
+ 
+     @Test
+-    public void flyingPlayerMovement(Env env) {
++    void flyingPlayerMovement(Env env) {
+         // Player movement should not send velocity packets as already client predicted
+         var instance = env.createFlatInstance();
+         var player = env.createPlayer(instance, new Pos(0, 42, 0));
+@@ -141,7 +141,7 @@ public class EntityVelocityIntegrationTest {
+     }
+ 
+     @Test
+-    public void testHasVelocity(Env env) {
++    void testHasVelocity(Env env) {
+         var instance = env.createFlatInstance();
+         loadChunks(instance);
+ 
+@@ -164,7 +164,7 @@ public class EntityVelocityIntegrationTest {
+     }
+ 
+     @Test
+-    public void countVelocityPackets(Env env) {
++    void countVelocityPackets(Env env) {
+         final int VELOCITY_UPDATE_INTERVAL = 1;
+ 
+         var instance = env.createFlatInstance();
+diff --git a/src/test/java/net/minestom/server/entity/EntityViewDirectionIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityViewDirectionIntegrationTest.java
+index 00d15fb47f66a452336339b59833c10bf2c03674..5ba3cb257207b4cf630ee3c24fb54f80c85a85d6 100644
+--- a/src/test/java/net/minestom/server/entity/EntityViewDirectionIntegrationTest.java
++++ b/src/test/java/net/minestom/server/entity/EntityViewDirectionIntegrationTest.java
+@@ -9,11 +9,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertTrue;
+ 
+ @EnvTest
+-public class EntityViewDirectionIntegrationTest {
++class EntityViewDirectionIntegrationTest {
+     private static final float EPSILON = 0.01f;
+ 
+     @Test
+-    public void viewYawAndPitch(Env env) {
++    void viewYawAndPitch(Env env) {
+         var instance = env.createFlatInstance();
+         var entity = new Entity(EntityType.ZOMBIE);
+         entity.setInstance(instance, new Pos(0, 40, 0)).join();
+@@ -48,7 +48,7 @@ public class EntityViewDirectionIntegrationTest {
+     }
+ 
+     @Test
+-    public void lookAtPos(Env env) {
++    void lookAtPos(Env env) {
+         var instance = env.createFlatInstance();
+         var entity = new Entity(EntityType.ZOMBIE);
+         double eyeHeight = entity.getEyeHeight(); // adding this to some position Y coordinates, to look horizontally
+@@ -87,7 +87,7 @@ public class EntityViewDirectionIntegrationTest {
+     }
+ 
+     @Test
+-    public void lookAtEntitySameType(Env env) {
++    void lookAtEntitySameType(Env env) {
+         var instance = env.createFlatInstance();
+         // same type, same eye height
+         var e1 = new Entity(EntityType.ZOMBIE);
+@@ -121,7 +121,7 @@ public class EntityViewDirectionIntegrationTest {
+     }
+ 
+     @Test
+-    public void lookAtEntityDifferentType(Env env) {
++    void lookAtEntityDifferentType(Env env) {
+         var instance = env.createFlatInstance();
+         // same type, same eye height
+         var e1 = new Entity(EntityType.ZOMBIE);
+diff --git a/src/test/java/net/minestom/server/entity/EntityViewIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityViewIntegrationTest.java
+index 181b303252adccd24255baaa9a76ca18dc297d9b..b87d2081c413b2693f65b3d6b93814574ef377e7 100644
+--- a/src/test/java/net/minestom/server/entity/EntityViewIntegrationTest.java
++++ b/src/test/java/net/minestom/server/entity/EntityViewIntegrationTest.java
+@@ -9,10 +9,10 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+ @EnvTest
+-public class EntityViewIntegrationTest {
++class EntityViewIntegrationTest {
+ 
+     @Test
+-    public void emptyEntity(Env env) {
++    void emptyEntity(Env env) {
+         var instance = env.createFlatInstance();
+         var entity = new Entity(EntityType.ZOMBIE);
+         entity.setInstance(instance, new Pos(0, 40, 42)).join();
+@@ -20,14 +20,14 @@ public class EntityViewIntegrationTest {
+     }
+ 
+     @Test
+-    public void emptyPlayer(Env env) {
++    void emptyPlayer(Env env) {
+         var instance = env.createFlatInstance();
+         var player = env.createPlayer(instance, new Pos(0, 42, 0));
+         assertEquals(0, player.getViewers().size());
+     }
+ 
+     @Test
+-    public void multiPlayers(Env env) {
++    void multiPlayers(Env env) {
+         var instance = env.createFlatInstance();
+         var p1 = env.createPlayer(instance, new Pos(0, 42, 42));
+         var p2 = env.createPlayer(instance, new Pos(0, 42, 42));
+@@ -48,7 +48,7 @@ public class EntityViewIntegrationTest {
+     }
+ 
+     @Test
+-    public void manualViewers(Env env) {
++    void manualViewers(Env env) {
+         var instance = env.createFlatInstance();
+         var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
+         var p2 = env.createPlayer(instance, new Pos(0, 42, 5_000));
+@@ -65,7 +65,7 @@ public class EntityViewIntegrationTest {
+     }
+ 
+     @Test
+-    public void movements(Env env) {
++    void movements(Env env) {
+         var instance = env.createFlatInstance();
+         var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
+         var p2 = env.createPlayer(instance, new Pos(0, 42, 96));
+@@ -79,7 +79,7 @@ public class EntityViewIntegrationTest {
+     }
+ 
+     @Test
+-    public void autoViewable(Env env) {
++    void autoViewable(Env env) {
+         var instance = env.createFlatInstance();
+         var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
+         assertTrue(p1.isAutoViewable());
+@@ -96,7 +96,7 @@ public class EntityViewIntegrationTest {
+     }
+ 
+     @Test
+-    public void predictableViewers(Env env) {
++    void predictableViewers(Env env) {
+         var instance = env.createFlatInstance();
+         var p = env.createPlayer(instance, new Pos(0, 42, 0));
+         assertTrue(p.hasPredictableViewers());
+@@ -123,7 +123,7 @@ public class EntityViewIntegrationTest {
+     }
+ 
+     @Test
+-    public void livingVehicle(Env env) {
++    void livingVehicle(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var player = connection.connect(instance, new Pos(0, 40, 0)).join();
+@@ -153,7 +153,7 @@ public class EntityViewIntegrationTest {
+     }
+ 
+     @Test
+-    public void vehicleInheritance(Env env) {
++    void vehicleInheritance(Env env) {
+         var instance = env.createFlatInstance();
+         var p1 = env.createPlayer(instance, new Pos(0, 40, 0));
+         var p2 = env.createPlayer(instance, new Pos(0, 40, 0));
+diff --git a/src/test/java/net/minestom/server/entity/EntityViewerRuleIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityViewerRuleIntegrationTest.java
+index 40038cf6f257e058e79ffb8eacdcf96ca1e61685..6074de4b7fc26017f615bf08503dd01055ee1e39 100644
+--- a/src/test/java/net/minestom/server/entity/EntityViewerRuleIntegrationTest.java
++++ b/src/test/java/net/minestom/server/entity/EntityViewerRuleIntegrationTest.java
+@@ -10,10 +10,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+ @EnvTest
+-public class EntityViewerRuleIntegrationTest {
++class EntityViewerRuleIntegrationTest {
+ 
+     @Test
+-    public void viewableRule(Env env) {
++    void viewableRule(Env env) {
+         var instance = env.createFlatInstance();
+         var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
+         p1.updateViewableRule(p -> p.getEntityId() == p1.getEntityId() + 1);
+@@ -30,7 +30,7 @@ public class EntityViewerRuleIntegrationTest {
+     }
+ 
+     @Test
+-    public void viewableRuleUpdate(Env env) {
++    void viewableRuleUpdate(Env env) {
+         var instance = env.createFlatInstance();
+         var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
+ 
+@@ -48,7 +48,7 @@ public class EntityViewerRuleIntegrationTest {
+     }
+ 
+     @Test
+-    public void viewableRuleDouble(Env env) {
++    void viewableRuleDouble(Env env) {
+         var instance = env.createFlatInstance();
+         var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
+         var p2 = env.createPlayer(instance, new Pos(0, 42, 0));
+@@ -80,7 +80,7 @@ public class EntityViewerRuleIntegrationTest {
+     }
+ 
+     @Test
+-    public void viewerRule(Env env) {
++    void viewerRule(Env env) {
+         var instance = env.createFlatInstance();
+         var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
+         p1.updateViewerRule(e -> e.getEntityId() == p1.getEntityId() + 1);
+@@ -97,7 +97,7 @@ public class EntityViewerRuleIntegrationTest {
+     }
+ 
+     @Test
+-    public void viewerRuleUpdate(Env env) {
++    void viewerRuleUpdate(Env env) {
+         var instance = env.createFlatInstance();
+         var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
+         AtomicBoolean enabled = new AtomicBoolean(false);
+@@ -114,7 +114,7 @@ public class EntityViewerRuleIntegrationTest {
+     }
+ 
+     @Test
+-    public void viewerRuleDouble(Env env) {
++    void viewerRuleDouble(Env env) {
+         var instance = env.createFlatInstance();
+         var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
+         var p2 = env.createPlayer(instance, new Pos(0, 42, 0));
+diff --git a/src/test/java/net/minestom/server/entity/GameModeTest.java b/src/test/java/net/minestom/server/entity/GameModeTest.java
+index 2d7ea85dd0764cf052efa3ced47bab698c6c3aa4..4f00aa0e8ccdfd8a46152a6cb06b2cfb4f5729a7 100644
+--- a/src/test/java/net/minestom/server/entity/GameModeTest.java
++++ b/src/test/java/net/minestom/server/entity/GameModeTest.java
+@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
+ 
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+-public class GameModeTest {
++class GameModeTest {
+ 
+     @Test
+-    public void toId() {
++    void toId() {
+         assertEquals(GameMode.SURVIVAL.id(), 0);
+         assertEquals(GameMode.CREATIVE.id(), 1);
+         assertEquals(GameMode.ADVENTURE.id(), 2);
+@@ -15,7 +15,7 @@ public class GameModeTest {
+     }
+ 
+     @Test
+-    public void fromId() {
++    void fromId() {
+         assertEquals(GameMode.SURVIVAL, GameMode.fromId(0));
+         assertEquals(GameMode.CREATIVE, GameMode.fromId(1));
+         assertEquals(GameMode.ADVENTURE, GameMode.fromId(2));
+diff --git a/src/test/java/net/minestom/server/entity/PassengerIntegrationTest.java b/src/test/java/net/minestom/server/entity/PassengerIntegrationTest.java
+index 2b9402f1cbf337d38d1cc0d6ae5a68d91050b173..012ac45c68a090b8ca18b7181490313ead8d99f3 100644
+--- a/src/test/java/net/minestom/server/entity/PassengerIntegrationTest.java
++++ b/src/test/java/net/minestom/server/entity/PassengerIntegrationTest.java
+@@ -8,10 +8,10 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+ @EnvTest
+-public class PassengerIntegrationTest {
++class PassengerIntegrationTest {
+ 
+     @Test
+-    public void passenger(Env env) {
++    void passenger(Env env) {
+         var instance = env.createFlatInstance();
+         var vehicle = new Entity(EntityType.ZOMBIE);
+         var passenger = new Entity(EntityType.ZOMBIE);
+@@ -28,7 +28,7 @@ public class PassengerIntegrationTest {
+     }
+ 
+     @Test
+-    public void passengerTeleport(Env env) {
++    void passengerTeleport(Env env) {
+         var instance = env.createFlatInstance();
+         var vehicle = new Entity(EntityType.ZOMBIE);
+         var passenger = new Entity(EntityType.ZOMBIE);
+diff --git a/src/test/java/net/minestom/server/entity/PlayerHeldIntegrationTest.java b/src/test/java/net/minestom/server/entity/PlayerHeldIntegrationTest.java
+index efd06b005614c0bc67ed985fa56988139e714f93..feccdb951f27d6e46fe8aa4f18ded7a0d3949d21 100644
+--- a/src/test/java/net/minestom/server/entity/PlayerHeldIntegrationTest.java
++++ b/src/test/java/net/minestom/server/entity/PlayerHeldIntegrationTest.java
+@@ -12,10 +12,10 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+ @EnvTest
+-public class PlayerHeldIntegrationTest {
++class PlayerHeldIntegrationTest {
+ 
+     @Test
+-    public void playerHeld(Env env) {
++    void playerHeld(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var player = connection.connect(instance, new Pos(0, 40, 0)).join();
+@@ -32,7 +32,7 @@ public class PlayerHeldIntegrationTest {
+     }
+ 
+     @Test
+-    public void playerHeldEvent(Env env) {
++    void playerHeldEvent(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var player = connection.connect(instance, new Pos(0, 40, 0)).join();
+diff --git a/src/test/java/net/minestom/server/entity/PlayerSkinTest.java b/src/test/java/net/minestom/server/entity/PlayerSkinTest.java
+index 771bdca2a59bc50d53578fe7a5abe4169f2dae07..4f8e547d6a00099f8e6b5fe03dd6aee6b79a8ce3 100644
+--- a/src/test/java/net/minestom/server/entity/PlayerSkinTest.java
++++ b/src/test/java/net/minestom/server/entity/PlayerSkinTest.java
+@@ -5,16 +5,16 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.assertNotNull;
+ import static org.junit.jupiter.api.Assertions.assertNull;
+ 
+-public class PlayerSkinTest {
++class PlayerSkinTest {
+ 
+     @Test
+-    public void validName() {
++    void validName() {
+         var skin = PlayerSkin.fromUsername("jeb_");
+         assertNotNull(skin);
+     }
+ 
+     @Test
+-    public void invalidName() {
++    void invalidName() {
+         var skin = PlayerSkin.fromUsername("jfdsa84vvcxadubasdfcvn");
+         assertNull(skin);
+     }
+diff --git a/src/test/java/net/minestom/server/entity/ai/ClosestEntityTargetTest.java b/src/test/java/net/minestom/server/entity/ai/ClosestEntityTargetTest.java
+index 5c34c621e1bf3d9a9ec07b927ca8473f05278846..25d78311447f9236c78ae319899c295f9b7e2225 100644
+--- a/src/test/java/net/minestom/server/entity/ai/ClosestEntityTargetTest.java
++++ b/src/test/java/net/minestom/server/entity/ai/ClosestEntityTargetTest.java
+@@ -12,10 +12,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertNull;
+ 
+ @EnvTest
+-public class ClosestEntityTargetTest {
++class ClosestEntityTargetTest {
+ 
+     @Test
+-    public void validFindTarget(Env env) {
++    void validFindTarget(Env env) {
+         var instance = env.createFlatInstance();
+ 
+         var self = new EntityCreature(EntityType.ZOMBIE);
+diff --git a/src/test/java/net/minestom/server/entity/player/PlayerBlockPlacementIntegrationTest.java b/src/test/java/net/minestom/server/entity/player/PlayerBlockPlacementIntegrationTest.java
+index c2bf3603d30cfc95e5d4aa5a9669cb08dca218c6..0566d0edc971797d11df73af3772b504072545da 100644
+--- a/src/test/java/net/minestom/server/entity/player/PlayerBlockPlacementIntegrationTest.java
++++ b/src/test/java/net/minestom/server/entity/player/PlayerBlockPlacementIntegrationTest.java
+@@ -19,11 +19,11 @@ import java.util.stream.Stream;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+ @EnvTest
+-public class PlayerBlockPlacementIntegrationTest {
++class PlayerBlockPlacementIntegrationTest {
+ 
+     @ParameterizedTest
+     @MethodSource("placeBlockFromAdventureModeParams")
+-    public void placeBlockFromAdventureMode(Block baseBlock, Block canPlaceOn, Env env) {
++    void placeBlockFromAdventureMode(Block baseBlock, Block canPlaceOn, Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var player = connection.connect(instance, new Pos(0, 42, 0)).join();
+diff --git a/src/test/java/net/minestom/server/entity/player/PlayerIntegrationTest.java b/src/test/java/net/minestom/server/entity/player/PlayerIntegrationTest.java
+index b36bec3de3026ca3e1b8f7217c05407da073dfe7..8d7be19dd4d72044a99a01af4190fd2c1b5d7937 100644
+--- a/src/test/java/net/minestom/server/entity/player/PlayerIntegrationTest.java
++++ b/src/test/java/net/minestom/server/entity/player/PlayerIntegrationTest.java
+@@ -23,13 +23,13 @@ import java.util.List;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+ @EnvTest
+-public class PlayerIntegrationTest {
++class PlayerIntegrationTest {
+ 
+     /**
+      * Test to see whether player abilities are updated correctly when changing gamemodes
+      */
+     @Test
+-    public void gamemodeTest(Env env) {
++    void gamemodeTest(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var player = connection.connect(instance, new Pos(0, 42, 0)).join();
+@@ -72,7 +72,7 @@ public class PlayerIntegrationTest {
+     }
+ 
+     @Test
+-    public void handSwapTest(Env env) {
++    void handSwapTest(Env env) {
+         ClientSettingsPacket packet = new ClientSettingsPacket("en_us", (byte) 16, ChatMessageType.FULL,
+                 true, (byte) 127, Player.MainHand.LEFT, true, true);
+ 
+@@ -110,7 +110,7 @@ public class PlayerIntegrationTest {
+     }
+ 
+     @Test
+-    public void playerJoinPackets(Env env) {
++    void playerJoinPackets(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+ 
+@@ -141,7 +141,7 @@ public class PlayerIntegrationTest {
+      * when changing dimensions
+      */
+     @Test
+-    public void refreshPlayerTest(Env env) {
++    void refreshPlayerTest(Env env) {
+         final int TEST_PERMISSION_LEVEL = 2;
+         final var testDimension = DimensionType.builder(NamespaceID.from("minestom:test_dimension")).build();
+         env.process().dimension().addDimension(testDimension);
+@@ -177,7 +177,7 @@ public class PlayerIntegrationTest {
+     }
+ 
+     @Test
+-    public void deathLocationTest(Env env) {
++    void deathLocationTest(Env env) {
+         String dimensionNamespace = "minestom:test_dimension";
+         final var testDimension = DimensionType.builder(NamespaceID.from(dimensionNamespace)).build();
+         env.process().dimension().addDimension(testDimension);
+@@ -195,7 +195,7 @@ public class PlayerIntegrationTest {
+     }
+     // Microtus start - Fix team spam
+     @Test
+-    public void displayNameTest(Env env) {
++    void displayNameTest(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var tracker = connection.trackIncoming(PlayerInfoUpdatePacket.class);
+@@ -228,7 +228,7 @@ public class PlayerIntegrationTest {
+     }
+ 
+     @Test
+-    public void teamPacketTest(Env env) {
++    void teamPacketTest(Env env) {
+         var team = env.process().team().createTeam("minestom");
+ 
+         var instance = env.createFlatInstance();
+diff --git a/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java b/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
+index 30e9977964d9d0e9732f3b6216cf1c839f7bc63c..1bd8b09c6c8f5c8ae02d398b6d44f88b6f491418 100644
+--- a/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
++++ b/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
+@@ -26,10 +26,10 @@ import java.util.concurrent.CompletableFuture;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+ @EnvTest
+-public class PlayerMovementIntegrationTest {
++class PlayerMovementIntegrationTest {
+ 
+     @Test
+-    public void teleportConfirm(Env env) {
++    void teleportConfirm(Env env) {
+         var instance = env.createFlatInstance();
+         var p1 = env.createPlayer(instance, new Pos(0, 40, 0));
+         // No confirmation
+@@ -45,7 +45,7 @@ public class PlayerMovementIntegrationTest {
+ 
+     // FIXME
+     //@Test
+-    public void singleTickMovementUpdate(Env env) {
++    void singleTickMovementUpdate(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var p1 = env.createPlayer(instance, new Pos(0, 40, 0));
+@@ -62,7 +62,7 @@ public class PlayerMovementIntegrationTest {
+     }
+ 
+     @Test
+-    public void chunkUpdateDebounceTest(Env env) {
++    void chunkUpdateDebounceTest(Env env) {
+         final Instance flatInstance = env.createFlatInstance();
+         final int viewDiameter = MinecraftServer.getChunkViewDistance() * 2 + 1;
+         // Preload all possible chunks to avoid issues due to async loading
+diff --git a/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkIntegrationTest.java b/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkIntegrationTest.java
+index 1dac5752d654cf22dc83d02c396dcb2c9be904e7..a4960aa5e69c4fffbe6edb12cae7fb25766a4eec 100644
+--- a/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkIntegrationTest.java
++++ b/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkIntegrationTest.java
+@@ -19,10 +19,10 @@ import static org.junit.jupiter.api.Assertions.*;
+ 
+ 
+ @EnvTest
+-public class PlayerRespawnChunkIntegrationTest {
++class PlayerRespawnChunkIntegrationTest {
+ 
+     @Test
+-    public void testChunkUnloadsOnRespawn(Env env) {
++    void testChunkUnloadsOnRespawn(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         Player player = connection.connect(instance, new Pos(0, 40, 0)).join();
+@@ -36,7 +36,7 @@ public class PlayerRespawnChunkIntegrationTest {
+     }
+ 
+     @Test
+-    public void testChunkReloadCount(Env env) {
++    void testChunkReloadCount(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         Player player = connection.connect(instance, new Pos(0, 40, 0)).join();
+@@ -50,7 +50,7 @@ public class PlayerRespawnChunkIntegrationTest {
+     }
+ 
+     @Test
+-    public void testPlayerTryRespawn(Env env) {
++    void testPlayerTryRespawn(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         Player player = connection.connect(instance, new Pos(0, 40, 0)).join();
+diff --git a/src/test/java/net/minestom/server/event/EventNodeGraphTest.java b/src/test/java/net/minestom/server/event/EventNodeGraphTest.java
+index c9f650b9eca9c9ad35ccc15d61e9e4e67cd48fb4..37d8007440767e211697478d2b0cba92cf038772 100644
+--- a/src/test/java/net/minestom/server/event/EventNodeGraphTest.java
++++ b/src/test/java/net/minestom/server/event/EventNodeGraphTest.java
+@@ -6,16 +6,16 @@ import java.util.List;
+ 
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+-public class EventNodeGraphTest {
++class EventNodeGraphTest {
+ 
+     @Test
+-    public void single() {
++    void single() {
+         EventNode<Event> node = EventNode.all("main");
+         verifyGraph(node, new EventNodeImpl.Graph("main", "Event", 0, List.of()));
+     }
+ 
+     @Test
+-    public void singleChild() {
++    void singleChild() {
+         EventNode<Event> node = EventNode.all("main");
+         node.addChild(EventNode.all("child"));
+         verifyGraph(node, new EventNodeImpl.Graph("main", "Event", 0,
+@@ -24,7 +24,7 @@ public class EventNodeGraphTest {
+     }
+ 
+     @Test
+-    public void childrenPriority() {
++    void childrenPriority() {
+         {
+             EventNode<Event> node = EventNode.all("main");
+             node.addChild(EventNode.all("child1").setPriority(5));
+diff --git a/src/test/java/net/minestom/server/event/EventNodeMapTest.java b/src/test/java/net/minestom/server/event/EventNodeMapTest.java
+index e803aa3e5319ba2abadd916b8e96781fc9734ed8..e14d519581c09110a5248e74c9f6a2d5dfaf8455 100644
+--- a/src/test/java/net/minestom/server/event/EventNodeMapTest.java
++++ b/src/test/java/net/minestom/server/event/EventNodeMapTest.java
+@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.*;
+ public class EventNodeMapTest {
+ 
+     @Test
+-    public void uniqueMapping() {
++    void uniqueMapping() {
+         var item = ItemStack.of(Material.DIAMOND);
+         var node = EventNode.all("main");
+         var itemNode1 = node.map(item, EventFilter.ITEM);
+@@ -31,7 +31,7 @@ public class EventNodeMapTest {
+     }
+ 
+     @Test
+-    public void lazyRegistration() {
++    void lazyRegistration() {
+         var item = ItemStack.of(Material.DIAMOND);
+         var node = (EventNodeImpl<Event>) EventNode.all("main");
+         var itemNode = node.map(item, EventFilter.ITEM);
+@@ -42,7 +42,7 @@ public class EventNodeMapTest {
+     }
+ 
+     @Test
+-    public void secondMap() {
++    void secondMap() {
+         var item = ItemStack.of(Material.DIAMOND);
+         var node = (EventNodeImpl<Event>) EventNode.all("main");
+         var itemNode = node.map(item, EventFilter.ITEM);
+@@ -51,7 +51,7 @@ public class EventNodeMapTest {
+     }
+ 
+     @Test
+-    public void map() {
++    void map() {
+         var item = ItemStack.of(Material.DIAMOND);
+         var node = EventNode.all("main");
+ 
+@@ -76,7 +76,7 @@ public class EventNodeMapTest {
+     }
+ 
+     @Test
+-    public void entityLocal() {
++    void entityLocal() {
+         var process = MinecraftServer.updateProcess();
+         var node = process.eventHandler();
+         var entity = new Entity(EntityType.ZOMBIE);
+@@ -102,7 +102,7 @@ public class EventNodeMapTest {
+     }
+ 
+     @Test
+-    public void ownerGC() {
++    void ownerGC() {
+         // Ensure that the mapped object gets GCed
+         var item = ItemStack.of(Material.DIAMOND);
+         var node = EventNode.all("main");
+diff --git a/src/test/java/net/minestom/server/event/EventNodeQueryTest.java b/src/test/java/net/minestom/server/event/EventNodeQueryTest.java
+index 9e035b0f764ee8e90cf8769edda1e87fc69af81d..fd481a2b8ff53cb174c788ac95dc071fa87ae6af 100644
+--- a/src/test/java/net/minestom/server/event/EventNodeQueryTest.java
++++ b/src/test/java/net/minestom/server/event/EventNodeQueryTest.java
+@@ -9,10 +9,10 @@ import java.util.List;
+ import static net.minestom.testing.TestUtils.assertEqualsIgnoreOrder;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+-public class EventNodeQueryTest {
++class EventNodeQueryTest {
+ 
+     @Test
+-    public void find() {
++    void find() {
+         var node = EventNode.all("main");
+         assertEquals(List.of(), node.findChildren("test"));
+ 
+@@ -33,7 +33,7 @@ public class EventNodeQueryTest {
+     }
+ 
+     @Test
+-    public void findType() {
++    void findType() {
+         var node = EventNode.all("main");
+         assertEquals(List.of(), node.findChildren("test", Event.class));
+ 
+@@ -58,7 +58,7 @@ public class EventNodeQueryTest {
+     }
+ 
+     @Test
+-    public void replace() {
++    void replace() {
+         var node = EventNode.all("main");
+ 
+         var child1 = EventNode.all("test");
+diff --git a/src/test/java/net/minestom/server/event/EventNodeTest.java b/src/test/java/net/minestom/server/event/EventNodeTest.java
+index 114033a08a7d9acebfd67ce535afe9e39a08262a..b1e46999c543fce8efabf4f38e3e655c5a153ef5 100644
+--- a/src/test/java/net/minestom/server/event/EventNodeTest.java
++++ b/src/test/java/net/minestom/server/event/EventNodeTest.java
+@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
+ import static net.minestom.testing.TestUtils.waitUntilCleared;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class EventNodeTest {
++class EventNodeTest {
+ 
+     static class EventTest implements Event {
+     }
+@@ -57,7 +57,7 @@ public class EventNodeTest {
+     }
+ 
+     @Test
+-    public void testCall() {
++    void testCall() {
+         var node = EventNode.all("main");
+         AtomicBoolean result = new AtomicBoolean(false);
+         var listener = EventListener.of(EventTest.class, eventTest -> result.set(true));
+@@ -74,7 +74,7 @@ public class EventNodeTest {
+     }
+ 
+     @Test
+-    public void testHandle() {
++    void testHandle() {
+         var node = EventNode.all("main");
+         var handle = node.getHandle(EventTest.class);
+         assertSame(handle, node.getHandle(EventTest.class));
+@@ -84,7 +84,7 @@ public class EventNodeTest {
+     }
+ 
+     @Test
+-    public void testCancellable() {
++    void testCancellable() {
+         var node = EventNode.all("main");
+         AtomicBoolean result = new AtomicBoolean(false);
+         var listener = EventListener.builder(CancellableTest.class)
+@@ -103,7 +103,7 @@ public class EventNodeTest {
+     }
+ 
+     @Test
+-    public void recursiveSub() {
++    void recursiveSub() {
+         var node = EventNode.all("main");
+         AtomicBoolean result1 = new AtomicBoolean(false);
+         AtomicBoolean result2 = new AtomicBoolean(false);
+@@ -144,7 +144,7 @@ public class EventNodeTest {
+     //}
+ 
+     @Test
+-    public void testChildren() {
++    void testChildren() {
+         var node = EventNode.all("main");
+         AtomicInteger result = new AtomicInteger(0);
+         var child1 = EventNode.all("child1").setPriority(1)
+@@ -159,14 +159,14 @@ public class EventNodeTest {
+                 });
+         node.addChild(child1);
+         node.addChild(child2);
+-        assertEquals(node.getChildren().size(), 2, "The node should have 2 children");
++        assertEquals(2, node.getChildren().size(), "The node should have 2 children");
+         node.call(new EventTest());
+         assertEquals(2, result.get(), "The event should be called after the call");
+ 
+         // Test removal
+         result.set(0);
+         node.removeChild(child2);
+-        assertEquals(node.getChildren().size(), 1, "The node should have 1 child");
++        assertEquals(1, node.getChildren().size() , "The node should have 1 child");
+         node.call(new EventTest());
+         assertEquals(1, result.get(), "child2 should has been removed");
+ 
+@@ -178,7 +178,7 @@ public class EventNodeTest {
+     }
+ 
+     @Test
+-    public void testFiltering() {
++    void testFiltering() {
+         AtomicBoolean result = new AtomicBoolean(false);
+         AtomicBoolean childResult = new AtomicBoolean(false);
+ 
+@@ -202,7 +202,7 @@ public class EventNodeTest {
+     }
+ 
+     @Test
+-    public void testBinding() {
++    void testBinding() {
+         var node = EventNode.all("main");
+ 
+         AtomicBoolean result = new AtomicBoolean(false);
+@@ -224,7 +224,7 @@ public class EventNodeTest {
+     }
+ 
+     @Test
+-    public void nodeEmptyGC() {
++    void nodeEmptyGC() {
+         var node = EventNode.all("main");
+         var ref = new WeakReference<>(node);
+ 
+@@ -234,7 +234,7 @@ public class EventNodeTest {
+     }
+ 
+     @Test
+-    public void nodeGC() {
++    void nodeGC() {
+         var node = EventNode.all("main");
+         var ref = new WeakReference<>(node);
+         node.addListener(EventTest.class, event -> {
+@@ -261,7 +261,7 @@ public class EventNodeTest {
+ //    }
+ 
+     @Test
+-    public void nodeMapGC() {
++    void nodeMapGC() {
+         var node = EventNode.all("main");
+ 
+         var handler = ItemStack.AIR;
+diff --git a/src/test/java/net/minestom/server/instance/AnvilLoaderIntegrationTest.java b/src/test/java/net/minestom/server/instance/AnvilLoaderIntegrationTest.java
+index 1e8f352c6dea803bbe9cea8998fb4d03535f6177..7fcb6ffa93f15baf5dc1d77f21a01068461f8115 100644
+--- a/src/test/java/net/minestom/server/instance/AnvilLoaderIntegrationTest.java
++++ b/src/test/java/net/minestom/server/instance/AnvilLoaderIntegrationTest.java
+@@ -19,14 +19,14 @@ import java.util.function.Consumer;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+ @EnvTest
+-public class AnvilLoaderIntegrationTest {
++class AnvilLoaderIntegrationTest {
+ 
+     private static final Path testRoot = Path.of("src", "test", "resources", "net", "minestom", "server", "instance", "anvil_loader");
+     private static final Path worldFolder = Path.of("integration_test_world");
+ 
+ 
+     @BeforeAll
+-    public static void prepareTest() throws IOException {
++    static void prepareTest() throws IOException {
+         // https://stackoverflow.com/a/60621544
+         Files.walkFileTree(testRoot, new SimpleFileVisitor<>() {
+ 
+@@ -48,7 +48,7 @@ public class AnvilLoaderIntegrationTest {
+ 
+ 
+     @Test
+-    public void loadHouse(Env env) {
++    void loadHouse(Env env) {
+         // load a world that contains only a basic house and make sure it is loaded properly
+ 
+         AnvilLoader chunkLoader = new AnvilLoader(worldFolder) {
+@@ -145,7 +145,7 @@ public class AnvilLoaderIntegrationTest {
+     }
+ 
+     @Test
+-    public void loadAndSaveChunk(Env env) throws InterruptedException {
++    void loadAndSaveChunk(Env env) throws InterruptedException {
+         Instance instance = env.createFlatInstance(new AnvilLoader(worldFolder) {
+             // Force loads inside current thread
+             @Override
+@@ -183,7 +183,7 @@ public class AnvilLoaderIntegrationTest {
+     }
+ 
+     @AfterAll
+-    public static void cleanupTest() throws IOException {
++    static void cleanupTest() throws IOException {
+         Files.walkFileTree(worldFolder, new SimpleFileVisitor<>() {
+ 
+             @Override
+diff --git a/src/test/java/net/minestom/server/instance/BlockClientNbtTest.java b/src/test/java/net/minestom/server/instance/BlockClientNbtTest.java
+index 837eda9fe513972169ed8d0e528cbcdc387e5401..96522d656031c43dce30959e90a20f6ee82905e3 100644
+--- a/src/test/java/net/minestom/server/instance/BlockClientNbtTest.java
++++ b/src/test/java/net/minestom/server/instance/BlockClientNbtTest.java
+@@ -17,10 +17,10 @@ import java.util.Map;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertNull;
+ 
+-public class BlockClientNbtTest {
++class BlockClientNbtTest {
+ 
+     @Test
+-    public void basic() {
++    void basic() {
+         assertNull(BlockUtils.extractClientNbt(Block.STONE));
+         assertNull(BlockUtils.extractClientNbt(Block.GRASS));
+         assertEquals(NBTCompound.EMPTY, BlockUtils.extractClientNbt(Block.CHEST));
+@@ -30,7 +30,7 @@ public class BlockClientNbtTest {
+     }
+ 
+     @Test
+-    public void handler() {
++    void handler() {
+         var handler = new BlockHandler() {
+             @Override
+             public @NotNull Collection<Tag<?>> getBlockEntityTags() {
+diff --git a/src/test/java/net/minestom/server/instance/BlockPropertiesTest.java b/src/test/java/net/minestom/server/instance/BlockPropertiesTest.java
+index 3fbe44370df7d98fa432de3a9d6eb95e2cc3fbbc..ca0bf1cf03eb11e1a9efe9e29a4464ca59a33c95 100644
+--- a/src/test/java/net/minestom/server/instance/BlockPropertiesTest.java
++++ b/src/test/java/net/minestom/server/instance/BlockPropertiesTest.java
+@@ -7,16 +7,16 @@ import java.util.Map;
+ import static net.minestom.server.utils.block.BlockUtils.parseProperties;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+-public class BlockPropertiesTest {
++class BlockPropertiesTest {
+ 
+     @Test
+-    public void empty() {
++    void empty() {
+         assertEquals(Map.of(), parseProperties("[]"));
+         assertEquals(Map.of(), parseProperties(""));
+     }
+ 
+     @Test
+-    public void noBrackets() {
++    void noBrackets() {
+         assertEquals(Map.of(), parseProperties("random test without brackets"));
+         assertEquals(Map.of(), parseProperties("["));
+         assertEquals(Map.of(), parseProperties("[end"));
+@@ -27,28 +27,28 @@ public class BlockPropertiesTest {
+     }
+ 
+     @Test
+-    public void spaces() {
++    void spaces() {
+         assertEquals(Map.of(), parseProperties("[    ]"));
+     }
+ 
+     @Test
+-    public void comma() {
++    void comma() {
+         assertEquals(Map.of(), parseProperties("[  , , ,,,,  ]"));
+     }
+ 
+     @Test
+-    public void single() {
++    void single() {
+         assertEquals(Map.of("facing", "east"), parseProperties("[facing=east]"));
+     }
+ 
+     @Test
+-    public void doubleSpace() {
++    void doubleSpace() {
+         assertEquals(Map.of("facing", "east", "key", "value"), parseProperties("[facing=east,key=value ]"));
+         assertEquals(Map.of("facing", "east", "key", "value"), parseProperties("[ facing = east, key= value ]"));
+     }
+ 
+     @Test
+-    public void allLengths() {
++    void allLengths() {
+         // Verify all length variations
+         for (int i = 0; i < 13; i++) {
+             StringBuilder properties = new StringBuilder("[");
+@@ -67,7 +67,7 @@ public class BlockPropertiesTest {
+     }
+ 
+     @Test
+-    public void corrupted() {
++    void corrupted() {
+         final int size = 12;
+         StringBuilder properties = new StringBuilder("[");
+         for (int j = 0; j < size; j++) {
+diff --git a/src/test/java/net/minestom/server/instance/ChunkViewerIntegrationTest.java b/src/test/java/net/minestom/server/instance/ChunkViewerIntegrationTest.java
+index 429a26a0a498574bff8109bbaa8d14c9a4b477d2..5e9b92c3c5c749ad75351f97d5d9799ae6937096 100644
+--- a/src/test/java/net/minestom/server/instance/ChunkViewerIntegrationTest.java
++++ b/src/test/java/net/minestom/server/instance/ChunkViewerIntegrationTest.java
+@@ -13,11 +13,11 @@ import org.junit.jupiter.params.provider.ValueSource;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+ @EnvTest
+-public class ChunkViewerIntegrationTest {
++class ChunkViewerIntegrationTest {
+ 
+     @ParameterizedTest
+     @ValueSource(booleans = {false, true})
+-    public void basicJoin(boolean sharedInstance, Env env) {
++    void basicJoin(boolean sharedInstance, Env env) {
+         Instance instance = env.createFlatInstance();
+         if (sharedInstance) {
+             // Chunks get their viewers from the instance
+@@ -36,7 +36,7 @@ public class ChunkViewerIntegrationTest {
+     }
+ 
+     @Test
+-    public void renderDistance(Env env) {
++    void renderDistance(Env env) {
+         final int viewRadius = MinecraftServer.getChunkViewDistance();
+         final int count = ChunkUtils.getChunkCount(viewRadius);
+         var instance = env.createFlatInstance();
+diff --git a/src/test/java/net/minestom/server/instance/EntityTrackerIntegrationTest.java b/src/test/java/net/minestom/server/instance/EntityTrackerIntegrationTest.java
+index 23c78ab95cf4c1d33bbec7a7ded112bf90e5d643..54cf27ff081129e662126ccdeff4e0333dbb4f46 100644
+--- a/src/test/java/net/minestom/server/instance/EntityTrackerIntegrationTest.java
++++ b/src/test/java/net/minestom/server/instance/EntityTrackerIntegrationTest.java
+@@ -20,10 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertSame;
+ 
+ @EnvTest
+-public class EntityTrackerIntegrationTest {
++class EntityTrackerIntegrationTest {
+ 
+     @Test
+-    public void maxDistance(Env env) {
++    void maxDistance(Env env) {
+         final Instance instance = env.createFlatInstance();
+         final Instance anotherInstance = env.createFlatInstance();
+         final Pos spawnPos = new Pos(0, 41, 0);
+@@ -55,7 +55,7 @@ public class EntityTrackerIntegrationTest {
+     }
+ 
+     @Test
+-    public void cornerInstanceSwap(Env env) {
++    void cornerInstanceSwap(Env env) {
+         final Instance instance = env.createFlatInstance();
+         final Instance anotherInstance = env.createFlatInstance();
+         final Pos spawnPos = new Pos(0, 41, 0);
+@@ -87,7 +87,7 @@ public class EntityTrackerIntegrationTest {
+     }
+ 
+     @Test
+-    public void viewable(Env env) {
++    void viewable(Env env) {
+         final Instance instance = env.createFlatInstance();
+         final Pos spawnPos = new Pos(0, 41, 0);
+         var viewable = instance.getEntityTracker().viewable(spawnPos.chunkX(), spawnPos.chunkZ());
+@@ -105,7 +105,7 @@ public class EntityTrackerIntegrationTest {
+     }
+ 
+     @Test
+-    public void viewableShared(Env env) {
++    void viewableShared(Env env) {
+         final InstanceContainer instance = (InstanceContainer) env.createFlatInstance();
+         var shared = env.process().instance().createSharedInstance(instance);
+         var sharedList = instance.getSharedInstances();
+diff --git a/src/test/java/net/minestom/server/instance/EntityTrackerTest.java b/src/test/java/net/minestom/server/instance/EntityTrackerTest.java
+index 45508ef388c32099b2bdac4a7a75808be3ce6d6c..fa1ed75e21bb788e634b9202605c26b2fa594d46 100644
+--- a/src/test/java/net/minestom/server/instance/EntityTrackerTest.java
++++ b/src/test/java/net/minestom/server/instance/EntityTrackerTest.java
+@@ -11,9 +11,9 @@ import java.util.Set;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class EntityTrackerTest {
++class EntityTrackerTest {
+     @Test
+-    public void register() {
++    void register() {
+         var ent1 = new Entity(EntityType.ZOMBIE);
+         var updater = new EntityTracker.Update<>() {
+             @Override
+@@ -40,7 +40,7 @@ public class EntityTrackerTest {
+     }
+ 
+     @Test
+-    public void move() {
++    void move() {
+         var ent1 = new Entity(EntityType.ZOMBIE);
+         var updater = new EntityTracker.Update<>() {
+             @Override
+@@ -65,7 +65,7 @@ public class EntityTrackerTest {
+     }
+ 
+     @Test
+-    public void tracking() {
++    void tracking() {
+         var ent1 = new Entity(EntityType.ZOMBIE);
+         var ent2 = new Entity(EntityType.ZOMBIE);
+ 
+@@ -124,7 +124,7 @@ public class EntityTrackerTest {
+     }
+ 
+     @Test
+-    public void nearby() {
++    void nearby() {
+         var ent1 = new Entity(EntityType.ZOMBIE);
+         var ent2 = new Entity(EntityType.ZOMBIE);
+         var ent3 = new Entity(EntityType.ZOMBIE);
+@@ -177,7 +177,7 @@ public class EntityTrackerTest {
+     }
+ 
+     @Test
+-    public void nearbySingleChunk() {
++    void nearbySingleChunk() {
+         var ent1 = new Entity(EntityType.ZOMBIE);
+         var ent2 = new Entity(EntityType.ZOMBIE);
+         var ent3 = new Entity(EntityType.ZOMBIE);
+@@ -217,7 +217,7 @@ public class EntityTrackerTest {
+     }
+ 
+     @Test
+-    public void collectionView() {
++    void collectionView() {
+         var ent1 = new Entity(EntityType.ZOMBIE);
+         var updater = new EntityTracker.Update<>() {
+             @Override
+diff --git a/src/test/java/net/minestom/server/instance/GeneratorForkConsumerIntegrationTest.java b/src/test/java/net/minestom/server/instance/GeneratorForkConsumerIntegrationTest.java
+index d4a50690b4a443799941034fd6124078a9336565..8cdd2f611a9228e3fa50449689625ba6a52ea23e 100644
+--- a/src/test/java/net/minestom/server/instance/GeneratorForkConsumerIntegrationTest.java
++++ b/src/test/java/net/minestom/server/instance/GeneratorForkConsumerIntegrationTest.java
+@@ -14,10 +14,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertNull;
+ 
+ @EnvTest
+-public class GeneratorForkConsumerIntegrationTest {
++class GeneratorForkConsumerIntegrationTest {
+ 
+     @Test
+-    public void empty(Env env) {
++    void empty(Env env) {
+         var manager = env.process().instance();
+         var instance = manager.createInstanceContainer();
+         AtomicReference<Exception> failed = new AtomicReference<>();
+@@ -34,61 +34,55 @@ public class GeneratorForkConsumerIntegrationTest {
+     }
+ 
+     @Test
+-    public void local(Env env) {
++    void local(Env env) {
+         var manager = env.process().instance();
+         var instance = manager.createInstanceContainer();
+-        instance.setGenerator(unit -> {
+-            unit.fork(setter -> {
+-                var dynamic = (GeneratorImpl.DynamicFork) setter;
+-                assertNull(dynamic.minSection);
+-                assertEquals(0, dynamic.width);
+-                assertEquals(0, dynamic.height);
+-                assertEquals(0, dynamic.depth);
+-                setter.setBlock(unit.absoluteStart(), Block.STONE);
+-                assertEquals(unit.absoluteStart(), dynamic.minSection);
+-                assertEquals(1, dynamic.width);
+-                assertEquals(1, dynamic.height);
+-                assertEquals(1, dynamic.depth);
+-            });
+-        });
++        instance.setGenerator(unit -> unit.fork(setter -> {
++            var dynamic = (GeneratorImpl.DynamicFork) setter;
++            assertNull(dynamic.minSection);
++            assertEquals(0, dynamic.width);
++            assertEquals(0, dynamic.height);
++            assertEquals(0, dynamic.depth);
++            setter.setBlock(unit.absoluteStart(), Block.STONE);
++            assertEquals(unit.absoluteStart(), dynamic.minSection);
++            assertEquals(1, dynamic.width);
++            assertEquals(1, dynamic.height);
++            assertEquals(1, dynamic.depth);
++        }));
+         instance.loadChunk(0, 0).join();
+         assertEquals(Block.STONE, instance.getBlock(0, -64, 0));
+     }
+ 
+     @Test
+-    public void doubleLocal(Env env) {
++    void doubleLocal(Env env) {
+         var manager = env.process().instance();
+         var instance = manager.createInstanceContainer();
+-        instance.setGenerator(unit -> {
+-            unit.fork(setter -> {
+-                setter.setBlock(unit.absoluteStart(), Block.STONE);
+-                setter.setBlock(unit.absoluteStart().add(1, 0, 0), Block.STONE);
+-            });
+-        });
++        instance.setGenerator(unit -> unit.fork(setter -> {
++            setter.setBlock(unit.absoluteStart(), Block.STONE);
++            setter.setBlock(unit.absoluteStart().add(1, 0, 0), Block.STONE);
++        }));
+         instance.loadChunk(0, 0).join();
+         assertEquals(Block.STONE, instance.getBlock(0, -64, 0));
+         assertEquals(Block.STONE, instance.getBlock(1, -64, 0));
+     }
+ 
+     @Test
+-    public void neighborZ(Env env) {
++    void neighborZ(Env env) {
+         var manager = env.process().instance();
+         var instance = manager.createInstanceContainer();
+-        instance.setGenerator(unit -> {
+-            unit.fork(setter -> {
+-                var dynamic = (GeneratorImpl.DynamicFork) setter;
+-                assertNull(dynamic.minSection);
+-                assertEquals(0, dynamic.width);
+-                assertEquals(0, dynamic.height);
+-                assertEquals(0, dynamic.depth);
+-                setter.setBlock(unit.absoluteStart(), Block.STONE);
+-                setter.setBlock(unit.absoluteStart().add(0, 0, 16), Block.GRASS);
+-                assertEquals(unit.absoluteStart(), dynamic.minSection);
+-                assertEquals(1, dynamic.width);
+-                assertEquals(1, dynamic.height);
+-                assertEquals(2, dynamic.depth);
+-            });
+-        });
++        instance.setGenerator(unit -> unit.fork(setter -> {
++            var dynamic = (GeneratorImpl.DynamicFork) setter;
++            assertNull(dynamic.minSection);
++            assertEquals(0, dynamic.width);
++            assertEquals(0, dynamic.height);
++            assertEquals(0, dynamic.depth);
++            setter.setBlock(unit.absoluteStart(), Block.STONE);
++            setter.setBlock(unit.absoluteStart().add(0, 0, 16), Block.GRASS);
++            assertEquals(unit.absoluteStart(), dynamic.minSection);
++            assertEquals(1, dynamic.width);
++            assertEquals(1, dynamic.height);
++            assertEquals(2, dynamic.depth);
++        }));
+         instance.loadChunk(0, 0).join();
+         instance.setGenerator(null);
+         instance.loadChunk(0, 1).join();
+@@ -97,24 +91,22 @@ public class GeneratorForkConsumerIntegrationTest {
+     }
+ 
+     @Test
+-    public void neighborX(Env env) {
++    void neighborX(Env env) {
+         var manager = env.process().instance();
+         var instance = manager.createInstanceContainer();
+-        instance.setGenerator(unit -> {
+-            unit.fork(setter -> {
+-                var dynamic = (GeneratorImpl.DynamicFork) setter;
+-                assertNull(dynamic.minSection);
+-                assertEquals(0, dynamic.width);
+-                assertEquals(0, dynamic.height);
+-                assertEquals(0, dynamic.depth);
+-                setter.setBlock(unit.absoluteStart(), Block.STONE);
+-                setter.setBlock(unit.absoluteStart().add(16, 0, 0), Block.GRASS);
+-                assertEquals(unit.absoluteStart(), dynamic.minSection);
+-                assertEquals(2, dynamic.width);
+-                assertEquals(1, dynamic.height);
+-                assertEquals(1, dynamic.depth);
+-            });
+-        });
++        instance.setGenerator(unit -> unit.fork(setter -> {
++            var dynamic = (GeneratorImpl.DynamicFork) setter;
++            assertNull(dynamic.minSection);
++            assertEquals(0, dynamic.width);
++            assertEquals(0, dynamic.height);
++            assertEquals(0, dynamic.depth);
++            setter.setBlock(unit.absoluteStart(), Block.STONE);
++            setter.setBlock(unit.absoluteStart().add(16, 0, 0), Block.GRASS);
++            assertEquals(unit.absoluteStart(), dynamic.minSection);
++            assertEquals(2, dynamic.width);
++            assertEquals(1, dynamic.height);
++            assertEquals(1, dynamic.depth);
++        }));
+         instance.loadChunk(0, 0).join();
+         instance.setGenerator(null);
+         instance.loadChunk(1, 0).join();
+@@ -123,31 +115,29 @@ public class GeneratorForkConsumerIntegrationTest {
+     }
+ 
+     @Test
+-    public void neighborY(Env env) {
++    void neighborY(Env env) {
+         var manager = env.process().instance();
+         var instance = manager.createInstanceContainer();
+-        instance.setGenerator(unit -> {
+-            unit.fork(setter -> {
+-                var dynamic = (GeneratorImpl.DynamicFork) setter;
+-                assertNull(dynamic.minSection);
+-                assertEquals(0, dynamic.width);
+-                assertEquals(0, dynamic.height);
+-                assertEquals(0, dynamic.depth);
+-                setter.setBlock(unit.absoluteStart(), Block.STONE);
+-                setter.setBlock(unit.absoluteStart().add(0, 16, 0), Block.GRASS);
+-                assertEquals(unit.absoluteStart(), dynamic.minSection);
+-                assertEquals(1, dynamic.width);
+-                assertEquals(2, dynamic.height);
+-                assertEquals(1, dynamic.depth);
+-            });
+-        });
++        instance.setGenerator(unit -> unit.fork(setter -> {
++            var dynamic = (GeneratorImpl.DynamicFork) setter;
++            assertNull(dynamic.minSection);
++            assertEquals(0, dynamic.width);
++            assertEquals(0, dynamic.height);
++            assertEquals(0, dynamic.depth);
++            setter.setBlock(unit.absoluteStart(), Block.STONE);
++            setter.setBlock(unit.absoluteStart().add(0, 16, 0), Block.GRASS);
++            assertEquals(unit.absoluteStart(), dynamic.minSection);
++            assertEquals(1, dynamic.width);
++            assertEquals(2, dynamic.height);
++            assertEquals(1, dynamic.depth);
++        }));
+         instance.loadChunk(0, 0).join();
+         assertEquals(Block.STONE, instance.getBlock(0, -64, 0));
+         assertEquals(Block.GRASS, instance.getBlock(0, -48, 0));
+     }
+ 
+     @Test
+-    public void verticalAndHorizontalSectionBorders(Env env) {
++    void verticalAndHorizontalSectionBorders(Env env) {
+         var manager = env.process().instance();
+         var instance = manager.createInstanceContainer();
+         Set<Point> points = ConcurrentHashMap.newKeySet();
+diff --git a/src/test/java/net/minestom/server/instance/GeneratorForkIntegrationTest.java b/src/test/java/net/minestom/server/instance/GeneratorForkIntegrationTest.java
+index ec9b91cebac942d77f6e027b5be9fc04bf2f7eb9..3580264ac43c7268834e53315d968afe480e707c 100644
+--- a/src/test/java/net/minestom/server/instance/GeneratorForkIntegrationTest.java
++++ b/src/test/java/net/minestom/server/instance/GeneratorForkIntegrationTest.java
+@@ -11,10 +11,10 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+ @EnvTest
+-public class GeneratorForkIntegrationTest {
++class GeneratorForkIntegrationTest {
+ 
+     @Test
+-    public void local(Env env) {
++    void local(Env env) {
+         var manager = env.process().instance();
+         var instance = manager.createInstanceContainer();
+         var block = Block.STONE;
+@@ -29,7 +29,7 @@ public class GeneratorForkIntegrationTest {
+     }
+ 
+     @Test
+-    public void size(Env env) {
++    void size(Env env) {
+         var manager = env.process().instance();
+         var instance = manager.createInstanceContainer();
+         // Set the Generator
+@@ -46,7 +46,7 @@ public class GeneratorForkIntegrationTest {
+     }
+ 
+     @Test
+-    public void signal(Env env) {
++    void signal(Env env) {
+         var manager = env.process().instance();
+         var instance = manager.createInstanceContainer();
+         var block = Block.STONE;
+@@ -65,7 +65,7 @@ public class GeneratorForkIntegrationTest {
+     }
+ 
+     @Test
+-    public void air(Env env) {
++    void air(Env env) {
+         var manager = env.process().instance();
+         var instance = manager.createInstanceContainer();
+         instance.setGenerator(unit -> {
+@@ -79,7 +79,7 @@ public class GeneratorForkIntegrationTest {
+     }
+ 
+     @Test
+-    public void fillHeight(Env env) {
++    void fillHeight(Env env) {
+         var manager = env.process().instance();
+         var instance = manager.createInstanceContainer();
+         instance.setGenerator(unit -> {
+@@ -95,7 +95,7 @@ public class GeneratorForkIntegrationTest {
+     }
+ 
+     @Test
+-    public void biome(Env env) {
++    void biome(Env env) {
+         var manager = env.process().instance();
+         var instance = manager.createInstanceContainer();
+         instance.setGenerator(unit -> {
+diff --git a/src/test/java/net/minestom/server/instance/GeneratorIntegrationTest.java b/src/test/java/net/minestom/server/instance/GeneratorIntegrationTest.java
+index e2ddf7d46b58c61ed33dd81c275428736dcf23b6..ce1e765ee0f3f0cc4319b63933d62511999d222e 100644
+--- a/src/test/java/net/minestom/server/instance/GeneratorIntegrationTest.java
++++ b/src/test/java/net/minestom/server/instance/GeneratorIntegrationTest.java
+@@ -15,11 +15,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertSame;
+ 
+ @EnvTest
+-public class GeneratorIntegrationTest {
++class GeneratorIntegrationTest {
+ 
+     @ParameterizedTest
+     @ValueSource(booleans = {false, true})
+-    public void loader(boolean data, Env env) {
++    void loader(boolean data, Env env) {
+         var manager = env.process().instance();
+         var block = data ? Block.STONE.withNbt(NBT.Compound(Map.of("key", NBT.String("value")))) : Block.STONE;
+         var instance = manager.createInstanceContainer();
+@@ -32,7 +32,7 @@ public class GeneratorIntegrationTest {
+     }
+ 
+     @Test
+-    public void exceptionCatch(Env env) {
++    void exceptionCatch(Env env) {
+         var manager = env.process().instance();
+         var instance = manager.createInstanceContainer();
+ 
+@@ -50,7 +50,7 @@ public class GeneratorIntegrationTest {
+     }
+ 
+     @Test
+-    public void fillHeightNegative(Env env) {
++    void fillHeightNegative(Env env) {
+         var manager = env.process().instance();
+         var instance = manager.createInstanceContainer();
+         instance.setGenerator(unit -> unit.modifier().fillHeight(-64, -60, Block.STONE));
+@@ -64,7 +64,7 @@ public class GeneratorIntegrationTest {
+     }
+ 
+     @Test
+-    public void fillHeightSingleSectionFull(Env env) {
++    void fillHeightSingleSectionFull(Env env) {
+         var manager = env.process().instance();
+         var instance = manager.createInstanceContainer();
+         instance.setGenerator(unit -> unit.modifier().fillHeight(0, 16, Block.GRASS_BLOCK));
+@@ -75,7 +75,7 @@ public class GeneratorIntegrationTest {
+     }
+ 
+     @Test
+-    public void fillHeightSingleSection(Env env) {
++    void fillHeightSingleSection(Env env) {
+         var manager = env.process().instance();
+         var instance = manager.createInstanceContainer();
+         instance.setGenerator(unit -> unit.modifier().fillHeight(4, 5, Block.GRASS_BLOCK));
+@@ -86,7 +86,7 @@ public class GeneratorIntegrationTest {
+     }
+ 
+     @Test
+-    public void fillHeightOverride(Env env) {
++    void fillHeightOverride(Env env) {
+         var manager = env.process().instance();
+         var instance = manager.createInstanceContainer();
+         instance.setGenerator(unit -> {
+diff --git a/src/test/java/net/minestom/server/instance/GeneratorTest.java b/src/test/java/net/minestom/server/instance/GeneratorTest.java
+index 4a53ede725c99c4448e28d11625476eed34189c5..ad3ba534f6a91b90a713518aba46ac260fbcdd72 100644
+--- a/src/test/java/net/minestom/server/instance/GeneratorTest.java
++++ b/src/test/java/net/minestom/server/instance/GeneratorTest.java
+@@ -25,10 +25,10 @@ import static net.minestom.server.utils.chunk.ChunkUtils.ceilSection;
+ import static net.minestom.server.utils.chunk.ChunkUtils.floorSection;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class GeneratorTest {
++class GeneratorTest {
+ 
+     @Test
+-    public void unitSize() {
++    void unitSize() {
+         assertDoesNotThrow(() -> dummyUnit(Vec.ZERO, new Vec(16)));
+         assertDoesNotThrow(() -> dummyUnit(new Vec(16), new Vec(32)));
+         assertThrows(IllegalArgumentException.class, () -> dummyUnit(new Vec(15), Vec.ZERO));
+@@ -39,7 +39,7 @@ public class GeneratorTest {
+ 
+     @ParameterizedTest
+     @MethodSource("sectionFloorParam")
+-    public void sectionFloor(int expected, int input) {
++    void sectionFloor(int expected, int input) {
+         assertEquals(expected, floorSection(input), "floorSection(" + input + ")");
+     }
+ 
+@@ -58,7 +58,7 @@ public class GeneratorTest {
+ 
+     @ParameterizedTest
+     @MethodSource("sectionCeilParam")
+-    public void sectionCeil(int expected, int input) {
++    void sectionCeil(int expected, int input) {
+         assertEquals(expected, ceilSection(input), "ceilSection(" + input + ")");
+     }
+ 
+@@ -76,7 +76,7 @@ public class GeneratorTest {
+     }
+ 
+     @Test
+-    public void chunkSize() {
++    void chunkSize() {
+         final int minSection = 0;
+         final int maxSection = 5;
+         final int chunkX = 3;
+@@ -91,7 +91,7 @@ public class GeneratorTest {
+     }
+ 
+     @Test
+-    public void chunkSizeNeg() {
++    void chunkSizeNeg() {
+         final int minSection = -1;
+         final int maxSection = 5;
+         final int chunkX = 3;
+@@ -106,7 +106,7 @@ public class GeneratorTest {
+     }
+ 
+     @Test
+-    public void sectionSize() {
++    void sectionSize() {
+         final int sectionX = 3;
+         final int sectionY = -5;
+         final int sectionZ = -2;
+@@ -117,7 +117,7 @@ public class GeneratorTest {
+     }
+ 
+     @Test
+-    public void chunkSubdivide() {
++    void chunkSubdivide() {
+         final int minSection = -1;
+         final int maxSection = 5;
+         final int chunkX = 3;
+@@ -137,7 +137,7 @@ public class GeneratorTest {
+     }
+ 
+     @Test
+-    public void chunkAbsolute() {
++    void chunkAbsolute() {
+         final int minSection = 0;
+         final int maxSection = 5;
+         final int chunkX = 3;
+@@ -158,7 +158,7 @@ public class GeneratorTest {
+     }
+ 
+     @Test
+-    public void chunkAbsoluteAll() {
++    void chunkAbsoluteAll() {
+         final int minSection = 0;
+         final int maxSection = 5;
+         final int chunkX = 3;
+@@ -186,7 +186,7 @@ public class GeneratorTest {
+     }
+ 
+     @Test
+-    public void chunkRelative() {
++    void chunkRelative() {
+         final int minSection = -1;
+         final int maxSection = 5;
+         final int chunkX = 3;
+@@ -213,7 +213,7 @@ public class GeneratorTest {
+     }
+ 
+     @Test
+-    public void chunkRelativeAll() {
++    void chunkRelativeAll() {
+         final int minSection = -1;
+         final int maxSection = 5;
+         final int chunkX = 3;
+@@ -242,7 +242,7 @@ public class GeneratorTest {
+     }
+ 
+     @Test
+-    public void chunkBiomeSet() {
++    void chunkBiomeSet() {
+         final int minSection = -1;
+         final int maxSection = 5;
+         final int chunkX = 3;
+@@ -263,7 +263,7 @@ public class GeneratorTest {
+     }
+ 
+     @Test
+-    public void chunkBiomeFill() {
++    void chunkBiomeFill() {
+         final int minSection = -1;
+         final int maxSection = 5;
+         final int chunkX = 3;
+@@ -284,7 +284,7 @@ public class GeneratorTest {
+     }
+ 
+     @Test
+-    public void chunkFillHeightExact() {
++    void chunkFillHeightExact() {
+         final int minSection = -1;
+         final int maxSection = 5;
+         final int sectionCount = maxSection - minSection;
+@@ -308,7 +308,7 @@ public class GeneratorTest {
+     }
+ 
+     @Test
+-    public void chunkFillHeightOneOff() {
++    void chunkFillHeightOneOff() {
+         final int minSection = -1;
+         final int maxSection = 5;
+         final int sectionCount = maxSection - minSection;
+@@ -346,7 +346,7 @@ public class GeneratorTest {
+     }
+ 
+     @Test
+-    public void sectionFill() {
++    void sectionFill() {
+         Section section = new Section();
+         var chunkUnit = GeneratorImpl.section(section, -1, -1, 0);
+         Generator generator = chunk -> chunk.modifier().fill(Block.STONE);
+diff --git a/src/test/java/net/minestom/server/instance/InstanceBlockIntegrationTest.java b/src/test/java/net/minestom/server/instance/InstanceBlockIntegrationTest.java
+index 5b0d774bc9d87540382de3b88f48f7542f8f473c..fc21a2c8e00e201b266f6e71d90249dc71b1cce6 100644
+--- a/src/test/java/net/minestom/server/instance/InstanceBlockIntegrationTest.java
++++ b/src/test/java/net/minestom/server/instance/InstanceBlockIntegrationTest.java
+@@ -11,10 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertThrows;
+ 
+ @EnvTest
+-public class InstanceBlockIntegrationTest {
++class InstanceBlockIntegrationTest {
+ 
+     @Test
+-    public void basic(Env env) {
++    void basic(Env env) {
+         var instance = env.createFlatInstance();
+         assertThrows(NullPointerException.class, () -> instance.getBlock(0, 0, 0),
+                 "No exception throw when getting a block in an unloaded chunk");
+@@ -35,7 +35,7 @@ public class InstanceBlockIntegrationTest {
+     }
+ 
+     @Test
+-    public void unloadCache(Env env) {
++    void unloadCache(Env env) {
+         var instance = env.createFlatInstance();
+         instance.loadChunk(0, 0).join();
+ 
+@@ -51,7 +51,7 @@ public class InstanceBlockIntegrationTest {
+     }
+ 
+     @Test
+-    public void blockNbt(Env env) {
++    void blockNbt(Env env) {
+         var instance = env.createFlatInstance();
+         assertThrows(NullPointerException.class, () -> instance.getBlock(0, 0, 0),
+                 "No exception throw when getting a block in an unloaded chunk");
+diff --git a/src/test/java/net/minestom/server/instance/InstanceBlockPacketIntegrationTest.java b/src/test/java/net/minestom/server/instance/InstanceBlockPacketIntegrationTest.java
+index 32e9b8703842e4e46428f99dc9fed81071e0743d..8b1d5556d34625eaa516499b1c9a702914f4fbf6 100644
+--- a/src/test/java/net/minestom/server/instance/InstanceBlockPacketIntegrationTest.java
++++ b/src/test/java/net/minestom/server/instance/InstanceBlockPacketIntegrationTest.java
+@@ -22,10 +22,10 @@ import java.util.List;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+ @EnvTest
+-public class InstanceBlockPacketIntegrationTest {
++class InstanceBlockPacketIntegrationTest {
+ 
+     @Test
+-    public void replaceAir(Env env) {
++    void replaceAir(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         connection.connect(instance, new Pos(0, 40, 0)).join();
+@@ -45,7 +45,7 @@ public class InstanceBlockPacketIntegrationTest {
+     }
+ 
+     @Test
+-    public void placeBlockEntity(Env env) {
++    void placeBlockEntity(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         connection.connect(instance, new Pos(0, 40, 0)).join();
+diff --git a/src/test/java/net/minestom/server/instance/InstanceEventsIntegrationTest.java b/src/test/java/net/minestom/server/instance/InstanceEventsIntegrationTest.java
+index 8f2404e5a4c06d98955ac7e2218ceb203f8b4fe5..7fd9f89ee545d55b58c35135ca502cdccadd9cac 100644
+--- a/src/test/java/net/minestom/server/instance/InstanceEventsIntegrationTest.java
++++ b/src/test/java/net/minestom/server/instance/InstanceEventsIntegrationTest.java
+@@ -7,9 +7,9 @@ import net.minestom.testing.EnvTest;
+ import org.junit.jupiter.api.Test;
+ 
+ @EnvTest
+-public class InstanceEventsIntegrationTest {
++class InstanceEventsIntegrationTest {
+     @Test
+-    public void registerAndUnregisterInstance(Env env) {
++    void registerAndUnregisterInstance(Env env) {
+         var registerListener = env.listen(InstanceRegisterEvent.class);
+         var unregisterListener = env.listen(InstanceUnregisterEvent.class);
+ 
+diff --git a/src/test/java/net/minestom/server/instance/InstanceUnregisterIntegrationTest.java b/src/test/java/net/minestom/server/instance/InstanceUnregisterIntegrationTest.java
+index ed7173f89fe078072270f4f41e66c22e1c8766a6..c830e87e18e6039b5b644945d8e909d987e4bed6 100644
+--- a/src/test/java/net/minestom/server/instance/InstanceUnregisterIntegrationTest.java
++++ b/src/test/java/net/minestom/server/instance/InstanceUnregisterIntegrationTest.java
+@@ -15,10 +15,10 @@ import java.util.UUID;
+ import static net.minestom.testing.TestUtils.waitUntilCleared;
+ 
+ @EnvTest
+-public class InstanceUnregisterIntegrationTest {
++class InstanceUnregisterIntegrationTest {
+ 
+     @Test
+-    public void sharedInstance(Env env) {
++    void sharedInstance(Env env) {
+         // Ensure that unregistering a shared instance does not unload the container chunks
+         var instanceManager = env.process().instance();
+         var instance = instanceManager.createInstanceContainer();
+@@ -40,7 +40,7 @@ public class InstanceUnregisterIntegrationTest {
+     }
+ 
+     @Test
+-    public void instanceGC(Env env) {
++    void instanceGC(Env env) {
+         var instance = env.createFlatInstance();
+         var ref = new WeakReference<>(instance);
+         env.process().instance().unregisterInstance(instance);
+@@ -51,7 +51,7 @@ public class InstanceUnregisterIntegrationTest {
+     }
+ 
+     @Test
+-    public void instanceNodeGC(Env env) {
++    void instanceNodeGC(Env env) {
+         final class Game {
+             final Instance instance;
+ 
+@@ -70,7 +70,7 @@ public class InstanceUnregisterIntegrationTest {
+     }
+ 
+     @Test
+-    public void chunkGC(Env env) {
++    void chunkGC(Env env) {
+         // Ensure that unregistering an instance does release its chunks
+         var instance = env.createFlatInstance();
+         var chunk = instance.loadChunk(0, 0).join();
+@@ -85,7 +85,7 @@ public class InstanceUnregisterIntegrationTest {
+     }
+ 
+     @Test
+-    public void testGCWithEventsLambda(Env env) {
++    void testGCWithEventsLambda(Env env) {
+         var ref = new WeakReference<>(new InstanceContainer(UUID.randomUUID(), DimensionType.OVERWORLD));
+         env.process().instance().registerInstance(ref.get());
+ 
+diff --git a/src/test/java/net/minestom/server/instance/WorldBorderIntegrationTest.java b/src/test/java/net/minestom/server/instance/WorldBorderIntegrationTest.java
+index 01c4c935fec5e312f6043106acac4d16520a3b9a..01c68deb717f2ce5f43406c93adda353c40cf397 100644
+--- a/src/test/java/net/minestom/server/instance/WorldBorderIntegrationTest.java
++++ b/src/test/java/net/minestom/server/instance/WorldBorderIntegrationTest.java
+@@ -7,10 +7,10 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+ @EnvTest
+-public class WorldBorderIntegrationTest {
++class WorldBorderIntegrationTest {
+ 
+     @Test
+-    public void setWorldborderSize(Env env) {
++    void setWorldborderSize(Env env) {
+         Instance instance = env.createFlatInstance();
+ 
+         instance.getWorldBorder().setDiameter(50.0);
+@@ -20,7 +20,7 @@ public class WorldBorderIntegrationTest {
+     }
+ 
+     @Test
+-    public void resizeWorldBorder(Env env) throws InterruptedException {
++    void resizeWorldBorder(Env env) throws InterruptedException {
+         Instance instance = env.createFlatInstance();
+ 
+         instance.getWorldBorder().setDiameter(50.0);
+diff --git a/src/test/java/net/minestom/server/instance/palette/PaletteOptimizationTest.java b/src/test/java/net/minestom/server/instance/palette/PaletteOptimizationTest.java
+index 9916d52ab23c645388ed4c6c215bf7203fb4bdc0..877f265955d81dba590da8166e994c0e4ec8854a 100644
+--- a/src/test/java/net/minestom/server/instance/palette/PaletteOptimizationTest.java
++++ b/src/test/java/net/minestom/server/instance/palette/PaletteOptimizationTest.java
+@@ -8,23 +8,23 @@ import java.util.Random;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertTrue;
+ 
+-public class PaletteOptimizationTest {
++class PaletteOptimizationTest {
+ 
+     @Test
+-    public void empty() {
++    void empty() {
+         var palette = createPalette();
+         paletteEquals(palette.palette, palette.optimizedPalette());
+     }
+ 
+     @Test
+-    public void single() {
++    void single() {
+         var palette = createPalette();
+         palette.set(0, 0, 0, 1);
+         paletteEquals(palette.palette, palette.optimizedPalette());
+     }
+ 
+     @Test
+-    public void random() {
++    void random() {
+         var random = new Random(12345);
+         var palette = createPalette();
+         palette.setAll((x, y, z) -> random.nextInt(256));
+@@ -34,7 +34,7 @@ public class PaletteOptimizationTest {
+     }
+ 
+     @Test
+-    public void manualFill() {
++    void manualFill() {
+         var palette = createPalette();
+         palette.setAll((x, y, z) -> 1);
+         paletteEquals(palette.palette, palette.optimizedPalette());
+diff --git a/src/test/java/net/minestom/server/instance/palette/PaletteTest.java b/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
+index 3372ade456530be692de5f74e8c9515d32614df2..583214ea6d1a4bb59956ee727644f571bba6484c 100644
+--- a/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
++++ b/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
+@@ -11,17 +11,17 @@ import java.util.concurrent.atomic.AtomicInteger;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class PaletteTest {
++class PaletteTest {
+ 
+     @Test
+-    public void singlePlacement() {
++    void singlePlacement() {
+         var palette = Palette.blocks();
+         palette.set(0, 0, 1, 1);
+         assertEquals(1, palette.get(0, 0, 1));
+     }
+ 
+     @Test
+-    public void placement() {
++    void placement() {
+         var palettes = testPalettes();
+         for (Palette palette : palettes) {
+             final int dimension = palette.dimension();
+@@ -56,7 +56,7 @@ public class PaletteTest {
+     }
+ 
+     @Test
+-    public void placementHighValue() {
++    void placementHighValue() {
+         final int value = 250_000;
+         for (Palette palette : testPalettes()) {
+             palette.set(0, 0, 1, value);
+@@ -65,7 +65,7 @@ public class PaletteTest {
+     }
+ 
+     @Test
+-    public void negPlacement() {
++    void negPlacement() {
+         var palettes = testPalettes();
+         for (Palette palette : palettes) {
+             assertThrows(IllegalArgumentException.class, () -> palette.set(-1, 0, 0, 64));
+@@ -79,7 +79,7 @@ public class PaletteTest {
+     }
+ 
+     @Test
+-    public void resize() {
++    void resize() {
+         Palette palette = Palette.newPalette(16, 5, 2);
+         palette.set(0, 0, 0, 1);
+         assertEquals(2, palette.bitsPerEntry());
+@@ -98,7 +98,7 @@ public class PaletteTest {
+ 
+ 
+     @Test
+-    public void fill() {
++    void fill() {
+         var palettes = testPalettes();
+         for (Palette palette : palettes) {
+             assertEquals(0, palette.count());
+@@ -129,7 +129,7 @@ public class PaletteTest {
+     }
+ 
+     @Test
+-    public void bulk() {
++    void bulk() {
+         var palettes = testPalettes();
+         for (Palette palette : palettes) {
+             final int dimension = palette.dimension();
+@@ -154,7 +154,7 @@ public class PaletteTest {
+     }
+ 
+     @Test
+-    public void bulkAll() {
++    void bulkAll() {
+         var palettes = testPalettes();
+         for (Palette palette : palettes) {
+             // Fill all entries
+@@ -172,7 +172,7 @@ public class PaletteTest {
+     }
+ 
+     @Test
+-    public void bulkAllOrder() {
++    void bulkAllOrder() {
+         var palettes = testPalettes();
+         for (Palette palette : palettes) {
+             AtomicInteger count = new AtomicInteger();
+@@ -210,7 +210,7 @@ public class PaletteTest {
+     }
+ 
+     @Test
+-    public void setAllConstant() {
++    void setAllConstant() {
+         var palettes = testPalettes();
+         for (Palette palette : palettes) {
+             palette.setAll((x, y, z) -> 1);
+@@ -219,7 +219,7 @@ public class PaletteTest {
+     }
+ 
+     @Test
+-    public void getAllPresent() {
++    void getAllPresent() {
+         var palettes = testPalettes();
+         for (Palette palette : palettes) {
+             palette.getAllPresent((x, y, z, value) -> fail("The palette should be empty"));
+@@ -234,7 +234,7 @@ public class PaletteTest {
+     }
+ 
+     @Test
+-    public void replaceAll() {
++    void replaceAll() {
+         var palettes = testPalettes();
+         for (Palette palette : palettes) {
+             palette.setAll((x, y, z) -> x + y + z + 1);
+@@ -247,7 +247,7 @@ public class PaletteTest {
+     }
+ 
+     @Test
+-    public void replace() {
++    void replace() {
+         var palettes = testPalettes();
+         for (Palette palette : palettes) {
+             palette.set(0, 0, 0, 1);
+@@ -260,7 +260,7 @@ public class PaletteTest {
+     }
+ 
+     @Test
+-    public void replaceLoop() {
++    void replaceLoop() {
+         var palette = Palette.newPalette(2, 15, 4);
+         palette.setAll((x, y, z) -> x + y + z);
+         final int dimension = palette.dimension();
+@@ -274,7 +274,7 @@ public class PaletteTest {
+     }
+ 
+     @Test
+-    public void dimension() {
++    void dimension() {
+         assertThrows(Exception.class, () -> Palette.newPalette(-4, 5, 3));
+         assertThrows(Exception.class, () -> Palette.newPalette(0, 5, 3));
+         assertThrows(Exception.class, () -> Palette.newPalette(1, 5, 3));
+diff --git a/src/test/java/net/minestom/server/inventory/InventoryIntegrationTest.java b/src/test/java/net/minestom/server/inventory/InventoryIntegrationTest.java
+index d0df75b49e882760cc1813ff813c2882a5870c61..ed95d0daf7d90aa7e7ab926500766416aacfc21b 100644
+--- a/src/test/java/net/minestom/server/inventory/InventoryIntegrationTest.java
++++ b/src/test/java/net/minestom/server/inventory/InventoryIntegrationTest.java
+@@ -15,12 +15,12 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+ @EnvTest
+-public class InventoryIntegrationTest {
++class InventoryIntegrationTest {
+ 
+     private static final ItemStack MAGIC_STACK = ItemStack.of(Material.DIAMOND, 3);
+ 
+     @Test
+-    public void setSlotDuplicateTest(Env env) {
++    void setSlotDuplicateTest(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var player = connection.connect(instance, new Pos(0, 42, 0)).join();
+@@ -44,7 +44,7 @@ public class InventoryIntegrationTest {
+     }
+ 
+     @Test
+-    public void setCursorItemDuplicateTest(Env env) {
++    void setCursorItemDuplicateTest(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var player = connection.connect(instance, new Pos(0, 42, 0)).join();
+@@ -68,7 +68,7 @@ public class InventoryIntegrationTest {
+     }
+ 
+     @Test
+-    public void clearInventoryTest(Env env) {
++    void clearInventoryTest(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var player = connection.connect(instance, new Pos(0, 42, 0)).join();
+@@ -111,7 +111,7 @@ public class InventoryIntegrationTest {
+     }
+ 
+     @Test
+-    public void closeInventoryTest(Env env) {
++    void closeInventoryTest(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var player = connection.connect(instance, new Pos(0, 42, 0)).join();
+@@ -123,7 +123,7 @@ public class InventoryIntegrationTest {
+     }
+ 
+     @Test
+-    public void openInventoryOnItemDropFromInventoryClosingTest(Env env) {
++    void openInventoryOnItemDropFromInventoryClosingTest(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var player = connection.connect(instance, new Pos(0, 42, 0)).join();
+diff --git a/src/test/java/net/minestom/server/inventory/InventoryTest.java b/src/test/java/net/minestom/server/inventory/InventoryTest.java
+index 612e3b162f38d6367dc016530270e38d46913281..2f3e637b8939987726dd15fdfedafdca51b9cf48 100644
+--- a/src/test/java/net/minestom/server/inventory/InventoryTest.java
++++ b/src/test/java/net/minestom/server/inventory/InventoryTest.java
+@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class InventoryTest {
++class InventoryTest {
+ 
+     static {
+         // Required to prevent initialization error during event call
+@@ -16,7 +16,7 @@ public class InventoryTest {
+     }
+ 
+     @Test
+-    public void testCreation() {
++    void testCreation() {
+         Inventory inventory = new Inventory(InventoryType.CHEST_1_ROW, "title");
+         assertEquals(InventoryType.CHEST_1_ROW, inventory.getInventoryType());
+         assertEquals(Component.text("title"), inventory.getTitle());
+@@ -26,7 +26,7 @@ public class InventoryTest {
+     }
+ 
+     @Test
+-    public void testEntry() {
++    void testEntry() {
+         var item1 = ItemStack.of(Material.DIAMOND);
+         var item2 = ItemStack.of(Material.GOLD_INGOT);
+ 
+@@ -52,7 +52,7 @@ public class InventoryTest {
+     }
+ 
+     @Test
+-    public void testTake() {
++    void testTake() {
+         ItemStack item = ItemStack.of(Material.DIAMOND, 32);
+         Inventory inventory = new Inventory(InventoryType.CHEST_1_ROW, "title");
+         inventory.setItemStack(0, item);
+@@ -66,7 +66,7 @@ public class InventoryTest {
+     }
+ 
+     @Test
+-    public void testAdd() {
++    void testAdd() {
+         Inventory inventory = new Inventory(InventoryType.HOPPER, "title");
+         assertTrue(inventory.addItemStack(ItemStack.of(Material.DIAMOND, 32), TransactionOption.ALL_OR_NOTHING));
+         assertTrue(inventory.addItemStack(ItemStack.of(Material.GOLD_BLOCK, 32), TransactionOption.ALL_OR_NOTHING));
+@@ -77,7 +77,7 @@ public class InventoryTest {
+     }
+ 
+     @Test
+-    public void testIds() {
++    void testIds() {
+         for (int i = 0; i <= 1000; ++i) {
+             final byte windowId = new Inventory(InventoryType.CHEST_1_ROW, "title").getWindowId();
+             assertTrue(windowId > 0);
+diff --git a/src/test/java/net/minestom/server/inventory/PlayerInventoryIntegrationTest.java b/src/test/java/net/minestom/server/inventory/PlayerInventoryIntegrationTest.java
+index 268a34a27684778f116dbbed910a67fff8ffbfc7..762d5e53f5ee07b36ecda7e68ca6e1b4fb95ccfd 100644
+--- a/src/test/java/net/minestom/server/inventory/PlayerInventoryIntegrationTest.java
++++ b/src/test/java/net/minestom/server/inventory/PlayerInventoryIntegrationTest.java
+@@ -16,12 +16,12 @@ import java.util.Map;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+ @EnvTest
+-public class PlayerInventoryIntegrationTest {
++class PlayerInventoryIntegrationTest {
+ 
+     private static final ItemStack MAGIC_STACK = ItemStack.of(Material.DIAMOND, 3);
+ 
+     @Test
+-    public void setSlotDuplicateTest(Env env) {
++    void setSlotDuplicateTest(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var player = connection.connect(instance, new Pos(0, 42, 0)).join();
+@@ -41,7 +41,7 @@ public class PlayerInventoryIntegrationTest {
+     }
+ 
+     @Test
+-    public void setCursorItemDuplicateTest(Env env) {
++    void setCursorItemDuplicateTest(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var player = connection.connect(instance, new Pos(0, 42, 0)).join();
+@@ -61,7 +61,7 @@ public class PlayerInventoryIntegrationTest {
+     }
+ 
+     @Test
+-    public void clearInventoryTest(Env env) {
++    void clearInventoryTest(Env env) {
+         var instance = env.createFlatInstance();
+         var connection = env.createConnection();
+         var player = connection.connect(instance, new Pos(0, 42, 0)).join();
+@@ -105,7 +105,7 @@ public class PlayerInventoryIntegrationTest {
+     }
+ 
+     @Test
+-    public void equipmentViewTest(Env env) {
++    void equipmentViewTest(Env env) {
+         var instance = env.createFlatInstance();
+         var connectionArmored = env.createConnection();
+         var playerArmored = connectionArmored.connect(instance, new Pos(0, 42, 0)).join();
+@@ -119,9 +119,7 @@ public class PlayerInventoryIntegrationTest {
+ 
+         // Setting to an item should send EntityEquipmentPacket to viewer
+         playerArmored.getInventory().setEquipment(EquipmentSlot.HELMET, MAGIC_STACK);
+-        equipmentTracker.assertSingle(entityEquipmentPacket -> {
+-            assertEquals(MAGIC_STACK, entityEquipmentPacket.equipments().get(EquipmentSlot.HELMET));
+-        });
++        equipmentTracker.assertSingle(entityEquipmentPacket -> assertEquals(MAGIC_STACK, entityEquipmentPacket.equipments().get(EquipmentSlot.HELMET)));
+ 
+         // Setting to the same item shouldn't send packet
+         equipmentTracker = connectionViewer.trackIncoming(EntityEquipmentPacket.class);
+@@ -131,13 +129,11 @@ public class PlayerInventoryIntegrationTest {
+         // Setting to air should send packet
+         equipmentTracker = connectionViewer.trackIncoming(EntityEquipmentPacket.class);
+         playerArmored.getInventory().setEquipment(EquipmentSlot.HELMET, ItemStack.AIR);
+-        equipmentTracker.assertSingle(entityEquipmentPacket -> {
+-            assertEquals(ItemStack.AIR, entityEquipmentPacket.equipments().get(EquipmentSlot.HELMET));
+-        });
++        equipmentTracker.assertSingle(entityEquipmentPacket -> assertEquals(ItemStack.AIR, entityEquipmentPacket.equipments().get(EquipmentSlot.HELMET)));
+     }
+ 
+     @Test
+-    public void heldItemViewTest(Env env) {
++    void heldItemViewTest(Env env) {
+         var instance = env.createFlatInstance();
+         var connectionHolder = env.createConnection();
+         var playerHolder = connectionHolder.connect(instance, new Pos(0, 42, 0)).join();
+@@ -152,23 +148,17 @@ public class PlayerInventoryIntegrationTest {
+         // Setting held item
+         var equipmentTracker = connectionViewer.trackIncoming(EntityEquipmentPacket.class);
+         playerHolder.setItemInMainHand(MAGIC_STACK);
+-        equipmentTracker.assertSingle(entityEquipmentPacket -> {
+-            assertEquals(MAGIC_STACK, entityEquipmentPacket.equipments().get(EquipmentSlot.MAIN_HAND));
+-        });
++        equipmentTracker.assertSingle(entityEquipmentPacket -> assertEquals(MAGIC_STACK, entityEquipmentPacket.equipments().get(EquipmentSlot.MAIN_HAND)));
+ 
+         // Changing held slot to an empty slot should update MAIN_HAND to empty item
+         equipmentTracker = connectionViewer.trackIncoming(EntityEquipmentPacket.class);
+         playerHolder.setHeldItemSlot((byte) 3);
+-        equipmentTracker.assertSingle(entityEquipmentPacket -> {
+-            assertEquals(ItemStack.AIR, entityEquipmentPacket.equipments().get(EquipmentSlot.MAIN_HAND));
+-        });
++        equipmentTracker.assertSingle(entityEquipmentPacket -> assertEquals(ItemStack.AIR, entityEquipmentPacket.equipments().get(EquipmentSlot.MAIN_HAND)));
+ 
+         // Changing held slot to the original slot should update MAIN_HAND to original item
+         equipmentTracker = connectionViewer.trackIncoming(EntityEquipmentPacket.class);
+         playerHolder.setHeldItemSlot((byte) 0);
+-        equipmentTracker.assertSingle(entityEquipmentPacket -> {
+-            assertEquals(MAGIC_STACK, entityEquipmentPacket.equipments().get(EquipmentSlot.MAIN_HAND));
+-        });
++        equipmentTracker.assertSingle(entityEquipmentPacket -> assertEquals(MAGIC_STACK, entityEquipmentPacket.equipments().get(EquipmentSlot.MAIN_HAND)));
+     }
+ 
+ }
+diff --git a/src/test/java/net/minestom/server/inventory/PlayerSlotConversionTest.java b/src/test/java/net/minestom/server/inventory/PlayerSlotConversionTest.java
+index 992051039124e3bf50dd4d667cb7433195f8c735..20e112920723b6046de91875a49757bf2c8a4058 100644
+--- a/src/test/java/net/minestom/server/inventory/PlayerSlotConversionTest.java
++++ b/src/test/java/net/minestom/server/inventory/PlayerSlotConversionTest.java
+@@ -8,10 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+ /**
+  * Test conversion from packet slots to internal ones (used in events and inventory methods)
+  */
+-public class PlayerSlotConversionTest {
++class PlayerSlotConversionTest {
+ 
+     @Test
+-    public void hotbar() {
++    void hotbar() {
+         // Convert 36-44 into 0-8
+         for (int i = 0; i < 9; i++) {
+             assertEquals(i, convertPlayerInventorySlot(i + 36, OFFSET));
+@@ -19,7 +19,7 @@ public class PlayerSlotConversionTest {
+     }
+ 
+     @Test
+-    public void mainInventory() {
++    void mainInventory() {
+         // No conversion, slots should stay 9-35
+         for (int i = 9; i < 9 * 4; i++) {
+             assertEquals(i, convertPlayerInventorySlot(i, OFFSET));
+@@ -27,7 +27,7 @@ public class PlayerSlotConversionTest {
+     }
+ 
+     @Test
+-    public void armor() {
++    void armor() {
+         assertEquals(HELMET_SLOT, 41);
+         assertEquals(CHESTPLATE_SLOT, 42);
+         assertEquals(LEGGINGS_SLOT, 43);
+@@ -43,7 +43,7 @@ public class PlayerSlotConversionTest {
+     }
+ 
+     @Test
+-    public void craft() {
++    void craft() {
+         assertEquals(CRAFT_RESULT, 36);
+         assertEquals(CRAFT_SLOT_1, 37);
+         assertEquals(CRAFT_SLOT_2, 38);
+diff --git a/src/test/java/net/minestom/server/inventory/click/integration/HeldClickIntegrationTest.java b/src/test/java/net/minestom/server/inventory/click/integration/HeldClickIntegrationTest.java
+index 93069a5a925fda0d289e03b72281b92d795ac4c2..55145c0001750c019f83135800e4481e7f89bd28 100644
+--- a/src/test/java/net/minestom/server/inventory/click/integration/HeldClickIntegrationTest.java
++++ b/src/test/java/net/minestom/server/inventory/click/integration/HeldClickIntegrationTest.java
+@@ -19,10 +19,10 @@ import java.util.List;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+ @EnvTest
+-public class HeldClickIntegrationTest {
++class HeldClickIntegrationTest {
+ 
+     @Test
+-    public void heldSelf(Env env) {
++    void heldSelf(Env env) {
+         var instance = env.createFlatInstance();
+         var player = env.createPlayer(instance, new Pos(0, 40, 0));
+         var inventory = player.getInventory();
+@@ -96,7 +96,7 @@ public class HeldClickIntegrationTest {
+     }
+ 
+     @Test
+-    public void heldExternal(Env env) {
++    void heldExternal(Env env) {
+         var instance = env.createFlatInstance();
+         var player = env.createPlayer(instance, new Pos(0, 40, 0));
+         var inventory = new Inventory(InventoryType.HOPPER, "test");
+diff --git a/src/test/java/net/minestom/server/inventory/click/integration/LeftClickIntegrationTest.java b/src/test/java/net/minestom/server/inventory/click/integration/LeftClickIntegrationTest.java
+index 87a81674699095298ef8614417497025bb70b479..57639fad9010c6e1d271bf27d83efed5d2026af9 100644
+--- a/src/test/java/net/minestom/server/inventory/click/integration/LeftClickIntegrationTest.java
++++ b/src/test/java/net/minestom/server/inventory/click/integration/LeftClickIntegrationTest.java
+@@ -21,10 +21,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertNull;
+ 
+ @EnvTest
+-public class LeftClickIntegrationTest {
++class LeftClickIntegrationTest {
+ 
+     @Test
+-    public void leftSelf(Env env) {
++    void leftSelf(Env env) {
+         var instance = env.createFlatInstance();
+         var player = env.createPlayer(instance, new Pos(0, 40, 0));
+         var inventory = player.getInventory();
+@@ -82,7 +82,7 @@ public class LeftClickIntegrationTest {
+     }
+ 
+     @Test
+-    public void leftExternal(Env env) {
++    void leftExternal(Env env) {
+         var instance = env.createFlatInstance();
+         var player = env.createPlayer(instance, new Pos(0, 40, 0));
+         var inventory = new Inventory(InventoryType.HOPPER, "test");
+diff --git a/src/test/java/net/minestom/server/inventory/click/integration/RightClickIntegrationTest.java b/src/test/java/net/minestom/server/inventory/click/integration/RightClickIntegrationTest.java
+index c4e4b6e403c628346273597f87507870e62860d3..ca2706d6dd9aa201043c921ee187bbb48c8df3bd 100644
+--- a/src/test/java/net/minestom/server/inventory/click/integration/RightClickIntegrationTest.java
++++ b/src/test/java/net/minestom/server/inventory/click/integration/RightClickIntegrationTest.java
+@@ -20,10 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertNull;
+ 
+ @EnvTest
+-public class RightClickIntegrationTest {
++class RightClickIntegrationTest {
+ 
+     @Test
+-    public void rightSelf(Env env) {
++    void rightSelf(Env env) {
+         var instance = env.createFlatInstance();
+         var player = env.createPlayer(instance, new Pos(0, 40, 0));
+         var inventory = player.getInventory();
+@@ -104,7 +104,7 @@ public class RightClickIntegrationTest {
+     }
+ 
+     @Test
+-    public void rightExternal(Env env) {
++    void rightExternal(Env env) {
+         var instance = env.createFlatInstance();
+         var player = env.createPlayer(instance, new Pos(0, 40, 0));
+         var inventory = new Inventory(InventoryType.HOPPER, "test");
+diff --git a/src/test/java/net/minestom/server/item/ItemAirTest.java b/src/test/java/net/minestom/server/item/ItemAirTest.java
+index db3d855f8114fe9cf0e2e61e834dd3de1157a135..17720b6b3b43d6b92c590864467dbfbac547609e 100644
+--- a/src/test/java/net/minestom/server/item/ItemAirTest.java
++++ b/src/test/java/net/minestom/server/item/ItemAirTest.java
+@@ -4,9 +4,9 @@ import org.junit.jupiter.api.Test;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class ItemAirTest {
++class ItemAirTest {
+     @Test
+-    public void testAir() {
++    void testAir() {
+         var item = ItemStack.of(Material.DIAMOND_SWORD);
+         assertFalse(item.isAir());
+         assertTrue(ItemStack.AIR.isAir());
+diff --git a/src/test/java/net/minestom/server/item/ItemAttributeTest.java b/src/test/java/net/minestom/server/item/ItemAttributeTest.java
+index 4111ba13173056cfc36b9c9602f62e33f6ae98a5..f8ea7c7d8c1b68b1914732c290f6936a318a12ee 100644
+--- a/src/test/java/net/minestom/server/item/ItemAttributeTest.java
++++ b/src/test/java/net/minestom/server/item/ItemAttributeTest.java
+@@ -5,9 +5,6 @@ import net.minestom.server.attribute.AttributeOperation;
+ import net.minestom.server.item.attribute.AttributeSlot;
+ import net.minestom.server.item.attribute.ItemAttribute;
+ import net.minestom.server.tag.TagHandler;
+-import net.minestom.server.tag.TagWritable;
+-import org.jglrxavpok.hephaistos.nbt.NBT;
+-import org.jglrxavpok.hephaistos.nbt.NBTCompound;
+ import org.junit.jupiter.api.Test;
+ 
+ import java.util.List;
+@@ -16,10 +13,10 @@ import java.util.UUID;
+ import static net.minestom.testing.TestUtils.assertEqualsSNBT;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+-public class ItemAttributeTest {
++class ItemAttributeTest {
+ 
+     @Test
+-    public void attribute() {
++    void attribute() {
+         var attributes = List.of(new ItemAttribute(
+                 new UUID(0, 0), "generic.attack_damage", Attribute.ATTACK_DAMAGE,
+                 AttributeOperation.ADDITION, 2, AttributeSlot.MAINHAND));
+@@ -30,7 +27,7 @@ public class ItemAttributeTest {
+     }
+ 
+     @Test
+-    public void attributeReader() {
++    void attributeReader() {
+         var attributes = List.of(new ItemAttribute(
+                 new UUID(0, 0), "generic.attack_damage", Attribute.ATTACK_DAMAGE,
+                 AttributeOperation.ADDITION, 2, AttributeSlot.MAINHAND));
+@@ -43,7 +40,7 @@ public class ItemAttributeTest {
+     }
+ 
+     @Test
+-    public void attributeNbt() {
++    void attributeNbt() {
+         var item = ItemStack.builder(Material.STICK)
+                 .meta(builder -> builder.attributes(
+                         List.of(new ItemAttribute(
+diff --git a/src/test/java/net/minestom/server/item/ItemBlockTest.java b/src/test/java/net/minestom/server/item/ItemBlockTest.java
+index 495e3de4962bdae90b9392c9ea4629d09eb966c2..5eda2abf47994345b2be8a7fe4dbf511039ae4aa 100644
+--- a/src/test/java/net/minestom/server/item/ItemBlockTest.java
++++ b/src/test/java/net/minestom/server/item/ItemBlockTest.java
+@@ -6,10 +6,10 @@ import org.junit.jupiter.api.Test;
+ import static net.minestom.testing.TestUtils.assertEqualsSNBT;
+ import static org.junit.jupiter.api.Assertions.assertTrue;
+ 
+-public class ItemBlockTest {
++class ItemBlockTest {
+ 
+     @Test
+-    public void canPlace() {
++    void canPlace() {
+         var item = ItemStack.builder(Material.STONE)
+                 .meta(builder -> builder.canPlaceOn(Block.STONE))
+                 .build();
+@@ -18,7 +18,7 @@ public class ItemBlockTest {
+     }
+ 
+     @Test
+-    public void canPlaceNbt() {
++    void canPlaceNbt() {
+         var item = ItemStack.builder(Material.STONE)
+                 .meta(builder -> builder.canPlaceOn(Block.STONE))
+                 .build();
+@@ -28,7 +28,7 @@ public class ItemBlockTest {
+     }
+ 
+     @Test
+-    public void canPlaceMismatchProperties() {
++    void canPlaceMismatchProperties() {
+         var item = ItemStack.builder(Material.STONE)
+                 .meta(builder -> builder.canPlaceOn(Block.SANDSTONE_STAIRS.withProperty("facing", "south")))
+                 .build();
+@@ -38,7 +38,7 @@ public class ItemBlockTest {
+     }
+ 
+     @Test
+-    public void canDestroy() {
++    void canDestroy() {
+         var item = ItemStack.builder(Material.STONE)
+                 .meta(builder -> builder.canDestroy(Block.STONE))
+                 .build();
+@@ -47,7 +47,7 @@ public class ItemBlockTest {
+     }
+ 
+     @Test
+-    public void canDestroyNbt() {
++    void canDestroyNbt() {
+         var item = ItemStack.builder(Material.STONE)
+                 .meta(builder -> builder.canDestroy(Block.STONE))
+                 .build();
+@@ -57,7 +57,7 @@ public class ItemBlockTest {
+     }
+ 
+     @Test
+-    public void canDestroyMismatchProperties() {
++    void canDestroyMismatchProperties() {
+         var item = ItemStack.builder(Material.STONE)
+                 .meta(builder -> builder.canDestroy(Block.SANDSTONE_STAIRS.withProperty("facing", "south")))
+                 .build();
+diff --git a/src/test/java/net/minestom/server/item/ItemDisplayTest.java b/src/test/java/net/minestom/server/item/ItemDisplayTest.java
+index 87700dc15cf193078b0da417f1129a41d80fec7e..98072ec96294ae4d61fee6252b446bbe2d5d4167 100644
+--- a/src/test/java/net/minestom/server/item/ItemDisplayTest.java
++++ b/src/test/java/net/minestom/server/item/ItemDisplayTest.java
+@@ -10,10 +10,10 @@ import java.util.stream.Stream;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class ItemDisplayTest {
++class ItemDisplayTest {
+ 
+     @Test
+-    public void lore() {
++    void lore() {
+         var item = ItemStack.of(Material.DIAMOND_SWORD);
+         assertEquals(List.of(), item.getLore());
+         assertNull(item.meta().toNBT().get("display"));
+diff --git a/src/test/java/net/minestom/server/item/ItemEnchantTest.java b/src/test/java/net/minestom/server/item/ItemEnchantTest.java
+index 46f818bcb3e2c8651be5dcf9e9e8fabb0a73cea7..bae7902020fa913c163c25966cc13a7245bf907b 100644
+--- a/src/test/java/net/minestom/server/item/ItemEnchantTest.java
++++ b/src/test/java/net/minestom/server/item/ItemEnchantTest.java
+@@ -7,22 +7,22 @@ import java.util.Map;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertTrue;
+ 
+-public class ItemEnchantTest {
++class ItemEnchantTest {
+ 
+     @Test
+-    public void enchant() {
++    void enchant() {
+         var item = ItemStack.of(Material.DIAMOND_SWORD);
+         var enchantments = item.meta().getEnchantmentMap();
+         assertTrue(enchantments.isEmpty(), "items do not have enchantments by default");
+ 
+         item = item.withMeta(meta -> meta.enchantment(Enchantment.EFFICIENCY, (short) 10));
+         enchantments = item.meta().getEnchantmentMap();
+-        assertEquals(enchantments.size(), 1);
++        assertEquals(1, enchantments.size());
+         assertEquals(enchantments.get(Enchantment.EFFICIENCY), (short) 10);
+ 
+         item = item.withMeta(meta -> meta.enchantment(Enchantment.INFINITY, (short) 5));
+         enchantments = item.meta().getEnchantmentMap();
+-        assertEquals(enchantments.size(), 2);
++        assertEquals(2, enchantments.size());
+         assertEquals(enchantments.get(Enchantment.EFFICIENCY), (short) 10);
+         assertEquals(enchantments.get(Enchantment.INFINITY), (short) 5);
+ 
+diff --git a/src/test/java/net/minestom/server/item/ItemMetaTest.java b/src/test/java/net/minestom/server/item/ItemMetaTest.java
+index fc8d2b7faf989c1e5003e3fc24de98ef25151430..43b17d140000b1d1341293adc7cf263d33557319 100644
+--- a/src/test/java/net/minestom/server/item/ItemMetaTest.java
++++ b/src/test/java/net/minestom/server/item/ItemMetaTest.java
+@@ -18,22 +18,22 @@ import java.util.UUID;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertNotNull;
+ 
+-public class ItemMetaTest {
++class ItemMetaTest {
+     @Test
+-    public void defaultMeta() {
++    void defaultMeta() {
+         var item = ItemStack.builder(Material.BUNDLE).build();
+         assertNotNull(item.meta());
+     }
+ 
+     @Test
+-    public void fromNBT() {
++    void fromNBT() {
+         var compound = NBT.Compound(Map.of("value", NBT.Int(5)));
+         var item = ItemStack.builder(Material.BUNDLE).meta(compound).build();
+         assertEquals(compound, item.meta().toNBT());
+     }
+ 
+     @Test
+-    public void bundle() {
++    void bundle() {
+         var item = ItemStack.builder(Material.BUNDLE)
+                 .meta(BundleMeta.class, bundleMetaBuilder -> {
+                     bundleMetaBuilder.addItem(ItemStack.of(Material.DIAMOND, 5));
+@@ -44,7 +44,7 @@ public class ItemMetaTest {
+     }
+ 
+     @Test
+-    public void buildView() {
++    void buildView() {
+         var uuid = UUID.randomUUID();
+         var skin = new PlayerSkin("xx", "yy");
+         var meta = new PlayerHeadMeta.Builder()
+diff --git a/src/test/java/net/minestom/server/item/ItemMetaViewTest.java b/src/test/java/net/minestom/server/item/ItemMetaViewTest.java
+index 4c20e7b822990b4e2e0baeb1de0a2a6d9ddd53ab..d39bb6024fc06807a14ac9db52bac54e1fb5b358 100644
+--- a/src/test/java/net/minestom/server/item/ItemMetaViewTest.java
++++ b/src/test/java/net/minestom/server/item/ItemMetaViewTest.java
+@@ -7,14 +7,14 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+ 
+-public class ItemMetaViewTest {
++class ItemMetaViewTest {
+     @Test
+-    public void viewType() {
++    void viewType() {
+         assertEquals(BundleMeta.Builder.class, ItemMetaViewImpl.viewType(BundleMeta.class));
+     }
+ 
+     @Test
+-    public void construct() {
++    void construct() {
+         assertInstanceOf(BundleMeta.Builder.class, ItemMetaViewImpl.constructBuilder(BundleMeta.class, TagHandler.newHandler()));
+     }
+ }
+diff --git a/src/test/java/net/minestom/server/item/ItemMetaWrittenBookTest.java b/src/test/java/net/minestom/server/item/ItemMetaWrittenBookTest.java
+index f8eb46b2fb547a5052659fe963223ef1e5adecc4..fc6891e20469de757dcc05d5e861cdc0a7a3be2f 100644
+--- a/src/test/java/net/minestom/server/item/ItemMetaWrittenBookTest.java
++++ b/src/test/java/net/minestom/server/item/ItemMetaWrittenBookTest.java
+@@ -18,9 +18,9 @@ import java.util.List;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.fail;
+ 
+-public class ItemMetaWrittenBookTest {
++class ItemMetaWrittenBookTest {
+     @Test
+-    public void testPages() {
++    void testPages() {
+         ItemStack book = ItemStack.of(Material.WRITTEN_BOOK);
+ 
+         Component pageA = Component.text("Page A");
+@@ -36,7 +36,7 @@ public class ItemMetaWrittenBookTest {
+     }
+ 
+     @Test
+-    public void testStyleComponents() {
++    void testStyleComponents() {
+         List<TextColor> colors = List.of(NamedTextColor.BLUE, NamedTextColor.WHITE, NamedTextColor.DARK_BLUE);
+         List<TextDecoration> decorations = List.of(TextDecoration.UNDERLINED, TextDecoration.STRIKETHROUGH, TextDecoration.ITALIC);
+         List<ClickEvent> clicks = List.of(
+@@ -79,7 +79,7 @@ public class ItemMetaWrittenBookTest {
+     }
+ 
+     @Test
+-    public void buildFromVanillSNBT() {
++    void buildFromVanillSNBT() {
+         String vanillaSNBT = """
+ {
+     pages:['[
+diff --git a/src/test/java/net/minestom/server/item/ItemTest.java b/src/test/java/net/minestom/server/item/ItemTest.java
+index c7fa1ca1fd0a6d4a8180581e8f1aa3962ab51f01..4171f07682bf707e5e314d15a4c79e8e0e941d4a 100644
+--- a/src/test/java/net/minestom/server/item/ItemTest.java
++++ b/src/test/java/net/minestom/server/item/ItemTest.java
+@@ -9,40 +9,40 @@ import java.util.Map;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class ItemTest {
++class ItemTest {
+ 
+     @Test
+-    public void testFields() {
++    void testFields() {
+         var item = ItemStack.of(Material.DIAMOND_SWORD);
+         assertEquals(item.material(), Material.DIAMOND_SWORD, "Material must be the same");
+-        assertEquals(item.amount(), 1, "Default item amount must be 1");
++        assertEquals(1, item.amount(), "Default item amount must be 1");
+         assertNull(item.getDisplayName(), "Default item display name must be null");
+         assertTrue(item.getLore().isEmpty(), "Default item lore must be empty");
+         ItemStack finalItem = item;
+         assertThrows(Exception.class, () -> finalItem.getLore().add(Component.text("Hey!")), "Lore list cannot be modified directly");
+ 
+         item = item.withAmount(5);
+-        assertEquals(item.amount(), 5, "Items with different amount should not be equals");
+-        assertEquals(item.withAmount(amount -> amount * 2).amount(), 10, "Amount must be multiplied by 2");
++        assertEquals(5, item.amount(), "Items with different amount should not be equals");
++        assertEquals(10,item.withAmount(amount -> amount * 2).amount(), "Amount must be multiplied by 2");
+     }
+ 
+     @Test
+-    public void defaultBuilder() {
++    void defaultBuilder() {
+         var item = ItemStack.builder(Material.DIAMOND_SWORD).build();
+         assertEquals(item.material(), Material.DIAMOND_SWORD, "Material must be the same");
+-        assertEquals(item.amount(), 1, "Default item amount must be 1");
++        assertEquals(1, item.amount(), "Default item amount must be 1");
+         assertNull(item.getDisplayName(), "Default item display name must be null");
+         assertTrue(item.getLore().isEmpty(), "Default item lore must be empty");
+         ItemStack finalItem = item;
+         assertThrows(Exception.class, () -> finalItem.getLore().add(Component.text("Hey!")), "Lore list cannot be modified directly");
+ 
+         item = item.withAmount(5);
+-        assertEquals(item.amount(), 5, "Items with different amount should not be equals");
+-        assertEquals(item.withAmount(amount -> amount * 2).amount(), 10, "Amount must be multiplied by 2");
++        assertEquals(5, item.amount(), "Items with different amount should not be equals");
++        assertEquals(10, item.withAmount(amount -> amount * 2).amount(), "Amount must be multiplied by 2");
+     }
+ 
+     @Test
+-    public void testEquality() {
++    void testEquality() {
+         var item1 = ItemStack.of(Material.DIAMOND_SWORD);
+         var item2 = ItemStack.of(Material.DIAMOND_SWORD);
+         assertEquals(item1, item2);
+@@ -54,7 +54,7 @@ public class ItemTest {
+     }
+ 
+     @Test
+-    public void testItemNbt() {
++    void testItemNbt() {
+         var itemNbt = createItem().toItemNBT();
+         assertEquals(itemNbt.getString("id"), createItem().material().name(), "id string should be the material name");
+         assertEquals(itemNbt.getByte("Count"), (byte) createItem().amount(), "Count byte should be the item amount");
+@@ -64,7 +64,7 @@ public class ItemTest {
+     }
+ 
+     @Test
+-    public void testFromNbt() {
++    void testFromNbt() {
+         var itemNbt = createItem().toItemNBT();
+         var item = ItemStack.fromItemNBT(itemNbt);
+         assertEquals(createItem(), item, "Items must be equal if created from the same item nbt");
+@@ -76,7 +76,7 @@ public class ItemTest {
+     }
+ 
+     @Test
+-    public void testBuilderReuse() {
++    void testBuilderReuse() {
+         var builder = ItemStack.builder(Material.DIAMOND);
+         var item1 = builder.build();
+         var item2 = builder.displayName(Component.text("Name")).build();
+@@ -86,7 +86,7 @@ public class ItemTest {
+     }
+ 
+     @Test
+-    public void materialUpdate() {
++    void materialUpdate() {
+         var nbt = NBT.Compound(Map.of("key", NBT.String("value")));
+         var item1 = ItemStack.fromNBT(Material.DIAMOND, nbt, 5);
+         var item2 = item1.withMaterial(Material.GOLD_INGOT);
+@@ -102,7 +102,7 @@ public class ItemTest {
+     }
+ 
+     @Test
+-    public void amountUpdate() {
++    void amountUpdate() {
+         var item1 = ItemStack.of(Material.DIAMOND, 5);
+         assertEquals(5, item1.amount());
+         assertEquals(6, item1.withAmount(6).amount());
+diff --git a/src/test/java/net/minestom/server/network/NetworkBufferTest.java b/src/test/java/net/minestom/server/network/NetworkBufferTest.java
+index 107e1c53a77414a300beb46143875dda25a4503f..ac349777f80d2711dcb120908ea8dd9b0e095fa3 100644
+--- a/src/test/java/net/minestom/server/network/NetworkBufferTest.java
++++ b/src/test/java/net/minestom/server/network/NetworkBufferTest.java
+@@ -15,10 +15,10 @@ import static net.minestom.server.network.NetworkBuffer.*;
+ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+-public class NetworkBufferTest {
++class NetworkBufferTest {
+ 
+     @Test
+-    public void resize() {
++    void resize() {
+         var buffer = new NetworkBuffer(6);
+         buffer.write(INT, 6);
+         assertEquals(4, buffer.writeIndex());
+@@ -42,7 +42,7 @@ public class NetworkBufferTest {
+     }
+ 
+     @Test
+-    public void readableBytes() {
++    void readableBytes() {
+         var buffer = new NetworkBuffer();
+         assertEquals(0, buffer.readableBytes());
+ 
+@@ -60,7 +60,7 @@ public class NetworkBufferTest {
+     }
+ 
+     @Test
+-    public void extractBytes() {
++    void extractBytes() {
+         var buffer = new NetworkBuffer();
+ 
+         buffer.write(BYTE, (byte) 25);
+@@ -87,7 +87,7 @@ public class NetworkBufferTest {
+     }
+ 
+     @Test
+-    public void makeArray() {
++    void makeArray() {
+         assertArrayEquals(new byte[0], NetworkBuffer.makeArray(buffer -> {
+         }));
+ 
+@@ -100,7 +100,7 @@ public class NetworkBufferTest {
+     }
+ 
+     @Test
+-    public void numbers() {
++    void numbers() {
+         assertBufferType(BOOLEAN, false, new byte[]{0x00});
+         assertBufferType(BOOLEAN, true, new byte[]{0x01});
+ 
+@@ -193,7 +193,7 @@ public class NetworkBufferTest {
+     }
+ 
+     @Test
+-    public void varInt() {
++    void varInt() {
+         assertBufferType(VAR_INT, 0, new byte[]{0});
+         assertBufferType(VAR_INT, 1, new byte[]{0x01});
+         assertBufferType(VAR_INT, 2, new byte[]{0x02});
+@@ -209,7 +209,7 @@ public class NetworkBufferTest {
+     }
+ 
+     @Test
+-    public void varLong() {
++    void varLong() {
+         assertBufferType(VAR_LONG, 0L, new byte[]{0});
+         assertBufferType(VAR_LONG, 1L, new byte[]{0x01});
+         assertBufferType(VAR_LONG, 2L, new byte[]{0x02});
+@@ -224,49 +224,49 @@ public class NetworkBufferTest {
+     }
+ 
+     @Test
+-    public void rawBytes() {
++    void rawBytes() {
+         // FIXME: currently break because the array is identity compared
+         //assertBufferType(NetworkBuffer.RAW_BYTES, new byte[]{0x0B, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64},
+         //      new byte[]{0x0B, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64});
+     }
+ 
+     @Test
+-    public void string() {
++    void string() {
+         assertBufferType(STRING, "Hello World", new byte[]{0x0B, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64});
+     }
+ 
+     @Test
+-    public void nbt() {
++    void nbt() {
+         assertBufferType(NetworkBuffer.NBT, org.jglrxavpok.hephaistos.nbt.NBT.Int(5));
+         assertBufferType(NetworkBuffer.NBT, org.jglrxavpok.hephaistos.nbt.NBT.Compound(Map.of("key", org.jglrxavpok.hephaistos.nbt.NBT.Int(5))));
+     }
+ 
+     @Test
+-    public void component() {
++    void component() {
+         assertBufferType(COMPONENT, Component.text("Hello world"));
+     }
+ 
+     @Test
+-    public void uuid() {
++    void uuid() {
+         assertBufferType(UUID, new UUID(0, 0), new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+         assertBufferType(UUID, new UUID(1, 1), new byte[]{0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1});
+     }
+ 
+     @Test
+-    public void item() {
++    void item() {
+         assertBufferType(ITEM, ItemStack.AIR);
+         assertBufferType(ITEM, ItemStack.of(Material.STONE, 1));
+         assertBufferType(ITEM, ItemStack.of(Material.DIAMOND_AXE, 1).withMeta(builder -> builder.damage(1)));
+     }
+ 
+     @Test
+-    public void optional() {
++    void optional() {
+         assertBufferTypeOptional(BOOLEAN, null, new byte[]{0});
+         assertBufferTypeOptional(BOOLEAN, true, new byte[]{1, 1});
+     }
+ 
+     @Test
+-    public void collection() {
++    void collection() {
+         assertBufferTypeCollection(BOOLEAN, List.of(), new byte[]{0});
+         assertBufferTypeCollection(BOOLEAN, List.of(true), new byte[]{0x01, 0x01});
+     }
+diff --git a/src/test/java/net/minestom/server/network/PacketWriteReadTest.java b/src/test/java/net/minestom/server/network/PacketWriteReadTest.java
+index 3e424c24f5c7064992c469439a0049f040ef038c..eb265352ab3a27a6bb8fb31df610027789570b83 100644
+--- a/src/test/java/net/minestom/server/network/PacketWriteReadTest.java
++++ b/src/test/java/net/minestom/server/network/PacketWriteReadTest.java
+@@ -1,15 +1,9 @@
+ package net.minestom.server.network;
+ 
+ import com.google.gson.JsonObject;
+-
+-import java.io.PrintStream;
+-
+ import net.kyori.adventure.bossbar.BossBar;
+ import net.kyori.adventure.text.Component;
+-import net.minestom.server.MinecraftServer;
+ import net.minestom.server.coordinate.Vec;
+-import net.minestom.server.crypto.ChatSession;
+-import net.minestom.server.crypto.PlayerPublicKey;
+ import net.minestom.server.entity.EquipmentSlot;
+ import net.minestom.server.entity.GameMode;
+ import net.minestom.server.entity.Metadata;
+@@ -26,18 +20,11 @@ import net.minestom.server.network.packet.server.login.SetCompressionPacket;
+ import net.minestom.server.network.packet.server.play.*;
+ import net.minestom.server.network.packet.server.play.DeclareRecipesPacket.Ingredient;
+ import net.minestom.server.network.packet.server.status.PongPacket;
+-import net.minestom.server.utils.crypto.KeyUtils;
+-import org.apache.commons.net.util.Base64;
+ import org.jglrxavpok.hephaistos.nbt.NBT;
+ import org.junit.jupiter.api.BeforeAll;
+ import org.junit.jupiter.api.Test;
+ 
+ import java.lang.reflect.InvocationTargetException;
+-import java.nio.charset.StandardCharsets;
+-import java.security.KeyFactory;
+-import java.security.PublicKey;
+-import java.security.spec.X509EncodedKeySpec;
+-import java.time.Instant;
+ import java.util.ArrayList;
+ import java.util.List;
+ import java.util.Map;
+@@ -148,12 +135,12 @@ public class PacketWriteReadTest {
+     }
+ 
+     @Test
+-    public void serverTest() {
++    void serverTest() {
+         SERVER_PACKETS.forEach(PacketWriteReadTest::testPacket);
+     }
+ 
+     @Test
+-    public void clientTest() {
++    void clientTest() {
+         CLIENT_PACKETS.forEach(PacketWriteReadTest::testPacket);
+     }
+ 
+diff --git a/src/test/java/net/minestom/server/network/SendablePacketTest.java b/src/test/java/net/minestom/server/network/SendablePacketTest.java
+index e1f05206055e80600e5fc3dcfb45599c081ab337..05527ae21b137891c54990d8a76f577bb47ad91b 100644
+--- a/src/test/java/net/minestom/server/network/SendablePacketTest.java
++++ b/src/test/java/net/minestom/server/network/SendablePacketTest.java
+@@ -11,10 +11,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class SendablePacketTest {
++class SendablePacketTest {
+ 
+     @Test
+-    public void lazy() {
++    void lazy() {
+         var packet = new SystemChatPacket(Component.text("Hello World!"), false);
+         AtomicBoolean called = new AtomicBoolean(false);
+         var lazy = new LazyPacket(() -> {
+@@ -27,7 +27,7 @@ public class SendablePacketTest {
+     }
+ 
+     @Test
+-    public void cached() {
++    void cached() {
+         var packet = new SystemChatPacket(Component.text("Hello World!"), false);
+         var cached = new CachedPacket(packet);
+         assertSame(packet, cached.packet());
+diff --git a/src/test/java/net/minestom/server/network/SocketReadTest.java b/src/test/java/net/minestom/server/network/SocketReadTest.java
+index 0f168ab61b905901d8aaca71d16526bcd8473d42..b86f9f16335d294f5ab0fe2b8211713aa99ad052 100644
+--- a/src/test/java/net/minestom/server/network/SocketReadTest.java
++++ b/src/test/java/net/minestom/server/network/SocketReadTest.java
+@@ -16,11 +16,11 @@ import java.util.zip.DataFormatException;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class SocketReadTest {
++class SocketReadTest {
+ 
+     @ParameterizedTest
+     @ValueSource(booleans = {false, true})
+-    public void complete(boolean compressed) throws DataFormatException {
++    void complete(boolean compressed) throws DataFormatException {
+         var packet = new ClientPluginMessagePacket("channel", new byte[2000]);
+ 
+         var buffer = ObjectPool.PACKET_POOL.get();
+@@ -44,7 +44,7 @@ public class SocketReadTest {
+ 
+     @ParameterizedTest
+     @ValueSource(booleans = {false, true})
+-    public void completeTwo(boolean compressed) throws DataFormatException {
++    void completeTwo(boolean compressed) throws DataFormatException {
+         var packet = new ClientPluginMessagePacket("channel", new byte[2000]);
+ 
+         var buffer = ObjectPool.PACKET_POOL.get();
+@@ -70,7 +70,7 @@ public class SocketReadTest {
+ 
+     @ParameterizedTest
+     @ValueSource(booleans = {false, true})
+-    public void insufficientLength(boolean compressed) throws DataFormatException {
++    void insufficientLength(boolean compressed) throws DataFormatException {
+         // Write a complete packet then the next packet length without any payload
+ 
+         var packet = new ClientPluginMessagePacket("channel", new byte[2000]);
+@@ -98,7 +98,7 @@ public class SocketReadTest {
+ 
+     @ParameterizedTest
+     @ValueSource(booleans = {false, true})
+-    public void incomplete(boolean compressed) throws DataFormatException {
++    void incomplete(boolean compressed) throws DataFormatException {
+         // Write a complete packet and incomplete var-int length for the next packet
+ 
+         var packet = new ClientPluginMessagePacket("channel", new byte[2000]);
+diff --git a/src/test/java/net/minestom/server/network/SocketWriteTest.java b/src/test/java/net/minestom/server/network/SocketWriteTest.java
+index 1202eeb1f2e1d9d11f82ddd99e9da43dec5d2f96..8f8aee350f584b5ef886f8529f56f21fa922be12 100644
+--- a/src/test/java/net/minestom/server/network/SocketWriteTest.java
++++ b/src/test/java/net/minestom/server/network/SocketWriteTest.java
+@@ -14,7 +14,7 @@ import static net.minestom.server.network.NetworkBuffer.STRING;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertNotEquals;
+ 
+-public class SocketWriteTest {
++class SocketWriteTest {
+ 
+     record IntPacket(int value) implements ServerPacket {
+         @Override
+@@ -41,7 +41,7 @@ public class SocketWriteTest {
+     }
+ 
+     @Test
+-    public void writeSingleUncompressed() {
++    void writeSingleUncompressed() {
+         var packet = new IntPacket(5);
+ 
+         var buffer = ObjectPool.PACKET_POOL.get();
+@@ -53,7 +53,7 @@ public class SocketWriteTest {
+     }
+ 
+     @Test
+-    public void writeMultiUncompressed() {
++    void writeMultiUncompressed() {
+         var packet = new IntPacket(5);
+ 
+         var buffer = ObjectPool.PACKET_POOL.get();
+@@ -66,7 +66,7 @@ public class SocketWriteTest {
+     }
+ 
+     @Test
+-    public void writeSingleCompressed() {
++    void writeSingleCompressed() {
+         var string = "Hello world!".repeat(200);
+         var stringLength = string.getBytes(StandardCharsets.UTF_8).length;
+         var lengthLength = Utils.getVarIntSize(stringLength);
+@@ -82,7 +82,7 @@ public class SocketWriteTest {
+     }
+ 
+     @Test
+-    public void writeSingleCompressedSmall() {
++    void writeSingleCompressedSmall() {
+         var packet = new IntPacket(5);
+ 
+         var buffer = ObjectPool.PACKET_POOL.get();
+@@ -94,7 +94,7 @@ public class SocketWriteTest {
+     }
+ 
+     @Test
+-    public void writeMultiCompressedSmall() {
++    void writeMultiCompressedSmall() {
+         var packet = new IntPacket(5);
+ 
+         var buffer = ObjectPool.PACKET_POOL.get();
+diff --git a/src/test/java/net/minestom/server/network/socket/ServerAddressTest.java b/src/test/java/net/minestom/server/network/socket/ServerAddressTest.java
+index 1836cf2b698dbbc8004a3a168448f1e13f3edd92..75680c92345e95f46e0528e618080f3217315381 100644
+--- a/src/test/java/net/minestom/server/network/socket/ServerAddressTest.java
++++ b/src/test/java/net/minestom/server/network/socket/ServerAddressTest.java
+@@ -10,10 +10,10 @@ import java.nio.file.Files;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class ServerAddressTest {
++class ServerAddressTest {
+ 
+     @Test
+-    public void inetAddressTest() throws IOException {
++    void inetAddressTest() throws IOException {
+         InetSocketAddress address = new InetSocketAddress("localhost", 25565);
+         var server = new Server(new PacketProcessor());
+         server.init(address);
+@@ -26,7 +26,7 @@ public class ServerAddressTest {
+     }
+ 
+     @Test
+-    public void inetAddressDynamicTest() throws IOException {
++    void inetAddressDynamicTest() throws IOException {
+         InetSocketAddress address = new InetSocketAddress("localhost", 0);
+         var server = new Server(new PacketProcessor());
+         server.init(address);
+@@ -39,7 +39,7 @@ public class ServerAddressTest {
+     }
+ 
+     @Test
+-    public void unixAddressTest() throws IOException {
++    void unixAddressTest() throws IOException {
+         UnixDomainSocketAddress address = UnixDomainSocketAddress.of("minestom.sock");
+         var server = new Server(new PacketProcessor());
+         server.init(address);
+@@ -54,7 +54,7 @@ public class ServerAddressTest {
+     }
+ 
+     @Test
+-    public void noAddressTest() throws IOException {
++    void noAddressTest() throws IOException {
+         var server = new Server(new PacketProcessor());
+         assertDoesNotThrow(server::stop);
+     }
+diff --git a/src/test/java/net/minestom/server/permission/TestPermissions.java b/src/test/java/net/minestom/server/permission/TestPermissions.java
+index c5604540d92ca2b579b79a8b2f1c33c89d5efe80..38c785b7dcf897634932897a538de40534b2f529 100644
+--- a/src/test/java/net/minestom/server/permission/TestPermissions.java
++++ b/src/test/java/net/minestom/server/permission/TestPermissions.java
+@@ -14,14 +14,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
+ import static org.junit.jupiter.api.Assertions.assertTrue;
+ 
+ // TODO: more tests
+-public class TestPermissions {
++class TestPermissions {
+ 
+     private Player player;
+ 
+     private Permission permission1, permission2, permission3, wildcard;
+ 
+     @BeforeEach
+-    public void init() {
++    void init() {
+         MinecraftServer.init(); // for entity manager
+         player = new Player(UUID.randomUUID(), "TestPlayer", null) {
+             @Override
+@@ -49,13 +49,13 @@ public class TestPermissions {
+     }
+ 
+     @Test
+-    public void noPermission() {
++    void noPermission() {
+         assertFalse(player.hasPermission(""));
+         assertFalse(player.hasPermission("random.permission"));
+     }
+ 
+     @Test
+-    public void hasPermissionClass() {
++    void hasPermissionClass() {
+ 
+         assertFalse(player.hasPermission(permission1));
+         player.addPermission(permission1);
+@@ -67,7 +67,7 @@ public class TestPermissions {
+     }
+ 
+     @Test
+-    public void hasPermissionNameNbt() {
++    void hasPermissionNameNbt() {
+         player.addPermission(permission1);
+         assertTrue(player.hasPermission("perm.name"));
+         assertTrue(player.hasPermission("perm.name",
+@@ -81,7 +81,7 @@ public class TestPermissions {
+     }
+ 
+     @Test
+-    public void hasPatternMatchingWildcard() {
++    void hasPatternMatchingWildcard() {
+         Permission permission = new Permission("foo.b*r.baz");
+         Permission match = new Permission("foo.baaar.baz");
+         Permission match2 = new Permission("foo.br.baz");
+@@ -105,7 +105,7 @@ public class TestPermissions {
+     }
+ 
+     @Test
+-    public void hasPermissionWildcard() {
++    void hasPermissionWildcard() {
+         Permission permission = new Permission("foo.b*");
+         Permission match = new Permission("foo.baaar.baz");
+         Permission match2 = new Permission("foo.b");
+@@ -129,7 +129,7 @@ public class TestPermissions {
+     }
+ 
+     @Test
+-    public void hasAllPermissionsWithWildcard() {
++    void hasAllPermissionsWithWildcard() {
+         assertFalse(player.hasPermission(permission2));
+         assertFalse(player.hasPermission(permission3));
+         player.addPermission(wildcard);
+@@ -138,7 +138,7 @@ public class TestPermissions {
+     }
+ 
+     @AfterEach
+-    public void cleanup() {
++    void cleanup() {
+ 
+     }
+ }
+diff --git a/src/test/java/net/minestom/server/snapshot/ChunkSnapshotIntegrationTest.java b/src/test/java/net/minestom/server/snapshot/ChunkSnapshotIntegrationTest.java
+index 6f0809d0cbabffda885bea76a0eb8a8c9cefaf77..35ffcf8aa1139c530ce37ff34b9412795abd4d3b 100644
+--- a/src/test/java/net/minestom/server/snapshot/ChunkSnapshotIntegrationTest.java
++++ b/src/test/java/net/minestom/server/snapshot/ChunkSnapshotIntegrationTest.java
+@@ -8,10 +8,10 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+ @EnvTest
+-public class ChunkSnapshotIntegrationTest {
++class ChunkSnapshotIntegrationTest {
+ 
+     @Test
+-    public void blocks(Env env) {
++    void blocks(Env env) {
+         var instance = env.createFlatInstance();
+         instance.setBlock(0, 0, 0, Block.STONE);
+         var snapshot = ServerSnapshot.update();
+diff --git a/src/test/java/net/minestom/server/snapshot/EntitySnapshotIntegrationTest.java b/src/test/java/net/minestom/server/snapshot/EntitySnapshotIntegrationTest.java
+index 734b3c8889285b157dc081061db3cdd161ad40bc..c471c4873159e18d10db004fdb03a1fa2c0c1c08 100644
+--- a/src/test/java/net/minestom/server/snapshot/EntitySnapshotIntegrationTest.java
++++ b/src/test/java/net/minestom/server/snapshot/EntitySnapshotIntegrationTest.java
+@@ -10,10 +10,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertNull;
+ 
+ @EnvTest
+-public class EntitySnapshotIntegrationTest {
++class EntitySnapshotIntegrationTest {
+ 
+     @Test
+-    public void basic(Env env) {
++    void basic(Env env) {
+         var instance = env.createFlatInstance();
+         var ent = new Entity(EntityType.ZOMBIE);
+         ent.setInstance(instance).join();
+diff --git a/src/test/java/net/minestom/server/snapshot/InstanceSnapshotIntegrationTest.java b/src/test/java/net/minestom/server/snapshot/InstanceSnapshotIntegrationTest.java
+index 7863e30ea16ca00b351222b71f731836792c4e27..973a3401ae0aae9e97dde19c11db9cf12754e73d 100644
+--- a/src/test/java/net/minestom/server/snapshot/InstanceSnapshotIntegrationTest.java
++++ b/src/test/java/net/minestom/server/snapshot/InstanceSnapshotIntegrationTest.java
+@@ -7,10 +7,10 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+ @EnvTest
+-public class InstanceSnapshotIntegrationTest {
++class InstanceSnapshotIntegrationTest {
+ 
+     @Test
+-    public void basic(Env env) {
++    void basic(Env env) {
+         env.createFlatInstance();
+         var snapshot = ServerSnapshot.update();
+ 
+diff --git a/src/test/java/net/minestom/server/tag/TagComponentTest.java b/src/test/java/net/minestom/server/tag/TagComponentTest.java
+index 44c126e1795196110fc799a7d5cf5d8536cf393d..55a37fd275dd3a1bf92476c21124f7df778d5c62 100644
+--- a/src/test/java/net/minestom/server/tag/TagComponentTest.java
++++ b/src/test/java/net/minestom/server/tag/TagComponentTest.java
+@@ -6,10 +6,10 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertNull;
+ 
+-public class TagComponentTest {
++class TagComponentTest {
+ 
+     @Test
+-    public void get() {
++    void get() {
+         var component = Component.text("Hey");
+         var tag = Tag.Component("component");
+         var handler = TagHandler.newHandler();
+@@ -18,14 +18,14 @@ public class TagComponentTest {
+     }
+ 
+     @Test
+-    public void empty() {
++    void empty() {
+         var tag = Tag.Component("component");
+         var handler = TagHandler.newHandler();
+         assertNull(handler.getTag(tag));
+     }
+ 
+     @Test
+-    public void invalidTag() {
++    void invalidTag() {
+         var tag = Tag.Component("entry");
+         var handler = TagHandler.newHandler();
+         handler.setTag(Tag.Integer("entry"), 1);
+@@ -33,7 +33,7 @@ public class TagComponentTest {
+     }
+ 
+     @Test
+-    public void nbtFallback() {
++    void nbtFallback() {
+         var component = Component.text("Hey");
+         var tag = Tag.Component("component");
+         var handler = TagHandler.newHandler();
+diff --git a/src/test/java/net/minestom/server/tag/TagEqualityTest.java b/src/test/java/net/minestom/server/tag/TagEqualityTest.java
+index 79905d4ee8e881b547e8c754ad1f1838f30e7f55..5bba1cbbbc77a12eab24abd0b5efb4297569f67e 100644
+--- a/src/test/java/net/minestom/server/tag/TagEqualityTest.java
++++ b/src/test/java/net/minestom/server/tag/TagEqualityTest.java
+@@ -5,10 +5,10 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertNotEquals;
+ 
+-public class TagEqualityTest {
++class TagEqualityTest {
+ 
+     @Test
+-    public void sameType() {
++    void sameType() {
+         var tag1 = Tag.Integer("key");
+         var tag2 = Tag.Integer("key");
+         assertEquals(tag1, tag1);
+@@ -17,49 +17,49 @@ public class TagEqualityTest {
+     }
+ 
+     @Test
+-    public void differentKey() {
++    void differentKey() {
+         var tag1 = Tag.Integer("key1");
+         var tag2 = Tag.Integer("key2");
+         assertNotEquals(tag1, tag2);
+     }
+ 
+     @Test
+-    public void sameList() {
++    void sameList() {
+         var tag1 = Tag.Integer("key").list();
+         var tag2 = Tag.Integer("key").list();
+         assertEquals(tag1, tag2);
+     }
+ 
+     @Test
+-    public void differentList() {
++    void differentList() {
+         var tag1 = Tag.Integer("key").list();
+         var tag2 = Tag.Integer("key");
+         assertNotEquals(tag1, tag2);
+     }
+ 
+     @Test
+-    public void unmatchedList() {
++    void unmatchedList() {
+         var tag1 = Tag.Integer("key").list().list();
+         var tag2 = Tag.Integer("key").list();
+         assertNotEquals(tag1, tag2);
+     }
+ 
+     @Test
+-    public void samePath() {
++    void samePath() {
+         var tag1 = Tag.Integer("key").path("path");
+         var tag2 = Tag.Integer("key").path("path");
+         assertEquals(tag1, tag2);
+     }
+ 
+     @Test
+-    public void differentPath() {
++    void differentPath() {
+         var tag1 = Tag.Integer("key").path("path");
+         var tag2 = Tag.Integer("key").path("path2");
+         assertNotEquals(tag1, tag2);
+     }
+ 
+     @Test
+-    public void unmatchedPath() {
++    void unmatchedPath() {
+         var tag1 = Tag.Integer("key").path("path", "path2");
+         var tag2 = Tag.Integer("key").path("path");
+         assertNotEquals(tag1, tag2);
+diff --git a/src/test/java/net/minestom/server/tag/TagHandlerCopyTest.java b/src/test/java/net/minestom/server/tag/TagHandlerCopyTest.java
+index 11b8660c3502e61735195931bd24377d773f7bbc..aca9523ad96a04af17b301257a46c26ac723582a 100644
+--- a/src/test/java/net/minestom/server/tag/TagHandlerCopyTest.java
++++ b/src/test/java/net/minestom/server/tag/TagHandlerCopyTest.java
+@@ -6,10 +6,10 @@ import static net.minestom.testing.TestUtils.assertEqualsSNBT;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertNull;
+ 
+-public class TagHandlerCopyTest {
++class TagHandlerCopyTest {
+ 
+     @Test
+-    public void copy() {
++    void copy() {
+         var handler = TagHandler.newHandler();
+         handler.setTag(Tag.String("key"), "test");
+ 
+@@ -18,7 +18,7 @@ public class TagHandlerCopyTest {
+     }
+ 
+     @Test
+-    public void copyCachePath() {
++    void copyCachePath() {
+         var tag = Tag.String("key").path("path");
+         var handler = TagHandler.newHandler();
+         handler.setTag(tag, "test");
+@@ -43,7 +43,7 @@ public class TagHandlerCopyTest {
+     }
+ 
+     @Test
+-    public void copyCache() {
++    void copyCache() {
+         var tag = Tag.String("key");
+         var handler = TagHandler.newHandler();
+         handler.setTag(tag, "test");
+@@ -71,7 +71,7 @@ public class TagHandlerCopyTest {
+     }
+ 
+     @Test
+-    public void copyRehashing() {
++    void copyRehashing() {
+         var handler = TagHandler.newHandler();
+         TagHandler handlerCopy;
+         for (int i = 0; i < 1000; i++) {
+diff --git a/src/test/java/net/minestom/server/tag/TagHandlerReadableCopyTest.java b/src/test/java/net/minestom/server/tag/TagHandlerReadableCopyTest.java
+index 90d4a6466541c6aeb3f0d0ac75201c1ef7c7507f..82774de7c0083501796f42b3cc11c8a36b8d44a1 100644
+--- a/src/test/java/net/minestom/server/tag/TagHandlerReadableCopyTest.java
++++ b/src/test/java/net/minestom/server/tag/TagHandlerReadableCopyTest.java
+@@ -6,10 +6,10 @@ import static net.minestom.testing.TestUtils.assertEqualsSNBT;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertSame;
+ 
+-public class TagHandlerReadableCopyTest {
++class TagHandlerReadableCopyTest {
+ 
+     @Test
+-    public void copyCache() {
++    void copyCache() {
+         var tag = Tag.String("key");
+         var handler = TagHandler.newHandler();
+         handler.setTag(tag, "test");
+@@ -23,7 +23,7 @@ public class TagHandlerReadableCopyTest {
+     }
+ 
+     @Test
+-    public void copyCachePath() {
++    void copyCachePath() {
+         var tag = Tag.String("key").path("path");
+         var handler = TagHandler.newHandler();
+         handler.setTag(tag, "test");
+@@ -38,14 +38,14 @@ public class TagHandlerReadableCopyTest {
+     }
+ 
+     @Test
+-    public void copyCacheReuse() {
++    void copyCacheReuse() {
+         var handler = TagHandler.newHandler();
+         handler.setTag(Tag.String("key"), "test");
+         assertSame(handler.readableCopy(), handler.readableCopy());
+     }
+ 
+     @Test
+-    public void copyRehashing() {
++    void copyRehashing() {
+         var tag = Tag.String("key");
+         var handler = TagHandler.newHandler();
+         handler.setTag(tag, "test");
+diff --git a/src/test/java/net/minestom/server/tag/TagItemTest.java b/src/test/java/net/minestom/server/tag/TagItemTest.java
+index d3ab11a63bb4bec693621031c0b2fa711ef10e4b..862ab326cef5bb0ac14a91ef7b94c31720e7a263 100644
+--- a/src/test/java/net/minestom/server/tag/TagItemTest.java
++++ b/src/test/java/net/minestom/server/tag/TagItemTest.java
+@@ -11,10 +11,10 @@ import static net.minestom.testing.TestUtils.waitUntilCleared;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertNull;
+ 
+-public class TagItemTest {
++class TagItemTest {
+ 
+     @Test
+-    public void get() {
++    void get() {
+         var item = ItemStack.of(Material.DIAMOND);
+         var tag = Tag.ItemStack("item");
+         var handler = TagHandler.newHandler();
+@@ -24,7 +24,7 @@ public class TagItemTest {
+     }
+ 
+     @Test
+-    public void getDifferentObject() {
++    void getDifferentObject() {
+         var item = ItemStack.of(Material.DIAMOND);
+         var handler = TagHandler.newHandler();
+         handler.setTag(Tag.ItemStack("item"), item);
+@@ -33,7 +33,7 @@ public class TagItemTest {
+     }
+ 
+     @Test
+-    public void remove() {
++    void remove() {
+         var item = ItemStack.of(Material.DIAMOND);
+         var tag = Tag.ItemStack("item");
+         var handler = TagHandler.newHandler();
+@@ -45,7 +45,7 @@ public class TagItemTest {
+     }
+ 
+     @Test
+-    public void gc() {
++    void gc() {
+         var item = ItemStack.of(Material.DIAMOND);
+         var tag = Tag.ItemStack("item");
+         var handler = TagHandler.newHandler();
+@@ -60,7 +60,7 @@ public class TagItemTest {
+     }
+ 
+     @Test
+-    public void invalidation() {
++    void invalidation() {
+         var item = ItemStack.of(Material.DIAMOND);
+         var item2 = ItemStack.of(Material.DIAMOND, 2);
+         var handler = TagHandler.newHandler();
+@@ -73,7 +73,7 @@ public class TagItemTest {
+     }
+ 
+     @Test
+-    public void differentTagInvalidation() {
++    void differentTagInvalidation() {
+         var item = ItemStack.of(Material.DIAMOND);
+         var item2 = ItemStack.of(Material.DIAMOND, 2);
+         var handler = TagHandler.newHandler();
+@@ -95,7 +95,7 @@ public class TagItemTest {
+     }
+ 
+     @Test
+-    public void snbt() {
++    void snbt() {
+         var handler = TagHandler.newHandler();
+         var tag = Tag.ItemStack("item");
+         handler.setTag(tag, ItemStack.of(Material.DIAMOND));
+diff --git a/src/test/java/net/minestom/server/tag/TagListTest.java b/src/test/java/net/minestom/server/tag/TagListTest.java
+index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..ae025e28379b91947e6d665d2d788f3eb5c6d106 100644
+--- a/src/test/java/net/minestom/server/tag/TagListTest.java
++++ b/src/test/java/net/minestom/server/tag/TagListTest.java
+@@ -9,10 +9,10 @@ import java.util.List;
+ import static net.minestom.testing.TestUtils.assertEqualsSNBT;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class TagListTest {
++class TagListTest {
+ 
+     @Test
+-    public void basic() {
++    void basic() {
+         var handler = TagHandler.newHandler();
+         Tag<Integer> tag = Tag.Integer("number");
+         Tag<List<Integer>> list = tag.list();
+@@ -27,7 +27,7 @@ public class TagListTest {
+     }
+ 
+     @Test
+-    public void cache() {
++    void cache() {
+         var handler = TagHandler.newHandler();
+         var tag = Tag.Integer("number").list();
+         var val = List.of(1, 2, 3);
+@@ -37,7 +37,7 @@ public class TagListTest {
+     }
+ 
+     @Test
+-    public void recursiveCache() {
++    void recursiveCache() {
+         var handler = TagHandler.newHandler();
+         var tag = Tag.Integer("number").list().list();
+         var val = List.of(List.of(1, 2, 3), List.of(4, 5, 6));
+@@ -49,7 +49,7 @@ public class TagListTest {
+     }
+ 
+     @Test
+-    public void recursiveCacheIncorrect() {
++    void recursiveCacheIncorrect() {
+         var handler = TagHandler.newHandler();
+         var tag = Tag.Integer("number").list().list();
+         var val = List.of(List.of(1, 2, 3), new ArrayList<>(Arrays.asList(4, 5, 6)));
+@@ -62,7 +62,7 @@ public class TagListTest {
+     }
+ 
+     @Test
+-    public void snbt() {
++    void snbt() {
+         var handler = TagHandler.newHandler();
+         Tag<List<Integer>> tag = Tag.Integer("numbers").list();
+ 
+@@ -75,7 +75,7 @@ public class TagListTest {
+     }
+ 
+     @Test
+-    public void empty() {
++    void empty() {
+         var handler = TagHandler.newHandler();
+         Tag<List<Integer>> tag = Tag.Integer("numbers").list();
+         handler.setTag(tag, List.of());
+@@ -83,7 +83,7 @@ public class TagListTest {
+     }
+ 
+     @Test
+-    public void emptySnbt() {
++    void emptySnbt() {
+         var handler = TagHandler.newHandler();
+         Tag<List<Integer>> tag = Tag.Integer("numbers").list();
+         handler.setTag(tag, List.of());
+@@ -95,7 +95,7 @@ public class TagListTest {
+     }
+ 
+     @Test
+-    public void removal() {
++    void removal() {
+         var handler = TagHandler.newHandler();
+         Tag<List<Integer>> tag = Tag.Integer("numbers").list();
+         handler.setTag(tag, List.of(1));
+@@ -105,7 +105,7 @@ public class TagListTest {
+     }
+ 
+     @Test
+-    public void removalSnbt() {
++    void removalSnbt() {
+         var handler = TagHandler.newHandler();
+         Tag<List<Integer>> tag = Tag.Integer("numbers").list();
+         handler.setTag(tag, List.of(1));
+@@ -119,7 +119,7 @@ public class TagListTest {
+     }
+ 
+     @Test
+-    public void chaining() {
++    void chaining() {
+         var handler = TagHandler.newHandler();
+         Tag<List<List<Integer>>> tag = Tag.Integer("numbers").list().list();
+         var integers = List.of(List.of(1, 2, 3), List.of(4, 5, 6));
+@@ -130,7 +130,7 @@ public class TagListTest {
+     }
+ 
+     @Test
+-    public void chainingSnbt() {
++    void chainingSnbt() {
+         var handler = TagHandler.newHandler();
+         Tag<List<List<Integer>>> tag = Tag.Integer("numbers").list().list();
+         var integers = List.of(List.of(1, 2, 3), List.of(4, 5, 6));
+@@ -148,7 +148,7 @@ public class TagListTest {
+     }
+ 
+     @Test
+-    public void defaultValue() {
++    void defaultValue() {
+         var handler = TagHandler.newHandler();
+         var val = List.of(1, 2, 3);
+         var tag = Tag.Integer("number").list().defaultValue(val);
+@@ -156,7 +156,7 @@ public class TagListTest {
+     }
+ 
+     @Test
+-    public void defaultValueReset() {
++    void defaultValueReset() {
+         var handler = TagHandler.newHandler();
+         var tag = Tag.Integer("number").defaultValue(5);
+         var list = tag.list();
+@@ -165,7 +165,7 @@ public class TagListTest {
+     }
+ 
+     @Test
+-    public void immutability() {
++    void immutability() {
+         var handler = TagHandler.newHandler();
+         var tag = Tag.Integer("number").list();
+         List<Integer> val = new ArrayList<>();
+@@ -181,7 +181,7 @@ public class TagListTest {
+     }
+ 
+     @Test
+-    public void chainingImmutability() {
++    void chainingImmutability() {
+         var handler = TagHandler.newHandler();
+         Tag<List<List<Integer>>> tag = Tag.Integer("numbers").list().list();
+         List<List<Integer>> val = new ArrayList<>();
+@@ -201,7 +201,7 @@ public class TagListTest {
+     }
+ 
+     @Test
+-    public void immutabilitySnbt() {
++    void immutabilitySnbt() {
+         var handler = TagHandler.newHandler();
+         var tag = Tag.Integer("numbers").list();
+         List<Integer> val = new ArrayList<>();
+@@ -223,7 +223,7 @@ public class TagListTest {
+     }
+ 
+     @Test
+-    public void chainingImmutabilitySnbt() {
++    void chainingImmutabilitySnbt() {
+         var handler = TagHandler.newHandler();
+         Tag<List<List<Integer>>> tag = Tag.Integer("numbers").list().list();
+         List<List<Integer>> val = new ArrayList<>();
+diff --git a/src/test/java/net/minestom/server/tag/TagMapTest.java b/src/test/java/net/minestom/server/tag/TagMapTest.java
+index 08595008d38f29988b368940439c46f1994d1a5a..c2ea9ead15f1e86dfc31829c1b8cc234ce9bba8f 100644
+--- a/src/test/java/net/minestom/server/tag/TagMapTest.java
++++ b/src/test/java/net/minestom/server/tag/TagMapTest.java
+@@ -5,13 +5,13 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertNull;
+ 
+-public class TagMapTest {
++class TagMapTest {
+ 
+     private record Entry(int value) {
+     }
+ 
+     @Test
+-    public void map() {
++    void map() {
+         var handler = TagHandler.newHandler();
+         var intTag = Tag.Integer("key");
+         var tag = intTag.map(Entry::new, Entry::value);
+@@ -22,7 +22,7 @@ public class TagMapTest {
+     }
+ 
+     @Test
+-    public void mapDefault() {
++    void mapDefault() {
+         var handler = TagHandler.newHandler();
+         var intTag = Tag.Integer("key");
+         var tag = intTag.map(Entry::new, Entry::value);
+@@ -35,7 +35,7 @@ public class TagMapTest {
+     }
+ 
+     @Test
+-    public void mapDefaultAbsent() {
++    void mapDefaultAbsent() {
+         var handler = TagHandler.newHandler();
+         var tag = Tag.Integer("key").map(Entry::new, Entry::value);
+         assertNull(handler.getTag(tag));
+diff --git a/src/test/java/net/minestom/server/tag/TagNbtSeparatorTest.java b/src/test/java/net/minestom/server/tag/TagNbtSeparatorTest.java
+index 4e9f46c4143323f403ca2d2cf4fb419681323261..ed0d861d3abf80094695479cfdad7a3b9b960e2d 100644
+--- a/src/test/java/net/minestom/server/tag/TagNbtSeparatorTest.java
++++ b/src/test/java/net/minestom/server/tag/TagNbtSeparatorTest.java
+@@ -11,10 +11,10 @@ import java.util.Set;
+ 
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+-public class TagNbtSeparatorTest {
++class TagNbtSeparatorTest {
+ 
+     @Test
+-    public void primitives() {
++    void primitives() {
+         assertSeparation(new TagNbtSeparator.Entry<>(Tag.Byte("key"), (byte) 1),
+                 "key", NBT.Byte(1));
+         assertSeparation(new TagNbtSeparator.Entry<>(Tag.Short("key"), (short) 1),
+@@ -30,20 +30,20 @@ public class TagNbtSeparatorTest {
+     }
+ 
+     @Test
+-    public void compound() {
++    void compound() {
+         assertSeparation(new TagNbtSeparator.Entry<>(Tag.Byte("key").path("path"), (byte) 1),
+                 "path", NBT.Compound(Map.of("key", NBT.Byte(1))));
+     }
+ 
+     @Test
+-    public void compoundMultiple() {
++    void compoundMultiple() {
+         assertSeparation(Set.of(new TagNbtSeparator.Entry<>(Tag.Byte("key").path("path"), (byte) 1),
+                         new TagNbtSeparator.Entry<>(Tag.Integer("key2").path("path"), 2)),
+                 "path", NBT.Compound(Map.of("key", NBT.Byte(1), "key2", NBT.Int(2))));
+     }
+ 
+     @Test
+-    public void list() {
++    void list() {
+         assertSeparation(new TagNbtSeparator.Entry<>(Tag.Integer("key").list(), List.of(1)),
+                 "key", NBT.List(NBTType.TAG_Int, NBT.Int(1)));
+     }
+diff --git a/src/test/java/net/minestom/server/tag/TagNbtTest.java b/src/test/java/net/minestom/server/tag/TagNbtTest.java
+index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..40c970ef055dec4955fdd93e62f6e9dd58d34a10 100644
+--- a/src/test/java/net/minestom/server/tag/TagNbtTest.java
++++ b/src/test/java/net/minestom/server/tag/TagNbtTest.java
+@@ -15,10 +15,10 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
+ /**
+  * Ensure that NBT tag can be read from other tags properly.
+  */
+-public class TagNbtTest {
++class TagNbtTest {
+ 
+     @Test
+-    public void list() {
++    void list() {
+         var handler = TagHandler.newHandler();
+         var tag = Tag.NBT("nbt").list();
+         List<NBT> list = List.of(NBT.Int(1), NBT.Int(2), NBT.Int(3));
+@@ -35,7 +35,7 @@ public class TagNbtTest {
+     }
+ 
+     @Test
+-    public void map() {
++    void map() {
+         var handler = TagHandler.newHandler();
+         var tag = Tag.NBT("nbt").map(nbt -> ((NBTInt) nbt).getValue(), NBT::Int);
+         handler.setTag(tag, 5);
+@@ -51,7 +51,7 @@ public class TagNbtTest {
+     }
+ 
+     @Test
+-    public void fromCompoundModify() {
++    void fromCompoundModify() {
+         var compound = NBT.Compound(Map.of("key", NBT.Int(5)));
+         var handler = TagHandler.fromCompound(compound);
+         assertEquals(compound, handler.asCompound());
+@@ -71,7 +71,7 @@ public class TagNbtTest {
+     }
+ 
+     @Test
+-    public void fromCompoundModifyPath() {
++    void fromCompoundModifyPath() {
+         var compound = NBT.Compound(Map.of("path", NBT.Compound(Map.of("key", NBT.Int(5)))));
+         var handler = TagHandler.fromCompound(compound);
+         var tag = Tag.Integer("key").path("path");
+@@ -88,7 +88,7 @@ public class TagNbtTest {
+     }
+ 
+     @Test
+-    public void fromCompoundModifyDoublePath() {
++    void fromCompoundModifyDoublePath() {
+         var compound = NBT.Compound(Map.of("path", NBT.Compound(Map.of("path2",
+                 NBT.Compound(Map.of("key", NBT.Int(5)))))));
+         var handler = TagHandler.fromCompound(compound);
+@@ -106,7 +106,7 @@ public class TagNbtTest {
+     }
+ 
+     @Test
+-    public void compoundOverride() {
++    void compoundOverride() {
+         var handler = TagHandler.newHandler();
+         var nbtTag = Tag.NBT("path1");
+ 
+@@ -120,7 +120,7 @@ public class TagNbtTest {
+     }
+ 
+     @Test
+-    public void compoundRead() {
++    void compoundRead() {
+         var handler = TagHandler.newHandler();
+         var nbtTag = Tag.NBT("path1");
+ 
+@@ -133,7 +133,7 @@ public class TagNbtTest {
+     }
+ 
+     @Test
+-    public void compoundPathRead() {
++    void compoundPathRead() {
+         var handler = TagHandler.newHandler();
+         var nbtTag = Tag.NBT("compound").path("path");
+ 
+@@ -146,7 +146,7 @@ public class TagNbtTest {
+     }
+ 
+     @Test
+-    public void doubleCompoundRead() {
++    void doubleCompoundRead() {
+         var handler = TagHandler.newHandler();
+         var nbtTag = Tag.NBT("path1");
+ 
+@@ -159,7 +159,7 @@ public class TagNbtTest {
+     }
+ 
+     @Test
+-    public void compoundWrite() {
++    void compoundWrite() {
+         var handler = TagHandler.newHandler();
+         var nbtTag = Tag.NBT("path1");
+ 
+@@ -174,7 +174,7 @@ public class TagNbtTest {
+     }
+ 
+     @Test
+-    public void rawList() {
++    void rawList() {
+         var handler = TagHandler.newHandler();
+         var nbtTag = Tag.NBT("list");
+         var list = NBT.List(NBTType.TAG_Int, NBT.Int(1));
+@@ -183,7 +183,7 @@ public class TagNbtTest {
+     }
+ 
+     @Test
+-    public void listConversion() {
++    void listConversion() {
+         var handler = TagHandler.newHandler();
+         var nbtTag = Tag.NBT("list");
+         var listTag = Tag.Integer("list").list();
+@@ -196,7 +196,7 @@ public class TagNbtTest {
+     }
+ 
+     @Test
+-    public void rawArray() {
++    void rawArray() {
+         var handler = TagHandler.newHandler();
+         var nbtTag = Tag.NBT("array");
+         var array = NBT.IntArray(1, 2, 3);
+diff --git a/src/test/java/net/minestom/server/tag/TagPathTest.java b/src/test/java/net/minestom/server/tag/TagPathTest.java
+index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..53d6ade4e248c72c811e3057e8e0d42bfeee1190 100644
+--- a/src/test/java/net/minestom/server/tag/TagPathTest.java
++++ b/src/test/java/net/minestom/server/tag/TagPathTest.java
+@@ -7,10 +7,10 @@ import org.junit.jupiter.api.Test;
+ import static net.minestom.testing.TestUtils.assertEqualsSNBT;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class TagPathTest {
++class TagPathTest {
+ 
+     @Test
+-    public void basic() {
++    void basic() {
+         var handler = TagHandler.newHandler();
+         var tag = Tag.Integer("number");
+         var path = tag.path("display");
+@@ -28,13 +28,13 @@ public class TagPathTest {
+     }
+ 
+     @Test
+-    public void invalidPath() {
++    void invalidPath() {
+         assertThrows(IllegalArgumentException.class, () -> Tag.Integer("number").path(""));
+         assertThrows(IllegalArgumentException.class, () -> Tag.Integer("number").path("path", null));
+     }
+ 
+     @Test
+-    public void emptyRemoval() {
++    void emptyRemoval() {
+         var handler = TagHandler.newHandler();
+         var tag = Tag.Integer("number").path("display");
+         handler.removeTag(tag);
+@@ -43,7 +43,7 @@ public class TagPathTest {
+     }
+ 
+     @Test
+-    public void snbt() {
++    void snbt() {
+         var handler = TagHandler.newHandler();
+         var tag = Tag.Integer("number").path("display");
+         handler.setTag(tag, 5);
+@@ -60,7 +60,7 @@ public class TagPathTest {
+     }
+ 
+     @Test
+-    public void doubleSnbt() {
++    void doubleSnbt() {
+         var handler = TagHandler.newHandler();
+         var tag = Tag.Integer("number").path("display");
+         var tag1 = Tag.String("string").path("display");
+@@ -90,7 +90,7 @@ public class TagPathTest {
+     }
+ 
+     @Test
+-    public void secondPathClearSnbt() {
++    void secondPathClearSnbt() {
+         var handler = TagHandler.newHandler();
+         var numberTag = Tag.Integer("number").path("path1", "path2");
+         var stringTag = Tag.String("string").path("path1");
+@@ -118,7 +118,7 @@ public class TagPathTest {
+     }
+ 
+     @Test
+-    public void differentPath() {
++    void differentPath() {
+         var handler = TagHandler.newHandler();
+         var tag = Tag.Integer("number");
+         var path = tag.path("display");
+@@ -150,7 +150,7 @@ public class TagPathTest {
+     }
+ 
+     @Test
+-    public void overrideSnbt() {
++    void overrideSnbt() {
+         var handler = TagHandler.newHandler();
+         var tag = Tag.Integer("key");
+         var tag1 = Tag.Integer("value").path("key");
+@@ -172,7 +172,7 @@ public class TagPathTest {
+     }
+ 
+     @Test
+-    public void forgetPath() {
++    void forgetPath() {
+         var handler = TagHandler.newHandler();
+         var tag = Tag.Integer("key");
+         var path = Tag.Integer("value").path("key");
+@@ -181,7 +181,7 @@ public class TagPathTest {
+     }
+ 
+     @Test
+-    public void pathInvalidClear() {
++    void pathInvalidClear() {
+         var handler = TagHandler.newHandler();
+         var tag1 = Tag.Integer("pathInvalidClear1").path("key");
+         var tag2 = Tag.Integer("pathInvalidClear2").path("key");
+@@ -190,7 +190,7 @@ public class TagPathTest {
+     }
+ 
+     @Test
+-    public void chaining() {
++    void chaining() {
+         var handler = TagHandler.newHandler();
+         var tag = Tag.Integer("key");
+         var path = Tag.Integer("key").path("first", "second");
+@@ -213,7 +213,7 @@ public class TagPathTest {
+     }
+ 
+     @Test
+-    public void chainingDouble() {
++    void chainingDouble() {
+         var handler = TagHandler.newHandler();
+         var path = Tag.Integer("key").path("first", "second");
+         var path1 = Tag.Integer("key").path("first");
+@@ -257,7 +257,7 @@ public class TagPathTest {
+     }
+ 
+     @Test
+-    public void structureObstruction() {
++    void structureObstruction() {
+         record Entry(int value) {
+         }
+ 
+@@ -311,7 +311,7 @@ public class TagPathTest {
+     }
+ 
+     @Test
+-    public void tagObstruction() {
++    void tagObstruction() {
+         var handler = TagHandler.newHandler();
+         var tag = Tag.Integer("key");
+         var path = Tag.Integer("value").path("key", "second");
+diff --git a/src/test/java/net/minestom/server/tag/TagRecordTest.java b/src/test/java/net/minestom/server/tag/TagRecordTest.java
+index 1dfed907baf20311a82d5d4094500703454893e6..b189f7aa45fb74477dd54abbbeac7b1ca731be47 100644
+--- a/src/test/java/net/minestom/server/tag/TagRecordTest.java
++++ b/src/test/java/net/minestom/server/tag/TagRecordTest.java
+@@ -13,10 +13,10 @@ import java.util.Map;
+ import static net.minestom.testing.TestUtils.assertEqualsSNBT;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class TagRecordTest {
++class TagRecordTest {
+ 
+     @Test
+-    public void basic() {
++    void basic() {
+         var handler = TagHandler.newHandler();
+         var tag = Tag.Structure("vec", Vec.class);
+         var vec = new Vec(1, 2, 3);
+@@ -26,7 +26,7 @@ public class TagRecordTest {
+     }
+ 
+     @Test
+-    public void fromNBT() {
++    void fromNBT() {
+         var vecCompound = NBT.Compound(Map.of(
+                 "x", NBT.Double(1),
+                 "y", NBT.Double(2),
+@@ -37,7 +37,7 @@ public class TagRecordTest {
+     }
+ 
+     @Test
+-    public void fromNBTView() {
++    void fromNBTView() {
+         var handler = TagHandler.fromCompound(NBT.Compound(Map.of(
+                 "x", NBT.Double(1),
+                 "y", NBT.Double(2),
+@@ -47,7 +47,7 @@ public class TagRecordTest {
+     }
+ 
+     @Test
+-    public void basicSerializer() {
++    void basicSerializer() {
+         var handler = TagHandler.newHandler();
+         var serializer = TagRecord.serializer(Vec.class);
+         serializer.write(handler, new Vec(1, 2, 3));
+@@ -55,7 +55,7 @@ public class TagRecordTest {
+     }
+ 
+     @Test
+-    public void basicSnbt() {
++    void basicSnbt() {
+         var handler = TagHandler.newHandler();
+         var tag = Tag.Structure("vec", Vec.class);
+         var vec = new Vec(1, 2, 3);
+@@ -74,7 +74,7 @@ public class TagRecordTest {
+     }
+ 
+     @Test
+-    public void nbtSerializer() {
++    void nbtSerializer() {
+         record CompoundRecord(NBTCompound compound) {
+         }
+         var test = new CompoundRecord(NBT.Compound(Map.of("key", NBT.String("value"))));
+@@ -85,26 +85,26 @@ public class TagRecordTest {
+     }
+ 
+     @Test
+-    public void unsupportedList() {
++    void unsupportedList() {
+         record Test(List<Object> list) {
+         }
+         assertThrows(IllegalArgumentException.class, () -> Tag.Structure("test", Test.class));
+     }
+ 
+     @Test
+-    public void unsupportedArray() {
++    void unsupportedArray() {
+         record Test(Object[] array) {
+         }
+         assertThrows(IllegalArgumentException.class, () -> Tag.Structure("test", Test.class));
+     }
+ 
+     @Test
+-    public void forceRecord() {
++    void forceRecord() {
+         assertThrows(Throwable.class, () -> Tag.Structure("entity", Class.class.cast(Entity.class)));
+     }
+ 
+     @Test
+-    public void invalidItem() {
++    void invalidItem() {
+         // ItemStack cannot become a record due to `ItemStack#toItemNBT` being serialized differently, and independently of
+         // the item record components
+         assertThrows(Throwable.class, () -> Tag.Structure("item", Class.class.cast(ItemStack.class)));
+diff --git a/src/test/java/net/minestom/server/tag/TagSerializerTest.java b/src/test/java/net/minestom/server/tag/TagSerializerTest.java
+index 2f7c6e91e46910f8536218f9d85b9ee3f1468802..e3ca53d336f58f78ba359cce392e9ff3dffdff81 100644
+--- a/src/test/java/net/minestom/server/tag/TagSerializerTest.java
++++ b/src/test/java/net/minestom/server/tag/TagSerializerTest.java
+@@ -7,9 +7,9 @@ import org.junit.jupiter.api.Test;
+ 
+ import java.util.List;
+ 
+-public class TagSerializerTest {
++class TagSerializerTest {
+     @Test
+-    public void fromCompound(){
++    void fromCompound(){
+         var serializer = TagSerializer.fromCompound(FireworkEffect::fromCompound, FireworkEffect::asCompound);
+         var effect = new FireworkEffect(false, false, FireworkEffectType.BURST, List.of(), List.of());
+         TagHandler handler = TagHandler.newHandler();
+diff --git a/src/test/java/net/minestom/server/tag/TagStructureTest.java b/src/test/java/net/minestom/server/tag/TagStructureTest.java
+index d4f271c89568f90bd6eae7078602ba48cf4f0941..1c4f4e128624ecf265986d186341f8dd5fb85d07 100644
+--- a/src/test/java/net/minestom/server/tag/TagStructureTest.java
++++ b/src/test/java/net/minestom/server/tag/TagStructureTest.java
+@@ -10,7 +10,7 @@ import java.util.UUID;
+ import static net.minestom.testing.TestUtils.assertEqualsSNBT;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class TagStructureTest {
++class TagStructureTest {
+ 
+     private static final Tag<Entry> STRUCTURE_TAG = Tag.Structure("entry", new TagSerializer<>() {
+         private static final Tag<String> VALUE_TAG = Tag.String("value");
+@@ -46,7 +46,7 @@ public class TagStructureTest {
+     }
+ 
+     @Test
+-    public void basic() {
++    void basic() {
+         var handler = TagHandler.newHandler();
+         assertNull(handler.getTag(STRUCTURE_TAG));
+         assertFalse(handler.hasTag(STRUCTURE_TAG));
+@@ -62,7 +62,7 @@ public class TagStructureTest {
+     }
+ 
+     @Test
+-    public void snbt() {
++    void snbt() {
+         var handler = TagHandler.newHandler();
+         var entry = new Entry("hello");
+         handler.setTag(STRUCTURE_TAG, entry);
+@@ -79,7 +79,7 @@ public class TagStructureTest {
+     }
+ 
+     @Test
+-    public void overrideBasic() {
++    void overrideBasic() {
+         var handler = TagHandler.newHandler();
+         assertNull(handler.getTag(STRUCTURE_TAG));
+         assertFalse(handler.hasTag(STRUCTURE_TAG));
+@@ -105,7 +105,7 @@ public class TagStructureTest {
+     }
+ 
+     @Test
+-    public void overrideNbt() {
++    void overrideNbt() {
+         var handler = TagHandler.newHandler();
+         var entry1 = new Entry("hello");
+         var entry2 = new Entry("hello2");
+@@ -134,7 +134,7 @@ public class TagStructureTest {
+     }
+ 
+     @Test
+-    public void pathOverride() {
++    void pathOverride() {
+         var handler = TagHandler.newHandler();
+         Tag<UUID> uuidTag = Tag.UUID("Id").path("SkullOwner");
+         Tag<PlayerSkin> skinTag = Tag.Structure("Properties", new TagSerializer<PlayerSkin>() {
+diff --git a/src/test/java/net/minestom/server/tag/TagTest.java b/src/test/java/net/minestom/server/tag/TagTest.java
+index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..ba4ff92e14b8c3dfb486d47ab53ab38f2b905d00 100644
+--- a/src/test/java/net/minestom/server/tag/TagTest.java
++++ b/src/test/java/net/minestom/server/tag/TagTest.java
+@@ -11,10 +11,10 @@ import java.util.Map;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class TagTest {
++class TagTest {
+ 
+     @Test
+-    public void intGet() {
++    void intGet() {
+         var mutable = new MutableNBTCompound().setInt("key", 5);
+         var tag = Tag.Integer("key");
+         var handler = TagHandler.fromCompound(new MutableNBTCompound());
+@@ -28,7 +28,7 @@ public class TagTest {
+     }
+ 
+     @Test
+-    public void intNull() {
++    void intNull() {
+         var handler = TagHandler.fromCompound(new MutableNBTCompound().set("key", NBT.Int(5)));
+         // Removal
+         var tag = Tag.Integer("key");
+@@ -38,7 +38,7 @@ public class TagTest {
+     }
+ 
+     @Test
+-    public void intRemove() {
++    void intRemove() {
+         var handler = TagHandler.fromCompound(new MutableNBTCompound().set("key", NBT.Int(5)));
+         // Removal
+         var tag = Tag.Integer("key");
+@@ -48,14 +48,14 @@ public class TagTest {
+     }
+ 
+     @Test
+-    public void snbt() {
++    void snbt() {
+         var mutable = new MutableNBTCompound().setInt("key", 5);
+         var reader = TagHandler.fromCompound(mutable);
+         assertEquals(reader.asCompound().toSNBT(), mutable.toCompound().toSNBT(), "SNBT is not the same");
+     }
+ 
+     @Test
+-    public void fromNbt() {
++    void fromNbt() {
+         var mutable = new MutableNBTCompound().setInt("key", 5);
+         var handler = TagHandler.fromCompound(mutable);
+         assertEquals(5, handler.getTag(Tag.Integer("key")));
+@@ -63,7 +63,7 @@ public class TagTest {
+     }
+ 
+     @Test
+-    public void fromNbtCache() {
++    void fromNbtCache() {
+         // Ensure that TagHandler#asCompound reuse the same compound used for construction
+         var compound = NBT.Compound(Map.of("key", NBT.Int(5)));
+         var handler = TagHandler.fromCompound(compound);
+@@ -71,7 +71,7 @@ public class TagTest {
+     }
+ 
+     @Test
+-    public void defaultValue() {
++    void defaultValue() {
+         var nullable = Tag.String("key");
+         var notNull = nullable.defaultValue("Hey");
+         assertNotSame(nullable, notNull);
+@@ -86,7 +86,7 @@ public class TagTest {
+     }
+ 
+     @Test
+-    public void invalidType() {
++    void invalidType() {
+         var tag1 = Tag.Integer("key");
+         var tag2 = Tag.String("key");
+ 
+@@ -99,7 +99,7 @@ public class TagTest {
+     }
+ 
+     @Test
+-    public void item() {
++    void item() {
+         var item = ItemStack.of(Material.DIAMOND);
+         var tag = Tag.ItemStack("item");
+         var handler = TagHandler.newHandler();
+@@ -108,7 +108,7 @@ public class TagTest {
+     }
+ 
+     @Test
+-    public void tagResizing() {
++    void tagResizing() {
+         var tag1 = Tag.Integer("tag1");
+         var tag2 = Tag.Integer("tag2");
+         var handler = TagHandler.newHandler();
+@@ -121,7 +121,7 @@ public class TagTest {
+     }
+ 
+     @Test
+-    public void nbtResizing() {
++    void nbtResizing() {
+         var handler = TagHandler.fromCompound(NBT.Compound(Map.of(
+                 "tag1", NBT.Int(5),
+                 "tag2", NBT.Int(1))));
+@@ -131,7 +131,7 @@ public class TagTest {
+     }
+ 
+     @Test
+-    public void rehashing() {
++    void rehashing() {
+         var handler = TagHandler.newHandler();
+         for (int i = 0; i < 1000; i++) {
+             handler.setTag(Tag.Integer("rehashing" + i), i);
+diff --git a/src/test/java/net/minestom/server/tag/TagUpdateTest.java b/src/test/java/net/minestom/server/tag/TagUpdateTest.java
+index 222b875de2388871adbf7c0f84affa60481f992a..59a64d77c7cc4a5a40b569897cf6131060bc4902 100644
+--- a/src/test/java/net/minestom/server/tag/TagUpdateTest.java
++++ b/src/test/java/net/minestom/server/tag/TagUpdateTest.java
+@@ -6,10 +6,10 @@ import org.junit.jupiter.api.Test;
+ import static net.minestom.testing.TestUtils.assertEqualsSNBT;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class TagUpdateTest {
++class TagUpdateTest {
+ 
+     @Test
+-    public void update() {
++    void update() {
+         var tag = Tag.Integer("coin");
+         var handler = TagHandler.newHandler();
+         handler.updateTag(tag, integer -> {
+@@ -25,7 +25,7 @@ public class TagUpdateTest {
+     }
+ 
+     @Test
+-    public void updateDefault() {
++    void updateDefault() {
+         var tag = Tag.Integer("coin").defaultValue(25);
+         var handler = TagHandler.newHandler();
+         handler.updateTag(tag, integer -> {
+@@ -41,7 +41,7 @@ public class TagUpdateTest {
+     }
+ 
+     @Test
+-    public void updateRemoval() {
++    void updateRemoval() {
+         var tag = Tag.Integer("coin");
+         var handler = TagHandler.newHandler();
+         handler.setTag(tag, 5);
+@@ -54,7 +54,7 @@ public class TagUpdateTest {
+     }
+ 
+     @Test
+-    public void updateRemovalPath() {
++    void updateRemovalPath() {
+         var tag = Tag.Integer("coin").path("path");
+         var handler = TagHandler.newHandler();
+         handler.setTag(tag, 5);
+@@ -67,7 +67,7 @@ public class TagUpdateTest {
+     }
+ 
+     @Test
+-    public void updateAndGet() {
++    void updateAndGet() {
+         var tag = Tag.Integer("coin");
+         var handler = TagHandler.newHandler();
+         var result = handler.updateAndGetTag(tag, integer -> {
+@@ -83,7 +83,7 @@ public class TagUpdateTest {
+     }
+ 
+     @Test
+-    public void getAndUpdate() {
++    void getAndUpdate() {
+         var tag = Tag.Integer("coin");
+         var handler = TagHandler.newHandler();
+         var result = handler.getAndUpdateTag(tag, integer -> {
+@@ -99,7 +99,7 @@ public class TagUpdateTest {
+     }
+ 
+     @Test
+-    public void updateHiddenSimilarity() {
++    void updateHiddenSimilarity() {
+         var tag1 = Tag.Integer("coin");
+         var tag2 = Tag.Integer("coin").map(i -> i + 1, i -> i - 1);
+         var handler = TagHandler.newHandler();
+@@ -110,7 +110,7 @@ public class TagUpdateTest {
+     }
+ 
+     @Test
+-    public void updateStructureConversion() {
++    void updateStructureConversion() {
+         record Test(int coin) {
+         }
+ 
+@@ -131,7 +131,7 @@ public class TagUpdateTest {
+     }
+ 
+     @Test
+-    public void updateStructureConversionPath() {
++    void updateStructureConversionPath() {
+         record Test(int coin) {
+         }
+ 
+@@ -152,7 +152,7 @@ public class TagUpdateTest {
+     }
+ 
+     @Test
+-    public void updateStructureConversionPathDouble() {
++    void updateStructureConversionPathDouble() {
+         record Test(int coin) {
+         }
+         record Structure(Test test) {
+@@ -176,7 +176,7 @@ public class TagUpdateTest {
+     }
+ 
+     @Test
+-    public void updateViewConversion() {
++    void updateViewConversion() {
+         record Test(int coin) {
+         }
+ 
+@@ -194,7 +194,7 @@ public class TagUpdateTest {
+     }
+ 
+     @Test
+-    public void updateIncompatible() {
++    void updateIncompatible() {
+         var tagI = Tag.Integer("coin");
+         var tagD = Tag.Double("coin");
+         var handler = TagHandler.newHandler();
+@@ -203,7 +203,7 @@ public class TagUpdateTest {
+     }
+ 
+     @Test
+-    public void updateInner() {
++    void updateInner() {
+         var tag = Tag.Structure("vec", Vec.class);
+         var tagX = Tag.Double("x").path("vec");
+         var handler = TagHandler.newHandler();
+diff --git a/src/test/java/net/minestom/server/tag/TagUuidTest.java b/src/test/java/net/minestom/server/tag/TagUuidTest.java
+index 7867639d8e7566b15ca176627dcafa69cd1be41f..2cdcbe1aa884b444fbe45a8cebb593bc34ecd2de 100644
+--- a/src/test/java/net/minestom/server/tag/TagUuidTest.java
++++ b/src/test/java/net/minestom/server/tag/TagUuidTest.java
+@@ -8,10 +8,10 @@ import java.util.UUID;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class TagUuidTest {
++class TagUuidTest {
+ 
+     @Test
+-    public void get() {
++    void get() {
+         var uuid = UUID.randomUUID();
+         var tag = Tag.UUID("uuid");
+         var handler = TagHandler.newHandler();
+@@ -20,14 +20,14 @@ public class TagUuidTest {
+     }
+ 
+     @Test
+-    public void empty() {
++    void empty() {
+         var tag = Tag.UUID("uuid");
+         var handler = TagHandler.newHandler();
+         assertNull(handler.getTag(tag));
+     }
+ 
+     @Test
+-    public void invalidTag() {
++    void invalidTag() {
+         var tag = Tag.UUID("entry");
+         var handler = TagHandler.newHandler();
+         handler.setTag(Tag.Integer("entry"), 1);
+@@ -35,7 +35,7 @@ public class TagUuidTest {
+     }
+ 
+     @Test
+-    public void toNbt() {
++    void toNbt() {
+         var tag = Tag.UUID("uuid");
+         var handler = TagHandler.newHandler();
+         handler.setTag(tag, UUID.fromString("9ab8ca63-3d7b-43ba-b805-a20a352dae9c"));
+@@ -46,7 +46,7 @@ public class TagUuidTest {
+     }
+ 
+     @Test
+-    public void fromNbt() {
++    void fromNbt() {
+         var tag = Tag.UUID("uuid");
+         var handler = TagHandler.newHandler();
+         handler.setTag(Tag.NBT("uuid"), NBT.IntArray(-1699165597, 1031488442, -1207590390, 892186268));
+diff --git a/src/test/java/net/minestom/server/tag/TagValueShareTest.java b/src/test/java/net/minestom/server/tag/TagValueShareTest.java
+index bbed3b075d006d8c6cc92545337e428d14422c72..b375a45d41a8b04d2b7f4a9046db10841547187c 100644
+--- a/src/test/java/net/minestom/server/tag/TagValueShareTest.java
++++ b/src/test/java/net/minestom/server/tag/TagValueShareTest.java
+@@ -11,40 +11,40 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
+ /**
+  * Test tags that can share cached values.
+  */
+-public class TagValueShareTest {
++class TagValueShareTest {
+ 
+     record Entry(int value) {
+     }
+ 
+     @Test
+-    public void same() {
++    void same() {
+         var tag = Tag.String("test");
+         assertTrue(tag.shareValue(tag));
+     }
+ 
+     @Test
+-    public void similar() {
++    void similar() {
+         var tag = Tag.String("test");
+         var tag2 = Tag.String("test");
+         assertTrue(tag.shareValue(tag2));
+     }
+ 
+     @Test
+-    public void differentDefault() {
++    void differentDefault() {
+         var tag = Tag.String("test").defaultValue("test2");
+         var tag2 = Tag.String("test").defaultValue("test3");
+         assertTrue(tag.shareValue(tag2));
+     }
+ 
+     @Test
+-    public void differentType() {
++    void differentType() {
+         var tag = Tag.String("test");
+         var tag2 = Tag.Integer("test");
+         assertFalse(tag.shareValue(tag2));
+     }
+ 
+     @Test
+-    public void mapSame() {
++    void mapSame() {
+         // Force identical functions
+         Function<Integer, Entry> t1 = Entry::new;
+         Function<Entry, Integer> t2 = Entry::value;
+@@ -56,26 +56,26 @@ public class TagValueShareTest {
+     }
+ 
+     @Test
+-    public void mapChild() {
++    void mapChild() {
+         var intTag = Tag.Integer("key");
+         var tag = intTag.map(Entry::new, Entry::value);
+         assertFalse(intTag.shareValue(tag));
+     }
+ 
+     @Test
+-    public void list() {
++    void list() {
+         var tag = Tag.String("test").list();
+         assertTrue(tag.shareValue(tag));
+     }
+ 
+     @Test
+-    public void listScope() {
++    void listScope() {
+         var tag = Tag.String("test");
+         assertFalse(tag.shareValue(tag.list()));
+     }
+ 
+     @Test
+-    public void similarList() {
++    void similarList() {
+         var tag = Tag.String("test").list();
+         var tag2 = Tag.String("test").list();
+         assertTrue(tag.shareValue(tag2));
+@@ -83,7 +83,7 @@ public class TagValueShareTest {
+     }
+ 
+     @Test
+-    public void differentList() {
++    void differentList() {
+         var tag = Tag.String("test").list();
+         var tag2 = Tag.String("test").list();
+         assertFalse(tag.shareValue(tag2.list()));
+@@ -91,7 +91,7 @@ public class TagValueShareTest {
+     }
+ 
+     @Test
+-    public void differentListType() {
++    void differentListType() {
+         var tag = Tag.String("test").list();
+         var tag2 = Tag.Integer("test").list();
+         assertFalse(tag.shareValue(tag2));
+@@ -99,14 +99,14 @@ public class TagValueShareTest {
+     }
+ 
+     @Test
+-    public void recordStructure() {
++    void recordStructure() {
+         var tag = Tag.Structure("test", Vec.class);
+         var tag2 = Tag.Structure("test", Vec.class);
+         assertTrue(tag.shareValue(tag2));
+     }
+ 
+     @Test
+-    public void recordStructureList() {
++    void recordStructureList() {
+         var tag = Tag.Structure("test", Vec.class).list();
+         var tag2 = Tag.Structure("test", Vec.class).list();
+         assertTrue(tag.shareValue(tag2));
+diff --git a/src/test/java/net/minestom/server/tag/TagViewTest.java b/src/test/java/net/minestom/server/tag/TagViewTest.java
+index 718d84a6bb77d1ccb9cf5a00358c9df20e141ddd..8ab88efa4bcf663f11ac9392adb425ac86cb9fbd 100644
+--- a/src/test/java/net/minestom/server/tag/TagViewTest.java
++++ b/src/test/java/net/minestom/server/tag/TagViewTest.java
+@@ -11,7 +11,7 @@ import java.util.Map;
+ import static net.minestom.testing.TestUtils.assertEqualsSNBT;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class TagViewTest {
++class TagViewTest {
+ 
+     private static final Tag<Entry> VIEW_TAG = Tag.View(new TagSerializer<>() {
+         private static final Tag<String> VALUE_TAG = Tag.String("value");
+@@ -32,7 +32,7 @@ public class TagViewTest {
+     }
+ 
+     @Test
+-    public void basic() {
++    void basic() {
+         var handler = TagHandler.newHandler();
+         assertNull(handler.getTag(VIEW_TAG));
+         assertFalse(handler.hasTag(VIEW_TAG));
+@@ -48,7 +48,7 @@ public class TagViewTest {
+     }
+ 
+     @Test
+-    public void snbt() {
++    void snbt() {
+         var handler = TagHandler.newHandler();
+         var entry = new Entry("hello");
+         handler.setTag(VIEW_TAG, entry);
+@@ -63,7 +63,7 @@ public class TagViewTest {
+     }
+ 
+     @Test
+-    public void snbtOverride() {
++    void snbtOverride() {
+         var handler = TagHandler.newHandler();
+         var entry = new Entry("hello");
+         handler.setTag(VIEW_TAG, entry);
+@@ -82,7 +82,7 @@ public class TagViewTest {
+     }
+ 
+     @Test
+-    public void empty() {
++    void empty() {
+         var handler = TagHandler.newHandler();
+         var tag = Tag.View(new TagSerializer<Entry>() {
+             @Override
+@@ -112,7 +112,7 @@ public class TagViewTest {
+     }
+ 
+     @Test
+-    public void path() {
++    void path() {
+         var handler = TagHandler.newHandler();
+         var tag = VIEW_TAG.path("path");
+         assertNull(handler.getTag(tag));
+@@ -129,7 +129,7 @@ public class TagViewTest {
+     }
+ 
+     @Test
+-    public void pathSnbt() {
++    void pathSnbt() {
+         var handler = TagHandler.newHandler();
+         var tag = VIEW_TAG.path("path");
+         var entry = new Entry("hello");
+@@ -147,7 +147,7 @@ public class TagViewTest {
+     }
+ 
+     @Test
+-    public void compoundSerializer() {
++    void compoundSerializer() {
+         var tag = Tag.View(TagSerializer.COMPOUND);
+         var handler = TagHandler.newHandler();
+         handler.setTag(tag, NBT.Compound(Map.of("value", NBT.String("hello"))));
+diff --git a/src/test/java/net/minestom/server/thread/AcquirableTest.java b/src/test/java/net/minestom/server/thread/AcquirableTest.java
+index 43753f558743fb6d8cdc7a15211e23b57e033e66..af6812e4251131fe3750600aae6ee1143f09375f 100644
+--- a/src/test/java/net/minestom/server/thread/AcquirableTest.java
++++ b/src/test/java/net/minestom/server/thread/AcquirableTest.java
+@@ -9,10 +9,10 @@ import java.util.concurrent.atomic.AtomicReference;
+ import static org.junit.jupiter.api.Assertions.assertNotEquals;
+ import static org.junit.jupiter.api.Assertions.assertNotNull;
+ 
+-public class AcquirableTest {
++class AcquirableTest {
+ 
+     @Test
+-    public void assignation() {
++    void assignation() {
+         AtomicReference<TickThread> tickThread = new AtomicReference<>();
+         Entity entity = new Entity(EntityType.ZOMBIE) {
+             @Override
+diff --git a/src/test/java/net/minestom/server/thread/ThreadDispatcherTest.java b/src/test/java/net/minestom/server/thread/ThreadDispatcherTest.java
+index 00f7b48addb0e4ba2ff77f2ea2b49faa374fa4b8..d9de83b15b836ca618f7b9e170062569e8d6e2f3 100644
+--- a/src/test/java/net/minestom/server/thread/ThreadDispatcherTest.java
++++ b/src/test/java/net/minestom/server/thread/ThreadDispatcherTest.java
+@@ -14,10 +14,10 @@ import java.util.stream.IntStream;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class ThreadDispatcherTest {
++class ThreadDispatcherTest {
+ 
+     @Test
+-    public void elementTick() {
++    void elementTick() {
+         final AtomicInteger counter = new AtomicInteger();
+         ThreadDispatcher<Object> dispatcher = ThreadDispatcher.singleThread();
+         assertEquals(1, dispatcher.threads().size());
+@@ -45,7 +45,7 @@ public class ThreadDispatcherTest {
+     }
+ 
+     @Test
+-    public void partitionTick() {
++    void partitionTick() {
+         // Partitions implementing Tickable should be ticked same as elements
+         final AtomicInteger counter1 = new AtomicInteger();
+         final AtomicInteger counter2 = new AtomicInteger();
+@@ -74,7 +74,7 @@ public class ThreadDispatcherTest {
+     }
+ 
+     @Test
+-    public void uniqueThread() {
++    void uniqueThread() {
+         // Ensure that partitions are properly dispatched across threads
+         final int threadCount = 10;
+         ThreadDispatcher<Tickable> dispatcher = ThreadDispatcher.of(ThreadProvider.counter(), threadCount);
+@@ -103,7 +103,7 @@ public class ThreadDispatcherTest {
+     }
+ 
+     @Test
+-    public void threadUpdate() {
++    void threadUpdate() {
+         // Ensure that partitions threads are properly updated every tick
+         // when RefreshType.ALWAYS is used
+         interface Updater extends Tickable {
+diff --git a/src/test/java/net/minestom/server/timer/TestScheduler.java b/src/test/java/net/minestom/server/timer/TestScheduler.java
+index fdbb080822e6110b4dfbe8dcb2b51c0f868170af..3ebcb5bfc47cbb6de2579938560c224cda81b8d8 100644
+--- a/src/test/java/net/minestom/server/timer/TestScheduler.java
++++ b/src/test/java/net/minestom/server/timer/TestScheduler.java
+@@ -8,10 +8,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class TestScheduler {
++class TestScheduler {
+ 
+     @Test
+-    public void tickTask() {
++    void tickTask() {
+         Scheduler scheduler = Scheduler.newScheduler();
+         AtomicBoolean result = new AtomicBoolean(false);
+         Task task = scheduler.scheduleNextTick(() -> result.set(true));
+@@ -26,7 +26,7 @@ public class TestScheduler {
+     }
+ 
+     @Test
+-    public void durationTask() throws InterruptedException {
++    void durationTask() throws InterruptedException {
+         Scheduler scheduler = Scheduler.newScheduler();
+         AtomicBoolean result = new AtomicBoolean(false);
+         scheduler.buildTask(() -> result.set(true))
+@@ -41,7 +41,7 @@ public class TestScheduler {
+     }
+ 
+     @Test
+-    public void immediateTask() {
++    void immediateTask() {
+         Scheduler scheduler = Scheduler.newScheduler();
+         AtomicBoolean result = new AtomicBoolean(false);
+         scheduler.scheduleNextProcess(() -> result.set(true));
+@@ -55,7 +55,7 @@ public class TestScheduler {
+     }
+ 
+     @Test
+-    public void cancelTask() {
++    void cancelTask() {
+         Scheduler scheduler = Scheduler.newScheduler();
+         AtomicBoolean result = new AtomicBoolean(false);
+         var task = scheduler.buildTask(() -> result.set(true))
+@@ -68,7 +68,7 @@ public class TestScheduler {
+     }
+ 
+     @Test
+-    public void cancelAsyncDelayedTask() throws InterruptedException {
++    void cancelAsyncDelayedTask() throws InterruptedException {
+         Scheduler scheduler = Scheduler.newScheduler();
+         AtomicBoolean result = new AtomicBoolean(false);
+         var task = scheduler.buildTask(() -> result.set(true))
+@@ -84,7 +84,7 @@ public class TestScheduler {
+     }
+ 
+     @Test
+-    public void parkTask() {
++    void parkTask() {
+         Scheduler scheduler = Scheduler.newScheduler();
+         // Ignored parked task
+         scheduler.buildTask(() -> fail("This parked task should never be executed"))
+@@ -108,7 +108,7 @@ public class TestScheduler {
+     }
+ 
+     @Test
+-    public void futureTask() {
++    void futureTask() {
+         Scheduler scheduler = Scheduler.newScheduler();
+         CompletableFuture<Void> future = new CompletableFuture<>();
+         AtomicBoolean result = new AtomicBoolean(false);
+@@ -123,7 +123,7 @@ public class TestScheduler {
+     }
+ 
+     @Test
+-    public void asyncTask() throws InterruptedException {
++    void asyncTask() throws InterruptedException {
+         final Thread currentThread = Thread.currentThread();
+         Scheduler scheduler = Scheduler.newScheduler();
+         AtomicBoolean result = new AtomicBoolean(false);
+diff --git a/src/test/java/net/minestom/server/utils/ChunkUtilsTest.java b/src/test/java/net/minestom/server/utils/ChunkUtilsTest.java
+index 5327ad0533a6262b55575da0e7851d3fe4e77f2b..c6d314ab4f1c99aed9d662432844a0edb28e014d 100644
+--- a/src/test/java/net/minestom/server/utils/ChunkUtilsTest.java
++++ b/src/test/java/net/minestom/server/utils/ChunkUtilsTest.java
+@@ -9,11 +9,11 @@ import org.junit.jupiter.api.Assertions;
+ import java.util.*;
+ import java.util.stream.Stream;
+ 
+-public class ChunkUtilsTest {
++class ChunkUtilsTest {
+ 
+     @ParameterizedTest
+     @MethodSource("testForDifferingChunksInRangeParams")
+-    public void testForDifferingChunksInRange(int nx, int nz, int ox, int oz, int r) {
++    void testForDifferingChunksInRange(int nx, int nz, int ox, int oz, int r) {
+         final Set<ChunkCoordinate> n = new HashSet<>();
+         final Set<ChunkCoordinate> o = new HashSet<>();
+         ChunkUtils.forChunksInRange(nx, nz, r, (x, z) -> n.add(new ChunkCoordinate(x, z)));
+diff --git a/src/test/java/net/minestom/server/utils/NamespaceIDTest.java b/src/test/java/net/minestom/server/utils/NamespaceIDTest.java
+index 5bae45cd92299a01210869345899018fa4c646af..07ce514e9d8268495d2e4ee632f6760a81a120e8 100644
+--- a/src/test/java/net/minestom/server/utils/NamespaceIDTest.java
++++ b/src/test/java/net/minestom/server/utils/NamespaceIDTest.java
+@@ -5,10 +5,10 @@ import org.junit.jupiter.api.Test;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class NamespaceIDTest {
++class NamespaceIDTest {
+ 
+     @Test
+-    public void init() {
++    void init() {
+         var namespace = NamespaceID.from("minecraft:any");
+         assertEquals("minecraft", namespace.domain());
+         assertEquals("any", namespace.path());
+@@ -21,7 +21,7 @@ public class NamespaceIDTest {
+     }
+ 
+     @Test
+-    public void equals() {
++    void equals() {
+         var namespace = NamespaceID.from("minecraft:any");
+         assertEquals(namespace, NamespaceID.from("minecraft:any"));
+         assertNotEquals(namespace, NamespaceID.from("minecraft:any2"));
+@@ -29,7 +29,7 @@ public class NamespaceIDTest {
+     }
+     // Microtus start - Fix namespace hashcode and equals
+     @Test
+-    public void hashCodeConsistentWithEquals() {
++    void hashCodeConsistentWithEquals() {
+         var namespace = NamespaceID.from("minecraft:any");
+         var key = Key.key("minecraft:any");
+ 
+@@ -39,50 +39,50 @@ public class NamespaceIDTest {
+     // Microtus end - Fix namespace hashcode and equals
+ 
+     @Test
+-    public void atMostOneColon() {
++    void atMostOneColon() {
+         assertThrows(AssertionError.class, () -> NamespaceID.from("minecraft:block:wool"));
+     }
+ 
+     @Test
+-    public void noSlashInDomain() {
++    void noSlashInDomain() {
+         assertThrows(AssertionError.class, () -> NamespaceID.from("minecraft/java_edition:any"));
+     }
+ 
+     @Test
+-    public void noDotInDomain() {
++    void noDotInDomain() {
+         assertThrows(AssertionError.class, () -> NamespaceID.from("minecraft.java:game"));
+     }
+ 
+     @Test
+-    public void noUppercase() {
++    void noUppercase() {
+         assertThrows(AssertionError.class, () -> NamespaceID.from("Minecraft:any"));
+         assertThrows(AssertionError.class, () -> NamespaceID.from("minecraft:Any"));
+     }
+ 
+     @Test
+-    public void noSpace() {
++    void noSpace() {
+         assertThrows(AssertionError.class, () -> NamespaceID.from("minecraft:a n y"));
+     }
+ 
+     @Test
+-    public void onlyLatinLowercase() {
++    void onlyLatinLowercase() {
+         assertThrows(AssertionError.class, () -> NamespaceID.from("Minecraft:voilà"));
+         assertThrows(AssertionError.class, () -> NamespaceID.from("minecraft:où_ça"));
+         assertThrows(AssertionError.class, () -> NamespaceID.from("minecraft:schrödingers_var"));
+     }
+ 
+     @Test
+-    public void numbersAllowed() {
++    void numbersAllowed() {
+         NamespaceID.from("0xc1:468786471");
+     }
+ 
+     @Test
+-    public void dotAllowedInPath() {
++    void dotAllowedInPath() {
+         NamespaceID.from("minecraft:ambient.cave");
+     }
+ 
+     @Test
+-    public void slashAllowedInPath() {
++    void slashAllowedInPath() {
+         NamespaceID.from("minecraft:textures/blocks/dirt.png");
+     }
+ }
+diff --git a/src/test/java/net/minestom/server/utils/ObjectPoolTest.java b/src/test/java/net/minestom/server/utils/ObjectPoolTest.java
+index 42c8557addf779784d57fc5eac5147fd533e4025..d3dc473514df009b1df3957ae5bdfde0e46cd05f 100644
+--- a/src/test/java/net/minestom/server/utils/ObjectPoolTest.java
++++ b/src/test/java/net/minestom/server/utils/ObjectPoolTest.java
+@@ -8,10 +8,10 @@ import java.util.Set;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class ObjectPoolTest {
++class ObjectPoolTest {
+ 
+     @Test
+-    public void pool() {
++    void pool() {
+         var pool = ObjectPool.BUFFER_POOL;
+         Set<BinaryBuffer> pooledBuffers = new HashSet<>();
+         pool.clear();
+@@ -31,7 +31,7 @@ public class ObjectPoolTest {
+     }
+ 
+     @Test
+-    public void autoClose() {
++    void autoClose() {
+         var pool = ObjectPool.BUFFER_POOL;
+         assertEquals(0, pool.count());
+         try (var ignored = pool.hold()) {
+diff --git a/src/test/java/net/minestom/server/utils/PositionUtilsTest.java b/src/test/java/net/minestom/server/utils/PositionUtilsTest.java
+index 888bee67eda2820ebb9944e04073dcb020c162dd..aeba8005db97d16d04b385b388ff469f533ac6a6 100644
+--- a/src/test/java/net/minestom/server/utils/PositionUtilsTest.java
++++ b/src/test/java/net/minestom/server/utils/PositionUtilsTest.java
+@@ -5,10 +5,10 @@ import org.junit.jupiter.api.Test;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class PositionUtilsTest {
++class PositionUtilsTest {
+ 
+     @Test
+-    public void yaw() {
++    void yaw() {
+         float plusX = PositionUtils.getLookYaw(10, 0);
+         assertEquals(-90, plusX, 1E-5);
+ 
+@@ -34,7 +34,7 @@ public class PositionUtilsTest {
+     }
+ 
+     @Test
+-    public void highPitch() {
++    void highPitch() {
+         float high = PositionUtils.getLookPitch(0, 999999, 0);
+         assertEquals(-90, high, 1E-5);
+ 
+diff --git a/src/test/java/net/minestom/server/utils/TestMojangUtils.java b/src/test/java/net/minestom/server/utils/TestMojangUtils.java
+index eee508bc380ebb9a8668b80acacfedf342bde903..4eb0a8407815dc946a268d5eeb6c09658e4c85c6 100644
+--- a/src/test/java/net/minestom/server/utils/TestMojangUtils.java
++++ b/src/test/java/net/minestom/server/utils/TestMojangUtils.java
+@@ -5,22 +5,22 @@ import org.junit.jupiter.api.Test;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class TestMojangUtils {
++class TestMojangUtils {
+     @Test
+-    public void testValidNameWorks() {
++    void testValidNameWorks() {
+         var result = MojangUtils.fromUsername("jeb_");
+         assertNotNull(result);
+         assertEquals("jeb_", result.get("name").getAsString());
+     }
+ 
+     @Test
+-    public void testInvalidNameReturnsNull() {
++    void testInvalidNameReturnsNull() {
+         var result = MojangUtils.fromUsername("jfdsa84vvcxadubasdfcvn"); // Longer than 16, always invalid
+         assertNull(result);
+     }
+ 
+     @Test
+-    public void testValidUuidWorks() {
++    void testValidUuidWorks() {
+         var result = MojangUtils.fromUuid("853c80ef3c3749fdaa49938b674adae6");
+         assertNotNull(result);
+         assertEquals("jeb_", result.get("name").getAsString());
+@@ -28,13 +28,13 @@ public class TestMojangUtils {
+     }
+ 
+     @Test
+-    public void testInvalidUuidReturnsNull() {
++    void testInvalidUuidReturnsNull() {
+         var result = MojangUtils.fromUuid("853c80ef3c3749fdaa49938b674adae6a"); // Longer than 32, always invalid
+         assertNull(result);
+     }
+ 
+     @Test
+-    public void testNonExistentUuidReturnsNull() {
++    void testNonExistentUuidReturnsNull() {
+         var result = MojangUtils.fromUuid("00000000-0000-0000-0000-000000000000");
+         assertNull(result);
+     }
+diff --git a/src/test/java/net/minestom/server/utils/TranslationIntegrationTest.java b/src/test/java/net/minestom/server/utils/TranslationIntegrationTest.java
+index fe070a1d1754c08e9143bd357bf63695c738c2a1..feb26612e86ad2d576a2d2f28600b01b340e4566 100644
+--- a/src/test/java/net/minestom/server/utils/TranslationIntegrationTest.java
++++ b/src/test/java/net/minestom/server/utils/TranslationIntegrationTest.java
+@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertNotEquals;
+ 
+ @EnvTest
+-public class TranslationIntegrationTest {
++class TranslationIntegrationTest {
+ 
+     @BeforeAll
+     static void translator() {
+@@ -30,7 +30,7 @@ public class TranslationIntegrationTest {
+     }
+ 
+     @Test
+-    public void testTranslationEnabled(final Env env) {
++    void testTranslationEnabled(final Env env) {
+         final var instance = env.createFlatInstance();
+         final var connection = env.createConnection();
+         final var player = connection.connect(instance, new Pos(0, 40, 0)).join();
+@@ -49,7 +49,7 @@ public class TranslationIntegrationTest {
+     }
+ 
+     @Test
+-    public void testTranslationDisabled(final Env env) {
++    void testTranslationDisabled(final Env env) {
+         final var instance = env.createFlatInstance();
+         final var connection = env.createConnection();
+         final var player = connection.connect(instance, new Pos(0, 40, 0)).join();
+diff --git a/src/test/java/net/minestom/server/utils/block/BlockIteratorTest.java b/src/test/java/net/minestom/server/utils/block/BlockIteratorTest.java
+index 12ba498890d53c76c1847fb0df1367943a33b4fe..a944e04ef851f120970e6e12a76a7dd670997c89 100644
+--- a/src/test/java/net/minestom/server/utils/block/BlockIteratorTest.java
++++ b/src/test/java/net/minestom/server/utils/block/BlockIteratorTest.java
+@@ -9,13 +9,13 @@ import java.util.List;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class BlockIteratorTest {
++class BlockIteratorTest {
+     private void assertContains(List<Point> points, Point point) {
+         assertTrue(points.contains(point), "Expected " + points + " to contain " + point);
+     }
+ 
+     @Test
+-    public void test2dOffsetppp() {
++    void test2dOffsetppp() {
+         Vec s = new Vec(0,  0.1, 0);
+         Vec e = new Vec(2, 1, 0);
+         BlockIterator iterator = new BlockIterator(s, e, 0, 4);
+@@ -29,7 +29,7 @@ public class BlockIteratorTest {
+     }
+ 
+     @Test
+-    public void test2dOffsetppn() {
++    void test2dOffsetppn() {
+         Vec s = new Vec(0,  0.1, 0);
+         Vec e = new Vec(-2, 1, 0);
+         BlockIterator iterator = new BlockIterator(s, e, 0, 4);
+@@ -44,7 +44,7 @@ public class BlockIteratorTest {
+     }
+ 
+     @Test
+-    public void test2dOffsetnpp() {
++    void test2dOffsetnpp() {
+         Vec s = new Vec(0,  -0.1, 0);
+         Vec e = new Vec(2, 1, 0);
+         BlockIterator iterator = new BlockIterator(s, e, 0, 4);
+@@ -59,7 +59,7 @@ public class BlockIteratorTest {
+     }
+ 
+     @Test
+-    public void test2dOffsetnnp() {
++    void test2dOffsetnnp() {
+         Vec s = new Vec(0,  -0.1, 0);
+         Vec e = new Vec(-2, 1, 0);
+         BlockIterator iterator = new BlockIterator(s, e, 0, 4);
+@@ -75,7 +75,7 @@ public class BlockIteratorTest {
+     }
+ 
+     @Test
+-    public void testZeroVelocity() {
++    void testZeroVelocity() {
+         Vec s = new Vec(0,  0, 0);
+         Vec e = new Vec(0, 0, 0);
+         BlockIterator iterator = new BlockIterator(s, e, 0, 4);
+@@ -83,7 +83,7 @@ public class BlockIteratorTest {
+     }
+ 
+     @Test
+-    public void testLongDistance() {
++    void testLongDistance() {
+         Vec s = new Vec(42.5, 0, 51.5);
+         Vec e = new Vec(-12, 0, -36);
+         BlockIterator iterator = new BlockIterator(s, e, 0, 37);
+@@ -163,7 +163,7 @@ public class BlockIteratorTest {
+     }
+ 
+     @Test
+-    public void testSkipping() {
++    void testSkipping() {
+         Vec s = new Vec(0.5, 40, 0.5);
+         Vec e = new Vec(27, 0, 21);
+         BlockIterator iterator = new BlockIterator(s, e, 0, 34);
+@@ -235,7 +235,7 @@ public class BlockIteratorTest {
+     }
+ 
+     @Test
+-    public void testExactEnd() {
++    void testExactEnd() {
+         Vec s = new Vec(0.5,  0, 0.5);
+         Vec e = new Vec(0, 1, 0);
+         BlockIterator iterator = new BlockIterator(s, e, 0, 1);
+@@ -245,7 +245,7 @@ public class BlockIteratorTest {
+     }
+ 
+     @Test
+-    public void testSameEnd() {
++    void testSameEnd() {
+         Vec s = new Vec(0.5,  0, 0.5);
+         Vec e = new Vec(0, 1, 0);
+         BlockIterator iterator = new BlockIterator(s, e, 0, 0.5);
+@@ -254,7 +254,7 @@ public class BlockIteratorTest {
+     }
+ 
+     @Test
+-    public void test3dExtraCollection() {
++    void test3dExtraCollection() {
+         Vec s = new Vec(0.1,  0.1, 0.1);
+         Vec e = new Vec(1, 1, 1);
+         BlockIterator iterator = new BlockIterator(s, e, 0, 4);
+@@ -283,7 +283,7 @@ public class BlockIteratorTest {
+     }
+ 
+     @Test
+-    public void test2dpp() {
++    void test2dpp() {
+         Vec s = new Vec(0,  0, 0);
+         Vec e = new Vec(2, 1, 0);
+         BlockIterator iterator = new BlockIterator(s, e, 0, 4);
+@@ -309,7 +309,7 @@ public class BlockIteratorTest {
+     }
+ 
+     @Test
+-    public void test2dpn() {
++    void test2dpn() {
+         Vec s = new Vec(0,  0, 0);
+         Vec e = new Vec(-2, 1, 0);
+         BlockIterator iterator = new BlockIterator(s, e, 0, 4);
+@@ -336,7 +336,7 @@ public class BlockIteratorTest {
+     }
+ 
+     @Test
+-    public void test2dnn() {
++    void test2dnn() {
+         Vec s = new Vec(0,  0, 0);
+         Vec e = new Vec(-2, -1, 0);
+         BlockIterator iterator = new BlockIterator(s, e, 0, 4);
+@@ -365,7 +365,7 @@ public class BlockIteratorTest {
+     }
+ 
+     @Test
+-    public void falling() {
++    void falling() {
+         Vec s = new Vec(0,  42, 0);
+         Vec e = new Vec(0, -10, 0);
+         BlockIterator iterator = new BlockIterator(s, e, 0, 14.142135623730951);
+diff --git a/src/test/java/net/minestom/server/utils/collection/AutoIncrementMapTest.java b/src/test/java/net/minestom/server/utils/collection/AutoIncrementMapTest.java
+index b19454170b525977d6a59353a8da6bc70896bad1..04946c4ab86fe6aad9cebcd510f64251af5c8a55 100644
+--- a/src/test/java/net/minestom/server/utils/collection/AutoIncrementMapTest.java
++++ b/src/test/java/net/minestom/server/utils/collection/AutoIncrementMapTest.java
+@@ -4,9 +4,9 @@ import org.junit.jupiter.api.Test;
+ 
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
+-public class AutoIncrementMapTest {
++class AutoIncrementMapTest {
+     @Test
+-    public void test() {
++    void test() {
+         AutoIncrementMap<String> map = new AutoIncrementMap<>();
+         for (int i = 0; i < 1000; i++) {
+             assertEquals(i, map.get("test" + i));
+diff --git a/src/test/java/net/minestom/server/utils/collection/ObjectArrayTest.java b/src/test/java/net/minestom/server/utils/collection/ObjectArrayTest.java
+index ee2f9544050ed61ad3467949cbdc80004d0739e4..cece245e05262a23325a48f8bd7194d7e87462e1 100644
+--- a/src/test/java/net/minestom/server/utils/collection/ObjectArrayTest.java
++++ b/src/test/java/net/minestom/server/utils/collection/ObjectArrayTest.java
+@@ -5,11 +5,11 @@ import org.junit.jupiter.params.provider.ValueSource;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class ObjectArrayTest {
++class ObjectArrayTest {
+ 
+     @ParameterizedTest
+     @ValueSource(booleans = {false, true})
+-    public void objectArray(boolean concurrent) {
++    void objectArray(boolean concurrent) {
+         ObjectArray<String> array = concurrent ? ObjectArray.concurrent() : ObjectArray.singleThread();
+ 
+         array.set(50, "Hey");
+@@ -37,7 +37,7 @@ public class ObjectArrayTest {
+ 
+     @ParameterizedTest
+     @ValueSource(booleans = {false, true})
+-    public void arrayCopy(boolean concurrent) {
++    void arrayCopy(boolean concurrent) {
+         ObjectArray<String> array = concurrent ? ObjectArray.concurrent() : ObjectArray.singleThread();
+ 
+         array.set(1, "Hey");

--- a/minestom-patches/0015-Update-java-keyword-usage.patch
+++ b/minestom-patches/0015-Update-java-keyword-usage.patch
@@ -697,14 +697,15 @@ index 4730006416bd9c4a7f1ff291feddb83c9ffedd6d..00764c03932ecef0e5ac7f68762e4d12
          return Stream.empty();
      }
 diff --git a/src/test/java/net/minestom/server/InsideTest.java b/src/test/java/net/minestom/server/InsideTest.java
-index 4fd8bc46ba32abc852398872bf8b63a30617408e..33c65cc23c0982d2e37eb12e40d844562bf85380 100644
+index 4fd8bc46ba32abc852398872bf8b63a30617408e..36d872b6e4e9a8db1fb7e75c808e912a3f52d12c 100644
 --- a/src/test/java/net/minestom/server/InsideTest.java
 +++ b/src/test/java/net/minestom/server/InsideTest.java
-@@ -5,9 +5,9 @@ import org.junit.jupiter.api.Test;
+@@ -5,9 +5,10 @@ import org.junit.jupiter.api.Test;
  
  import static org.junit.jupiter.api.Assertions.assertTrue;
  
 -public class InsideTest {
++//Microtus - update java keyword usage
 +class InsideTest {
      @Test
 -    public void inside() {
@@ -713,14 +714,15 @@ index 4fd8bc46ba32abc852398872bf8b63a30617408e..33c65cc23c0982d2e37eb12e40d84456
      }
  }
 diff --git a/src/test/java/net/minestom/server/ServerProcessTest.java b/src/test/java/net/minestom/server/ServerProcessTest.java
-index 96d1264f5efefc33cf125747b591a94dc0f5da57..c0c90d3e6fa722ca5e79d71955965b3f42fea33b 100644
+index 96d1264f5efefc33cf125747b591a94dc0f5da57..98a05295c822c1cebbcb23e7dcddbeac6834709c 100644
 --- a/src/test/java/net/minestom/server/ServerProcessTest.java
 +++ b/src/test/java/net/minestom/server/ServerProcessTest.java
-@@ -8,10 +8,10 @@ import java.util.concurrent.atomic.AtomicReference;
+@@ -8,10 +8,11 @@ import java.util.concurrent.atomic.AtomicReference;
  import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
  import static org.junit.jupiter.api.Assertions.assertThrows;
  
 -public class ServerProcessTest {
++//Microtus - update java keyword usage
 +class ServerProcessTest {
  
      @Test
@@ -729,7 +731,7 @@ index 96d1264f5efefc33cf125747b591a94dc0f5da57..c0c90d3e6fa722ca5e79d71955965b3f
          AtomicReference<ServerProcess> process = new AtomicReference<>();
          assertDoesNotThrow(() -> process.set(MinecraftServer.updateProcess()));
          assertDoesNotThrow(() -> process.get().start(new InetSocketAddress("localhost", 25565)));
-@@ -20,7 +20,7 @@ public class ServerProcessTest {
+@@ -20,7 +21,7 @@ public class ServerProcessTest {
      }
  
      @Test
@@ -739,12 +741,14 @@ index 96d1264f5efefc33cf125747b591a94dc0f5da57..c0c90d3e6fa722ca5e79d71955965b3f
          process.start(new InetSocketAddress("localhost", 25565));
          var ticker = process.ticker();
 diff --git a/src/test/java/net/minestom/server/advancements/AdvancementIntegrationTest.java b/src/test/java/net/minestom/server/advancements/AdvancementIntegrationTest.java
-index d74d97e8b826dbca100f31d830bba83b91ced040..2d317516f9e63cd732019b22b39d7c76d5861ec8 100644
+index d74d97e8b826dbca100f31d830bba83b91ced040..e8c664e3ecf6ba0483d2c78292c7e9df45463094 100644
 --- a/src/test/java/net/minestom/server/advancements/AdvancementIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/advancements/AdvancementIntegrationTest.java
-@@ -10,10 +10,10 @@ import org.junit.jupiter.api.Test;
+@@ -9,11 +9,12 @@ import org.junit.jupiter.api.Test;
+ 
  import static org.junit.jupiter.api.Assertions.*;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class AdvancementIntegrationTest {
 +class AdvancementIntegrationTest {
@@ -755,7 +759,7 @@ index d74d97e8b826dbca100f31d830bba83b91ced040..2d317516f9e63cd732019b22b39d7c76
          var instance = env.createFlatInstance();
          var player = env.createPlayer(instance, new Pos(0, 42, 0));
  
-@@ -46,7 +46,7 @@ public class AdvancementIntegrationTest {
+@@ -46,7 +47,7 @@ public class AdvancementIntegrationTest {
      }
  
      @Test
@@ -765,14 +769,15 @@ index d74d97e8b826dbca100f31d830bba83b91ced040..2d317516f9e63cd732019b22b39d7c76
          var player = env.createPlayer(instance, new Pos(0, 42, 0));
  
 diff --git a/src/test/java/net/minestom/server/adventure/provider/TranslationTest.java b/src/test/java/net/minestom/server/adventure/provider/TranslationTest.java
-index 6754317b80025d68e92e526ba8a4eab9fefbfe6a..fa2ea6380affb15c5e5e4cb94ccb478277a16a50 100644
+index 6754317b80025d68e92e526ba8a4eab9fefbfe6a..a3a72f90485a8736130008e0af937c37913db8fe 100644
 --- a/src/test/java/net/minestom/server/adventure/provider/TranslationTest.java
 +++ b/src/test/java/net/minestom/server/adventure/provider/TranslationTest.java
-@@ -4,10 +4,10 @@ import net.kyori.adventure.text.Component;
+@@ -4,10 +4,11 @@ import net.kyori.adventure.text.Component;
  import net.minestom.server.adventure.MinestomAdventure;
  import org.junit.jupiter.api.Test;
  
 -public class TranslationTest {
++//Microtus - update java keyword usage
 +class TranslationTest {
  
      @Test
@@ -782,19 +787,21 @@ index 6754317b80025d68e92e526ba8a4eab9fefbfe6a..fa2ea6380affb15c5e5e4cb94ccb4782
          try {
              MinestomFlattenerProvider.INSTANCE.flatten(Component.translatable("key.unregistered"), text -> {
 diff --git a/src/test/java/net/minestom/server/collision/EntityBlockPhysicsIntegrationTest.java b/src/test/java/net/minestom/server/collision/EntityBlockPhysicsIntegrationTest.java
-index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a3b690598 100644
+index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab33ae56a3c 100644
 --- a/src/test/java/net/minestom/server/collision/EntityBlockPhysicsIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/collision/EntityBlockPhysicsIntegrationTest.java
-@@ -17,7 +17,7 @@ import java.util.Map;
+@@ -16,8 +16,9 @@ import java.util.Map;
+ 
  import static org.junit.jupiter.api.Assertions.*;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class EntityBlockPhysicsIntegrationTest {
 +class EntityBlockPhysicsIntegrationTest {
      private static final Point PRECISION = new Pos(0.01, 0.01, 0.01);
  
      private static boolean checkPoints(Point expected, Point actual) {
-@@ -45,7 +45,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -45,7 +46,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -803,7 +810,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(0, 43, 1, Block.STONE);
  
-@@ -58,7 +58,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -58,7 +59,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -812,7 +819,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
  
          for (int i = -2; i <= 2; ++i)
-@@ -76,7 +76,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -76,7 +77,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -821,7 +828,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(13, 99, 16, Block.STONE);
  
-@@ -91,7 +91,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -91,7 +92,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -830,7 +837,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(0, 42, 0, Block.OAK_FENCE);
  
-@@ -104,7 +104,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -104,7 +105,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -839,7 +846,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
  
          for (int i = -2; i <= 2; ++i)
-@@ -123,7 +123,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -123,7 +124,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -848,7 +855,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(0, 42, 0, Block.OAK_FENCE);
          instance.setBlock(0, 43, 0, Block.BROWN_CARPET);
-@@ -137,7 +137,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -137,7 +138,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -857,7 +864,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(1, 42, 0, Block.OAK_FENCE);
  
-@@ -150,7 +150,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -150,7 +151,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -866,7 +873,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(4, 40, -1, Block.SANDSTONE_STAIRS);
          instance.setBlock(16, 40, 0, Block.STONE);
-@@ -164,7 +164,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -164,7 +165,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -875,7 +882,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(4, 40, 0, Block.GRASS_BLOCK);
          instance.setBlock(16, 40, 0, Block.STONE);
-@@ -181,7 +181,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -181,7 +182,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -884,7 +891,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(1, 42, 0, Block.OAK_FENCE);
          instance.setBlock(1, 43, 0, Block.BROWN_CARPET);
-@@ -195,7 +195,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -195,7 +196,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -893,7 +900,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
  
          for (int i = -2; i <= 2; ++i)
-@@ -214,7 +214,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -214,7 +215,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -902,7 +909,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
  
          for (int i = -2; i <= 2; ++i)
-@@ -233,7 +233,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -233,7 +234,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -911,7 +918,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
  
          for (int i = -2; i <= 2; ++i)
-@@ -264,7 +264,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -264,7 +265,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -920,7 +927,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(0, 42, 0, Block.OAK_FENCE);
          instance.setBlock(0, 43, 0, Block.BROWN_CARPET);
-@@ -278,7 +278,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -278,7 +279,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -929,7 +936,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
  
          instance.setBlock(0, 45, 0, Block.OAK_FENCE);
-@@ -292,7 +292,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -292,7 +293,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -938,7 +945,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(1, 43, 1, Block.STONE);
          instance.setBlock(1, 43, 2, Block.STONE);
-@@ -308,7 +308,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -308,7 +309,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -947,7 +954,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(1, 43, 1, Block.STONE);
          instance.setBlock(1, 43, 2, Block.STONE);
-@@ -322,7 +322,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -322,7 +323,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -956,7 +963,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          for (int i = -2; i <= 2; ++i)
              for (int j = -2; j <= 2; ++j)
-@@ -341,7 +341,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -341,7 +342,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -965,7 +972,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          for (int i = -2; i <= 2; ++i)
              for (int j = -2; j <= 2; ++j)
-@@ -363,7 +363,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -363,7 +364,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -974,7 +981,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          for (int i = -2; i <= 2; ++i)
              for (int j = -2; j <= 2; ++j)
-@@ -385,7 +385,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -385,7 +386,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -983,7 +990,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(11, 43, 11, Block.STONE);
  
-@@ -402,7 +402,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -402,7 +403,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -992,7 +999,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          Point z1 = new Pos(0, 0, 0);
          Point z2 = new Pos(15, 0, 0);
          Point z3 = new Pos(11, 0, 0);
-@@ -420,7 +420,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -420,7 +421,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1001,7 +1008,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(1, 43, 1, Block.STONE);
  
-@@ -433,7 +433,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -433,7 +434,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1010,7 +1017,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(1, 42, 1, Block.STONE);
  
-@@ -447,7 +447,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -447,7 +448,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1019,7 +1026,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          Block b = Block.ACACIA_TRAPDOOR.withProperties(Map.of("facing", "north", "open", "true"));
  
-@@ -462,7 +462,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -462,7 +463,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1028,7 +1035,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          Block b = Block.ACACIA_TRAPDOOR.withProperties(Map.of("facing", "south", "open", "true"));
  
-@@ -477,7 +477,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -477,7 +478,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1037,7 +1044,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          Block b = Block.ACACIA_TRAPDOOR.withProperties(Map.of("facing", "west", "open", "true"));
  
-@@ -492,7 +492,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -492,7 +493,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1046,7 +1053,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          Block b = Block.ACACIA_TRAPDOOR.withProperties(Map.of("facing", "east", "open", "true"));
  
-@@ -507,7 +507,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -507,7 +508,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1055,7 +1062,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          Block b = Block.ACACIA_TRAPDOOR.withProperties(Map.of("half", "top"));
  
-@@ -522,7 +522,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -522,7 +523,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1064,7 +1071,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          Block b = Block.ACACIA_TRAPDOOR;
  
-@@ -537,7 +537,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -537,7 +538,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1073,7 +1080,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(0, 40, 0, Block.STONE);
  
-@@ -550,7 +550,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -550,7 +551,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1082,7 +1089,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(0, 42, 0, Block.ACACIA_STAIRS);
  
-@@ -563,7 +563,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -563,7 +564,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1091,7 +1098,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(0, 42, 0, Block.ACACIA_STAIRS);
  
-@@ -576,7 +576,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -576,7 +577,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1100,7 +1107,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
  
          for (int i = -2; i <= 2; ++i)
-@@ -592,7 +592,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -592,7 +593,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1109,7 +1116,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(0, 60, 0, Block.STONE);
  
-@@ -605,7 +605,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -605,7 +606,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1118,7 +1125,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(1, 43, 1, Block.STONE);
          instance.setBlock(1, 43, 2, Block.STONE);
-@@ -620,7 +620,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -620,7 +621,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1127,7 +1134,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(1, 43, 0, Block.STONE);
  
-@@ -634,7 +634,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -634,7 +635,7 @@ public class EntityBlockPhysicsIntegrationTest {
  
      // Checks C include all checks for crossing one intermediate block (3 block checks)
      @Test
@@ -1136,7 +1143,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(1, 42, 0, Block.STONE);
  
-@@ -649,7 +649,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -649,7 +650,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1145,7 +1152,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(0, 42, 1, Block.STONE);
  
-@@ -664,7 +664,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -664,7 +665,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1154,7 +1161,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(1, 42, 1, Block.STONE);
  
-@@ -679,7 +679,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -679,7 +680,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1163,7 +1170,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(0, 42, 0, Block.STONE);
  
-@@ -694,7 +694,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -694,7 +695,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1172,7 +1179,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(0, 42, 1, Block.STONE);
  
-@@ -709,7 +709,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -709,7 +710,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1181,7 +1188,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(1, 42, 0, Block.STONE);
  
-@@ -724,7 +724,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -724,7 +725,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1190,7 +1197,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(0, 42, 0, Block.STONE);
  
-@@ -739,7 +739,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -739,7 +740,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1199,7 +1206,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(1, 42, 1, Block.STONE);
  
-@@ -755,7 +755,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -755,7 +756,7 @@ public class EntityBlockPhysicsIntegrationTest {
  
      // Checks CE include checks for crossing two intermediate block (4 block checks)
      @Test
@@ -1208,7 +1215,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(1, 43, 0, Block.STONE);
  
-@@ -770,7 +770,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -770,7 +771,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1217,7 +1224,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(0, 43, 1, Block.STONE);
  
-@@ -785,7 +785,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -785,7 +786,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1226,7 +1233,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(1, 43, 1, Block.STONE);
  
-@@ -801,7 +801,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -801,7 +802,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1235,7 +1242,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
  
          for (int i = -2; i <= 2; ++i)
-@@ -817,7 +817,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -817,7 +818,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1244,7 +1251,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(0, 43, 2, Block.STONE);
          instance.setBlock(2, 43, 0, Block.STONE);
-@@ -831,7 +831,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -831,7 +832,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1253,7 +1260,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
  
          instance.setBlock(0, 43, 1, Block.STONE);
-@@ -865,7 +865,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -865,7 +866,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1262,7 +1269,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityType.ZOMBIE);
  
-@@ -880,7 +880,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -880,7 +881,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1271,7 +1278,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityType.ZOMBIE);
  
-@@ -897,7 +897,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -897,7 +898,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1280,7 +1287,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityType.ZOMBIE);
  
-@@ -909,7 +909,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -909,7 +910,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1289,7 +1296,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          PhysicsResult previousResult = null;
  
-@@ -941,7 +941,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -941,7 +942,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1298,7 +1305,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityType.ZOMBIE);
  
-@@ -955,7 +955,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -955,7 +956,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1307,7 +1314,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityType.ZOMBIE);
  
-@@ -974,7 +974,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -974,7 +975,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1316,7 +1323,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityType.ZOMBIE);
  
-@@ -993,7 +993,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -993,7 +994,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1325,7 +1332,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          Block b = Block.ACACIA_TRAPDOOR.withProperties(Map.of("facing", "south", "open", "true"));
  
-@@ -1011,7 +1011,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -1011,7 +1012,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1334,7 +1341,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(0, 43, 1, Block.STONE);
  
-@@ -1031,7 +1031,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -1031,7 +1032,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1343,7 +1350,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(0, 43, 1, Block.STONE);
  
-@@ -1062,7 +1062,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -1062,7 +1063,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1352,7 +1359,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          var instance = env.createFlatInstance();
          instance.setBlock(0, 42, 0, Block.STONE);
  
-@@ -1077,7 +1077,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -1077,7 +1078,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1362,12 +1369,14 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a
          instance.setBlock(0, 42, 0, Block.STONE);
  
 diff --git a/src/test/java/net/minestom/server/collision/EntityBlockTouchTickIntegrationTest.java b/src/test/java/net/minestom/server/collision/EntityBlockTouchTickIntegrationTest.java
-index f5fbb8a9b99720d4a5594e683e9fb3729aaaaf89..2160a817501fc61bb6273767012c9e7179e7b25e 100644
+index f5fbb8a9b99720d4a5594e683e9fb3729aaaaf89..04b7b5bc1bb96e4d565bcb1348d433ff6ae55548 100644
 --- a/src/test/java/net/minestom/server/collision/EntityBlockTouchTickIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/collision/EntityBlockTouchTickIntegrationTest.java
-@@ -20,9 +20,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -19,10 +19,11 @@ import java.util.Set;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertTrue;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class EntityBlockTouchTickIntegrationTest {
 +class EntityBlockTouchTickIntegrationTest {
@@ -1377,7 +1386,7 @@ index f5fbb8a9b99720d4a5594e683e9fb3729aaaaf89..2160a817501fc61bb6273767012c9e71
          var instance = env.createFlatInstance();
  
          Set<Point> positions = new HashSet<>();
-@@ -60,7 +60,7 @@ public class EntityBlockTouchTickIntegrationTest {
+@@ -60,7 +61,7 @@ public class EntityBlockTouchTickIntegrationTest {
      }
  
      @Test
@@ -1386,7 +1395,7 @@ index f5fbb8a9b99720d4a5594e683e9fb3729aaaaf89..2160a817501fc61bb6273767012c9e71
          var instance = env.createFlatInstance();
          instance.loadChunk(new Pos(1000, 1000, 1000));
  
-@@ -100,7 +100,7 @@ public class EntityBlockTouchTickIntegrationTest {
+@@ -100,7 +101,7 @@ public class EntityBlockTouchTickIntegrationTest {
      }
  
      @Test
@@ -1395,7 +1404,7 @@ index f5fbb8a9b99720d4a5594e683e9fb3729aaaaf89..2160a817501fc61bb6273767012c9e71
          var instance = env.createFlatInstance();
          instance.loadChunk(new Pos(1000, 1000, 1000));
  
-@@ -148,7 +148,7 @@ public class EntityBlockTouchTickIntegrationTest {
+@@ -148,7 +149,7 @@ public class EntityBlockTouchTickIntegrationTest {
      }
  
      @Test
@@ -1405,12 +1414,14 @@ index f5fbb8a9b99720d4a5594e683e9fb3729aaaaf89..2160a817501fc61bb6273767012c9e71
          instance.loadChunk(new Pos(-1000, 44, -1000));
  
 diff --git a/src/test/java/net/minestom/server/collision/EntityProjectileCollisionIntegrationTest.java b/src/test/java/net/minestom/server/collision/EntityProjectileCollisionIntegrationTest.java
-index ee893bba4cc28ae29138eec0900dd89962d9fbfc..658ad566b1925008c5b2bf0ed26ea930f3dd899c 100644
+index ee893bba4cc28ae29138eec0900dd89962d9fbfc..f821c225bc8216c41092e5495942578350051878 100644
 --- a/src/test/java/net/minestom/server/collision/EntityProjectileCollisionIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/collision/EntityProjectileCollisionIntegrationTest.java
-@@ -24,10 +24,10 @@ import java.util.concurrent.atomic.AtomicReference;
+@@ -23,11 +23,12 @@ import java.util.concurrent.atomic.AtomicReference;
+ 
  import static org.junit.jupiter.api.Assertions.*;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class EntityProjectileCollisionIntegrationTest {
 +class EntityProjectileCollisionIntegrationTest {
@@ -1421,7 +1432,7 @@ index ee893bba4cc28ae29138eec0900dd89962d9fbfc..658ad566b1925008c5b2bf0ed26ea930
          final Instance instance = env.createFlatInstance();
          instance.getWorldBorder().setDiameter(1000.0);
  
-@@ -71,7 +71,7 @@ public class EntityProjectileCollisionIntegrationTest {
+@@ -71,7 +72,7 @@ public class EntityProjectileCollisionIntegrationTest {
      }
  
      @Test
@@ -1430,7 +1441,7 @@ index ee893bba4cc28ae29138eec0900dd89962d9fbfc..658ad566b1925008c5b2bf0ed26ea930
          final Instance instance = env.createFlatInstance();
          instance.getWorldBorder().setDiameter(1000.0);
  
-@@ -119,7 +119,7 @@ public class EntityProjectileCollisionIntegrationTest {
+@@ -119,7 +120,7 @@ public class EntityProjectileCollisionIntegrationTest {
      }
  
      @Test
@@ -1440,12 +1451,14 @@ index ee893bba4cc28ae29138eec0900dd89962d9fbfc..658ad566b1925008c5b2bf0ed26ea930
          instance.getWorldBorder().setDiameter(1000.0);
  
 diff --git a/src/test/java/net/minestom/server/collision/PlacementCollisionIntegrationTest.java b/src/test/java/net/minestom/server/collision/PlacementCollisionIntegrationTest.java
-index 27a2f36c19fd8c2dce75f1bd1ff514dadd027b8a..f3e90e530f4b3487e50d83634b3e0351f5388437 100644
+index 27a2f36c19fd8c2dce75f1bd1ff514dadd027b8a..b41c07c8beb6d9ca9ea0aef138082fe04e462b85 100644
 --- a/src/test/java/net/minestom/server/collision/PlacementCollisionIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/collision/PlacementCollisionIntegrationTest.java
-@@ -12,30 +12,30 @@ import org.junit.jupiter.api.Test;
+@@ -11,31 +11,32 @@ import org.junit.jupiter.api.Test;
+ 
  import static org.junit.jupiter.api.Assertions.*;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class PlacementCollisionIntegrationTest {
 +class PlacementCollisionIntegrationTest {
@@ -1480,14 +1493,15 @@ index 27a2f36c19fd8c2dce75f1bd1ff514dadd027b8a..f3e90e530f4b3487e50d83634b3e0351
          env.createPlayer(instance, new Pos(5.7, -8, 6.389));
          assertNull(BlockCollision.canPlaceBlockAt(instance, new Vec(5, -9, 6), Block.STONE));
 diff --git a/src/test/java/net/minestom/server/command/ArgumentParserTest.java b/src/test/java/net/minestom/server/command/ArgumentParserTest.java
-index 232d55948303a74d35724c2d601ace10a8d98811..844f846afe976a4667a2743957d19b155a7d7a3f 100644
+index 232d55948303a74d35724c2d601ace10a8d98811..66fd64bd2306cd905050893621cdc66fd25890df 100644
 --- a/src/test/java/net/minestom/server/command/ArgumentParserTest.java
 +++ b/src/test/java/net/minestom/server/command/ArgumentParserTest.java
-@@ -11,10 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+@@ -11,10 +11,11 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
  /**
   * Test string version of arguments.
   */
 -public class ArgumentParserTest {
++//Microtus - update java keyword usage
 +class ArgumentParserTest {
  
      @Test
@@ -1497,14 +1511,15 @@ index 232d55948303a74d35724c2d601ace10a8d98811..844f846afe976a4667a2743957d19b15
          assertParserEquals("Literal<example>", ArgumentType.Literal("example"));
          assertParserEquals("Boolean<example>", ArgumentType.Boolean("example"));
 diff --git a/src/test/java/net/minestom/server/command/ArgumentTest.java b/src/test/java/net/minestom/server/command/ArgumentTest.java
-index 6aa58875c186549b658ef5a5277dc4fbd378df80..0c438d1230824e25352af1a53534a3b0e97234b3 100644
+index 6aa58875c186549b658ef5a5277dc4fbd378df80..1f8e528b34f03c217b03948ba1cd1a41d0225570 100644
 --- a/src/test/java/net/minestom/server/command/ArgumentTest.java
 +++ b/src/test/java/net/minestom/server/command/ArgumentTest.java
-@@ -11,16 +11,16 @@ import java.util.List;
+@@ -11,16 +11,17 @@ import java.util.List;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class ArgumentTest {
++//Microtus - update java keyword usage
 +class ArgumentTest {
  
      @Test
@@ -1520,7 +1535,7 @@ index 6aa58875c186549b658ef5a5277dc4fbd378df80..0c438d1230824e25352af1a53534a3b0
          var arg = ArgumentType.String("id");
  
          assertFalse(arg.hasErrorCallback());
-@@ -30,7 +30,7 @@ public class ArgumentTest {
+@@ -30,7 +31,7 @@ public class ArgumentTest {
      }
  
      @Test
@@ -1529,7 +1544,7 @@ index 6aa58875c186549b658ef5a5277dc4fbd378df80..0c438d1230824e25352af1a53534a3b0
          var arg = ArgumentType.String("id");
  
          assertFalse(arg.isOptional());
-@@ -40,7 +40,7 @@ public class ArgumentTest {
+@@ -40,7 +41,7 @@ public class ArgumentTest {
      }
  
      @Test
@@ -1539,7 +1554,7 @@ index 6aa58875c186549b658ef5a5277dc4fbd378df80..0c438d1230824e25352af1a53534a3b0
  
          assertFalse(arg.hasSuggestion());
 diff --git a/src/test/java/net/minestom/server/command/ArgumentTypeTest.java b/src/test/java/net/minestom/server/command/ArgumentTypeTest.java
-index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec96243cbb963 100644
+index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedcfbe8ca41 100644
 --- a/src/test/java/net/minestom/server/command/ArgumentTypeTest.java
 +++ b/src/test/java/net/minestom/server/command/ArgumentTypeTest.java
 @@ -16,7 +16,6 @@ import net.minestom.server.item.Enchantment;
@@ -1550,11 +1565,12 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
  import net.minestom.server.tag.Tag;
  import net.minestom.server.utils.location.RelativeVec;
  import net.minestom.server.utils.math.FloatRange;
-@@ -31,10 +30,10 @@ import java.util.UUID;
+@@ -31,10 +30,11 @@ import java.util.UUID;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class ArgumentTypeTest {
++//Microtus - update java keyword usage
 +class ArgumentTypeTest {
  
      @Test
@@ -1563,7 +1579,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.Enchantment("enchantment");
          assertInvalidArg(arg, "minecraft:invalid_enchantment");
          assertArg(arg, Enchantment.SWEEPING, Enchantment.SWEEPING.name());
-@@ -42,7 +41,7 @@ public class ArgumentTypeTest {
+@@ -42,7 +42,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1572,7 +1588,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.EntityType("entity_type");
          assertInvalidArg(arg, "minecraft:invalid_entity_type");
          assertArg(arg, EntityType.ARMOR_STAND, EntityType.ARMOR_STAND.name());
-@@ -50,7 +49,7 @@ public class ArgumentTypeTest {
+@@ -50,7 +50,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1581,7 +1597,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.Particle("particle");
          assertInvalidArg(arg, "minecraft:invalid_particle");
          assertArg(arg, Particle.BLOCK, Particle.BLOCK.name());
-@@ -58,7 +57,7 @@ public class ArgumentTypeTest {
+@@ -58,7 +58,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1590,7 +1606,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.BlockState("block_state");
          assertInvalidArg(arg, "minecraft:invalid_block[invalid_property=invalid_key]");
          assertInvalidArg(arg, "minecraft:stone[invalid_property=invalid_key]");
-@@ -69,7 +68,7 @@ public class ArgumentTypeTest {
+@@ -69,7 +69,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1599,7 +1615,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.Color("color");
          assertInvalidArg(arg, "invalid_color");
          assertArg(arg, Style.style(NamedTextColor.DARK_PURPLE), "dark_purple");
-@@ -77,7 +76,7 @@ public class ArgumentTypeTest {
+@@ -77,7 +77,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1608,7 +1624,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.Component("component");
          var component1 = Component.text("Example text", NamedTextColor.DARK_AQUA);
          var component2 = Component.text("Other example text", Style.style(TextDecoration.OBFUSCATED));
-@@ -90,7 +89,7 @@ public class ArgumentTypeTest {
+@@ -90,7 +90,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1617,7 +1633,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.Entity("entity");
  
          assertValidArg(arg, "@a");
-@@ -127,7 +126,7 @@ public class ArgumentTypeTest {
+@@ -127,7 +127,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1626,7 +1642,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.FloatRange("float_range");
          assertArg(arg, new FloatRange(0f, 50f), "0..50");
          assertArg(arg, new FloatRange(0f, 0f), "0..0");
-@@ -142,7 +141,7 @@ public class ArgumentTypeTest {
+@@ -142,7 +142,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1635,7 +1651,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.IntRange("int_range");
  
          assertArg(arg, new IntRange(0, 50), "0..50");
-@@ -161,14 +160,14 @@ public class ArgumentTypeTest {
+@@ -161,14 +161,14 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1652,7 +1668,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.NbtCompound("nbt_compound");
          assertArg(arg, NBT.Compound(mut -> mut.put("long_array", NBT.LongArray(12, 49, 119))), "{\"long_array\":[L;12L,49L,119L]}");
          assertArg(arg, NBT.Compound(mut -> mut.put("nested", NBT.Compound(mut2 ->
-@@ -183,7 +182,7 @@ public class ArgumentTypeTest {
+@@ -183,7 +183,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1661,7 +1677,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.NBT("nbt");
          assertArg(arg, NBT.String("string"), "string");
          assertArg(arg, NBT.String("string"), "\"string\"");
-@@ -198,14 +197,14 @@ public class ArgumentTypeTest {
+@@ -198,14 +198,14 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1678,7 +1694,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.ResourceLocation("resource_location");
          assertArg(arg, "minecraft:resource_location_example", "minecraft:resource_location_example");
          assertInvalidArg(arg, "minecraft:invalid resource location");
-@@ -213,14 +212,14 @@ public class ArgumentTypeTest {
+@@ -213,14 +213,14 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1695,7 +1711,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.Time("time");
          assertArg(arg, Duration.of(20, TimeUnit.SERVER_TICK), "20");
          assertArg(arg, Duration.of(40, TimeUnit.SERVER_TICK), "40t");
-@@ -232,14 +231,14 @@ public class ArgumentTypeTest {
+@@ -232,14 +232,14 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1712,7 +1728,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.Double("double");
          assertArg(arg, 2564d, "2564");
          assertArg(arg, -591.981d, "-591.981");
-@@ -248,7 +247,7 @@ public class ArgumentTypeTest {
+@@ -248,7 +248,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1721,7 +1737,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.Float("float");
          assertArg(arg, 2564f, "2564");
          assertArg(arg, -591.981f, "-591.981");
-@@ -257,7 +256,7 @@ public class ArgumentTypeTest {
+@@ -257,7 +257,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1730,7 +1746,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.Integer("integer");
          assertArg(arg, 2564, "2564");
          assertInvalidArg(arg, "256.4");
-@@ -265,15 +264,15 @@ public class ArgumentTypeTest {
+@@ -265,15 +265,15 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1749,7 +1765,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.RelativeBlockPosition("relative_block_position");
          var vec = new Vec(-3, 14, 255);
  
-@@ -297,7 +296,7 @@ public class ArgumentTypeTest {
+@@ -297,7 +297,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1758,7 +1774,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.RelativeVec2("relative_vec_2");
          var vec = new Vec(-3, 14.25);
  
-@@ -318,7 +317,7 @@ public class ArgumentTypeTest {
+@@ -318,7 +318,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1767,7 +1783,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.RelativeVec3("relative_vec_3");
          var vec = new Vec(-3, 14.25, 255);
  
-@@ -339,7 +338,7 @@ public class ArgumentTypeTest {
+@@ -339,7 +339,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1776,7 +1792,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.Boolean("boolean");
          assertArg(arg, true, "true");
          assertArg(arg, false, "false");
-@@ -347,7 +346,7 @@ public class ArgumentTypeTest {
+@@ -347,7 +347,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1785,7 +1801,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          enum ExampleEnum {FIRST, SECOND, Third, fourth}
  
          var arg = ArgumentType.Enum("enum", ExampleEnum.class);
-@@ -375,7 +374,7 @@ public class ArgumentTypeTest {
+@@ -375,7 +375,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1794,7 +1810,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.Group("group", ArgumentType.Integer("integer"), ArgumentType.String("string"), ArgumentType.Double("double"));
  
          // Test normal input
-@@ -401,7 +400,7 @@ public class ArgumentTypeTest {
+@@ -401,7 +401,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1803,7 +1819,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.Literal("literal");
          assertArg(arg, "literal", "literal");
          assertInvalidArg(arg, "not_literal");
-@@ -409,7 +408,7 @@ public class ArgumentTypeTest {
+@@ -409,7 +409,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1812,7 +1828,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.Loop("loop", ArgumentType.String("string"), ArgumentType.String("string2").map(s -> {
              throw new IllegalArgumentException("This argument should never be triggered");
          }));
-@@ -419,7 +418,7 @@ public class ArgumentTypeTest {
+@@ -419,7 +419,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1821,7 +1837,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.String("string");
          assertArg(arg, "text", "text");
          assertArg(arg, "more text", "\"more text\"");
-@@ -429,7 +428,7 @@ public class ArgumentTypeTest {
+@@ -429,7 +429,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1830,7 +1846,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
          var arg = ArgumentType.StringArray("string_array");
          assertArrayArg(arg, new String[]{"example", "text"}, "example text");
          assertArrayArg(arg, new String[]{"some", "more", "placeholder", "text"}, "some more placeholder text");
-@@ -439,7 +438,7 @@ public class ArgumentTypeTest {
+@@ -439,7 +439,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1840,14 +1856,15 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
  
          assertArg(arg, "word1", "word1");
 diff --git a/src/test/java/net/minestom/server/command/CommandConditionTest.java b/src/test/java/net/minestom/server/command/CommandConditionTest.java
-index f7450b020c91807984e83b004774c916621d152f..f76f113a161c315badfdec9ef5932dbf4a461e40 100644
+index f7450b020c91807984e83b004774c916621d152f..0c68f513645f949cf216db6936f809a8e89eedab 100644
 --- a/src/test/java/net/minestom/server/command/CommandConditionTest.java
 +++ b/src/test/java/net/minestom/server/command/CommandConditionTest.java
-@@ -13,10 +13,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
+@@ -13,10 +13,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class CommandConditionTest {
++//Microtus - update java keyword usage
 +class CommandConditionTest {
  
      @Test
@@ -1856,7 +1873,7 @@ index f7450b020c91807984e83b004774c916621d152f..f76f113a161c315badfdec9ef5932dbf
          var dispatcher = new CommandDispatcher();
          assertNull(dispatcher.findCommand("name"));
          var sender = new Sender();
-@@ -39,7 +39,7 @@ public class CommandConditionTest {
+@@ -39,7 +40,7 @@ public class CommandConditionTest {
      }
  
      @Test
@@ -1865,7 +1882,7 @@ index f7450b020c91807984e83b004774c916621d152f..f76f113a161c315badfdec9ef5932dbf
          var dispatcher = new CommandDispatcher();
          assertNull(dispatcher.findCommand("name"));
          var sender = new Sender();
-@@ -83,7 +83,7 @@ public class CommandConditionTest {
+@@ -83,7 +84,7 @@ public class CommandConditionTest {
      }
  
      @Test
@@ -1875,14 +1892,15 @@ index f7450b020c91807984e83b004774c916621d152f..f76f113a161c315badfdec9ef5932dbf
          assertNull(dispatcher.findCommand("name"));
          var sender = new Sender();
 diff --git a/src/test/java/net/minestom/server/command/CommandManagerTest.java b/src/test/java/net/minestom/server/command/CommandManagerTest.java
-index 0c69902dc9870ed8de36f90955c184f1cfc2b952..8e9cd85c205e12b8d85ddb3d3f01847cb0fdf115 100644
+index 0c69902dc9870ed8de36f90955c184f1cfc2b952..c536e48e85c14c9e94d3621ab00550d3615d9e60 100644
 --- a/src/test/java/net/minestom/server/command/CommandManagerTest.java
 +++ b/src/test/java/net/minestom/server/command/CommandManagerTest.java
-@@ -8,10 +8,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
+@@ -8,10 +8,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class CommandManagerTest {
++//Microtus - update java keyword usage
 +class CommandManagerTest {
  
      @Test
@@ -1891,7 +1909,7 @@ index 0c69902dc9870ed8de36f90955c184f1cfc2b952..8e9cd85c205e12b8d85ddb3d3f01847c
          var manager = new CommandManager();
  
          var command = new Command("name1", "name2");
-@@ -30,7 +30,7 @@ public class CommandManagerTest {
+@@ -30,7 +31,7 @@ public class CommandManagerTest {
      }
  
      @Test
@@ -1901,12 +1919,14 @@ index 0c69902dc9870ed8de36f90955c184f1cfc2b952..8e9cd85c205e12b8d85ddb3d3f01847c
  
          AtomicBoolean check = new AtomicBoolean(false);
 diff --git a/src/test/java/net/minestom/server/command/CommandPacketFilteringTest.java b/src/test/java/net/minestom/server/command/CommandPacketFilteringTest.java
-index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..f1723d9525bbb6f7af06fe948efde4edeffc17aa 100644
+index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..20a4553faacf73384fd9774601b04cbb979b3b14 100644
 --- a/src/test/java/net/minestom/server/command/CommandPacketFilteringTest.java
 +++ b/src/test/java/net/minestom/server/command/CommandPacketFilteringTest.java
-@@ -10,18 +10,18 @@ import java.util.Set;
+@@ -9,19 +9,20 @@ import org.junit.jupiter.api.Test;
+ import java.util.Set;
  import java.util.UUID;
  
++//Microtus - update java keyword usage
  @SuppressWarnings("ConstantConditions")
 -public class CommandPacketFilteringTest {
 +class CommandPacketFilteringTest {
@@ -1926,7 +1946,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..f1723d9525bbb6f7af06fe948efde4ed
          final Command foo = new Command("foo");
          foo.setCondition(((sender, commandString) -> true));
          assertFiltering(foo, """
-@@ -31,7 +31,7 @@ public class CommandPacketFilteringTest {
+@@ -31,7 +32,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -1935,7 +1955,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..f1723d9525bbb6f7af06fe948efde4ed
          final Command foo = new Command("foo");
          assertFiltering(foo, """
                  foo=%
-@@ -40,7 +40,7 @@ public class CommandPacketFilteringTest {
+@@ -40,7 +41,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -1944,7 +1964,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..f1723d9525bbb6f7af06fe948efde4ed
          final Command foo = new Command("foo");
          foo.setCondition((sender, commandString) -> true);
          final Command bar = new Command("bar");
-@@ -55,7 +55,7 @@ public class CommandPacketFilteringTest {
+@@ -55,7 +56,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -1953,7 +1973,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..f1723d9525bbb6f7af06fe948efde4ed
          final Command foo = new Command("foo");
          foo.setCondition((sender, commandString) -> true);
          final Command bar = new Command("bar");
-@@ -68,7 +68,7 @@ public class CommandPacketFilteringTest {
+@@ -68,7 +69,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -1962,7 +1982,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..f1723d9525bbb6f7af06fe948efde4ed
          final Command foo = new Command("foo");
          foo.setCondition((sender, commandString) -> true);
          final Command bar = new Command("bar");
-@@ -82,7 +82,7 @@ public class CommandPacketFilteringTest {
+@@ -82,7 +83,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -1971,7 +1991,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..f1723d9525bbb6f7af06fe948efde4ed
          final Command foo = new Command("foo");
          foo.setCondition((sender, commandString) -> true);
          final Command bar = new Command("bar");
-@@ -99,7 +99,7 @@ public class CommandPacketFilteringTest {
+@@ -99,7 +100,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -1980,7 +2000,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..f1723d9525bbb6f7af06fe948efde4ed
          final Command foo = new Command("foo");
          foo.addConditionalSyntax((sender, commandString) -> true, null, ArgumentType.Group("test", ArgumentType.Literal("bar")));
          assertFiltering(foo, """
-@@ -110,7 +110,7 @@ public class CommandPacketFilteringTest {
+@@ -110,7 +111,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -1989,7 +2009,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..f1723d9525bbb6f7af06fe948efde4ed
          final Command foo = new Command("foo");
          foo.addConditionalSyntax((sender, commandString) -> false, null, ArgumentType.Group("test", ArgumentType.Literal("foo")));
          assertFiltering(foo, """
-@@ -120,7 +120,7 @@ public class CommandPacketFilteringTest {
+@@ -120,7 +121,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -1998,7 +2018,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..f1723d9525bbb6f7af06fe948efde4ed
          final Command foo = new Command("foo");
          foo.addSyntax(null, ArgumentType.Group("test", ArgumentType.Literal("bar")));
          assertFiltering(foo, """
-@@ -131,7 +131,7 @@ public class CommandPacketFilteringTest {
+@@ -131,7 +132,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -2007,7 +2027,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..f1723d9525bbb6f7af06fe948efde4ed
          final Command foo = new Command("foo");
          foo.addConditionalSyntax((sender, commandString) -> true, null, ArgumentType.Group("test", ArgumentType.Literal("bar"), ArgumentType.Literal("baz")));
          assertFiltering(foo, """
-@@ -143,7 +143,7 @@ public class CommandPacketFilteringTest {
+@@ -143,7 +144,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -2016,7 +2036,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..f1723d9525bbb6f7af06fe948efde4ed
          final Command foo = new Command("foo");
          foo.addConditionalSyntax((sender, commandString) -> false, null, ArgumentType.Group("test", ArgumentType.Literal("foo"), ArgumentType.Literal("baz")));
          assertFiltering(foo, """
-@@ -153,7 +153,7 @@ public class CommandPacketFilteringTest {
+@@ -153,7 +154,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -2025,7 +2045,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..f1723d9525bbb6f7af06fe948efde4ed
          final Command foo = new Command("foo");
          foo.addSyntax(null, ArgumentType.Group("test", ArgumentType.Literal("bar"), ArgumentType.Literal("baz")));
          assertFiltering(foo, """
-@@ -165,7 +165,7 @@ public class CommandPacketFilteringTest {
+@@ -165,7 +166,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -2034,7 +2054,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..f1723d9525bbb6f7af06fe948efde4ed
          final Command foo = new Command("foo");
          foo.addSyntax(null, ArgumentType.Loop("test", ArgumentType.Literal("bar"), ArgumentType.Literal("baz")));
          assertFiltering(foo, """
-@@ -177,7 +177,7 @@ public class CommandPacketFilteringTest {
+@@ -177,7 +178,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -2043,7 +2063,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..f1723d9525bbb6f7af06fe948efde4ed
          final Command foo = new Command("foo");
          foo.addConditionalSyntax((sender, commandString) -> true, null, ArgumentType.Loop("test", ArgumentType.Literal("bar"), ArgumentType.Literal("baz")));
          assertFiltering(foo, """
-@@ -189,7 +189,7 @@ public class CommandPacketFilteringTest {
+@@ -189,7 +190,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -2053,14 +2073,15 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..f1723d9525bbb6f7af06fe948efde4ed
          foo.addConditionalSyntax((sender, commandString) -> false, null, ArgumentType.Loop("test", ArgumentType.Literal("bar"), ArgumentType.Literal("baz")));
          assertFiltering(foo, """
 diff --git a/src/test/java/net/minestom/server/command/CommandPacketTest.java b/src/test/java/net/minestom/server/command/CommandPacketTest.java
-index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..2b51669947330396da684b251e20e096138e1b36 100644
+index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..79c06e6051c032b2e0f2b7fca4d2320c515ea395 100644
 --- a/src/test/java/net/minestom/server/command/CommandPacketTest.java
 +++ b/src/test/java/net/minestom/server/command/CommandPacketTest.java
-@@ -9,9 +9,9 @@ import org.junit.jupiter.api.Test;
+@@ -9,9 +9,10 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNotNull;
  
 -public class CommandPacketTest {
++//Microtus - update java keyword usage
 +class CommandPacketTest {
      @Test
 -    public void singleCommandWithOneSyntax() {
@@ -2068,7 +2089,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..2b51669947330396da684b251e20e096
          final Command foo = new Command("foo");
          foo.addSyntax(CommandPacketTest::dummyExecutor, ArgumentType.Integer("bar"));
  
-@@ -34,7 +34,7 @@ public class CommandPacketTest {
+@@ -34,7 +35,7 @@ public class CommandPacketTest {
      }
  
      @Test
@@ -2077,7 +2098,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..2b51669947330396da684b251e20e096
          enum Dimension {OVERWORLD, THE_NETHER, THE_END}
          final Command execute = new Command("execute");
          execute.addSyntax(CommandPacketTest::dummyExecutor, ArgumentType.Loop("params",
-@@ -62,7 +62,7 @@ public class CommandPacketTest {
+@@ -62,7 +63,7 @@ public class CommandPacketTest {
      }
  
      @Test
@@ -2086,7 +2107,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..2b51669947330396da684b251e20e096
          var graph = Graph.builder(ArgumentType.Literal("foo"))
                  .append(ArgumentType.Enum("bar", A.class), b -> b.append(ArgumentType.Enum("baz", B.class)))
                  .build();
-@@ -76,7 +76,7 @@ public class CommandPacketTest {
+@@ -76,7 +77,7 @@ public class CommandPacketTest {
      }
  
      @Test
@@ -2095,7 +2116,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..2b51669947330396da684b251e20e096
          var graph = Graph.builder(ArgumentType.Literal("foo"))
                  .append(ArgumentType.Word("bar").from("A", "B", "C"))
                  .build();
-@@ -89,7 +89,7 @@ public class CommandPacketTest {
+@@ -89,7 +90,7 @@ public class CommandPacketTest {
      }
  
      @Test
@@ -2104,7 +2125,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..2b51669947330396da684b251e20e096
          var graph = Graph.builder(ArgumentType.Literal("foo"))
                  .append(ArgumentType.Word("bar"))
                  .build();
-@@ -102,7 +102,7 @@ public class CommandPacketTest {
+@@ -102,7 +103,7 @@ public class CommandPacketTest {
      }
  
      @Test
@@ -2113,7 +2134,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..2b51669947330396da684b251e20e096
          var graph = Graph.builder(ArgumentType.Literal("foo"))
                  .append(ArgumentType.Enum("bar", A.class), b -> b.append(ArgumentType.Command("baz")))
                  .build();
-@@ -117,7 +117,7 @@ public class CommandPacketTest {
+@@ -117,7 +118,7 @@ public class CommandPacketTest {
      }
  
      @Test
@@ -2122,7 +2143,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..2b51669947330396da684b251e20e096
          var graph = Graph.builder(ArgumentType.Literal("foo"))
                  .append(ArgumentType.Integer("int1"), b -> b.append(ArgumentType.Enum("test", A.class), c -> c.append(ArgumentType.Integer("int2"))))
                  .build();
-@@ -139,7 +139,7 @@ public class CommandPacketTest {
+@@ -139,7 +140,7 @@ public class CommandPacketTest {
      }
  
      @Test
@@ -2131,7 +2152,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..2b51669947330396da684b251e20e096
          var graph = Graph.builder(ArgumentType.Literal("foo"))
                  .append(ArgumentType.Group("1", ArgumentType.Integer("int1"), ArgumentType.Integer("int2")),
                          b -> b.append(ArgumentType.Group("2", ArgumentType.Integer("int3"), ArgumentType.Integer("int4"))))
-@@ -155,7 +155,7 @@ public class CommandPacketTest {
+@@ -155,7 +156,7 @@ public class CommandPacketTest {
                  """, graph);
      }
      @Test
@@ -2140,7 +2161,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..2b51669947330396da684b251e20e096
          var graph = Graph.builder(ArgumentType.Literal("foo"))
                  .append(ArgumentType.Enum("a", A.class))
                  .append(ArgumentType.Literal("l"))
-@@ -170,7 +170,7 @@ public class CommandPacketTest {
+@@ -170,7 +171,7 @@ public class CommandPacketTest {
      }
  
      @Test
@@ -2149,7 +2170,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..2b51669947330396da684b251e20e096
          var graph = Graph.builder(ArgumentType.Word("foo").from("foo", "bar"))
                  .build();
          assertPacketGraph("""
-@@ -180,7 +180,7 @@ public class CommandPacketTest {
+@@ -180,7 +181,7 @@ public class CommandPacketTest {
      }
  
      @Test
@@ -2158,7 +2179,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..2b51669947330396da684b251e20e096
          var graph = Graph.builder(ArgumentType.Word("foo").from("foo", "bar"))
                  .append(ArgumentType.Literal("l"))
                  .build();
-@@ -192,7 +192,7 @@ public class CommandPacketTest {
+@@ -192,7 +193,7 @@ public class CommandPacketTest {
      }
  
      @Test
@@ -2167,7 +2188,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..2b51669947330396da684b251e20e096
          var foo = Graph.builder(ArgumentType.Literal("foo"))
                  .append(ArgumentType.String("msg"))
                  .build();
-@@ -210,7 +210,7 @@ public class CommandPacketTest {
+@@ -210,7 +211,7 @@ public class CommandPacketTest {
      }
  
      @Test
@@ -2177,14 +2198,15 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..2b51669947330396da684b251e20e096
                  .append(ArgumentType.String("msg"))
                  .build();
 diff --git a/src/test/java/net/minestom/server/command/CommandParseTest.java b/src/test/java/net/minestom/server/command/CommandParseTest.java
-index d2751fcfd67ca910f59f33e5dcf4bcd9a23f429a..0c5062a628f072d0dc1608d0df533404e79d92cc 100644
+index d2751fcfd67ca910f59f33e5dcf4bcd9a23f429a..17ed355caedb5f10204de4a01bf5920866fc38b3 100644
 --- a/src/test/java/net/minestom/server/command/CommandParseTest.java
 +++ b/src/test/java/net/minestom/server/command/CommandParseTest.java
-@@ -11,16 +11,16 @@ import static net.minestom.server.command.builder.arguments.ArgumentType.Literal
+@@ -11,16 +11,17 @@ import static net.minestom.server.command.builder.arguments.ArgumentType.Literal
  import static net.minestom.server.command.builder.arguments.ArgumentType.Word;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class CommandParseTest {
++//Microtus - update java keyword usage
 +class CommandParseTest {
  
      @Test
@@ -2200,7 +2222,7 @@ index d2751fcfd67ca910f59f33e5dcf4bcd9a23f429a..0c5062a628f072d0dc1608d0df533404
          final AtomicBoolean b = new AtomicBoolean();
          var foo = Graph.merge(Graph.builder(Literal("foo"), createExecutor(b)).build());
          assertValid(foo, "foo", b);
-@@ -29,7 +29,7 @@ public class CommandParseTest {
+@@ -29,7 +30,7 @@ public class CommandParseTest {
      }
  
      @Test
@@ -2209,7 +2231,7 @@ index d2751fcfd67ca910f59f33e5dcf4bcd9a23f429a..0c5062a628f072d0dc1608d0df533404
          final AtomicBoolean b = new AtomicBoolean();
          final AtomicBoolean b1 = new AtomicBoolean();
          var graph = Graph.merge(
-@@ -44,7 +44,7 @@ public class CommandParseTest {
+@@ -44,7 +45,7 @@ public class CommandParseTest {
      }
  
      @Test
@@ -2218,7 +2240,7 @@ index d2751fcfd67ca910f59f33e5dcf4bcd9a23f429a..0c5062a628f072d0dc1608d0df533404
          final AtomicBoolean add = new AtomicBoolean();
          final AtomicBoolean action = new AtomicBoolean();
          var foo = Graph.merge(Graph.builder(Literal("foo"))
-@@ -69,7 +69,7 @@ public class CommandParseTest {
+@@ -69,7 +70,7 @@ public class CommandParseTest {
      }
  
      @Test
@@ -2227,7 +2249,7 @@ index d2751fcfd67ca910f59f33e5dcf4bcd9a23f429a..0c5062a628f072d0dc1608d0df533404
          final AtomicBoolean b = new AtomicBoolean();
          final AtomicReference<String> expectedFirstArg = new AtomicReference<>("T");
          var foo = Graph.merge(Graph.builder(Literal("foo"))
-@@ -92,7 +92,7 @@ public class CommandParseTest {
+@@ -92,7 +93,7 @@ public class CommandParseTest {
      }
  
      @Test
@@ -2236,7 +2258,7 @@ index d2751fcfd67ca910f59f33e5dcf4bcd9a23f429a..0c5062a628f072d0dc1608d0df533404
          enum A {a, b}
          final AtomicBoolean b = new AtomicBoolean();
          var foo = Graph.merge(Graph.builder(Literal("foo"))
-@@ -105,7 +105,7 @@ public class CommandParseTest {
+@@ -105,7 +106,7 @@ public class CommandParseTest {
      }
  
      @Test
@@ -2245,7 +2267,7 @@ index d2751fcfd67ca910f59f33e5dcf4bcd9a23f429a..0c5062a628f072d0dc1608d0df533404
          final AtomicBoolean b = new AtomicBoolean();
          var foo = Graph.merge(Graph.builder(Word("").from("foo", "bar"), createExecutor(b))
                  .build());
-@@ -115,7 +115,7 @@ public class CommandParseTest {
+@@ -115,7 +116,7 @@ public class CommandParseTest {
      }
  
      @Test
@@ -2255,14 +2277,15 @@ index d2751fcfd67ca910f59f33e5dcf4bcd9a23f429a..0c5062a628f072d0dc1608d0df533404
          var foo = Graph.merge(Graph.builder(Word("").from("foo", "bar"))
                  .append(ArgumentType.Integer("test"), createExecutor(b))
 diff --git a/src/test/java/net/minestom/server/command/CommandSenderTest.java b/src/test/java/net/minestom/server/command/CommandSenderTest.java
-index fe2b5186f3b90d46b465c0ca7fb319020f0b0286..a4ff2e54c1650dae3831c07072c0f54b803c5f20 100644
+index fe2b5186f3b90d46b465c0ca7fb319020f0b0286..fe864c687498c507dfda082f1740c5f810ec895a 100644
 --- a/src/test/java/net/minestom/server/command/CommandSenderTest.java
 +++ b/src/test/java/net/minestom/server/command/CommandSenderTest.java
-@@ -16,10 +16,10 @@ import java.util.Set;
+@@ -16,10 +16,11 @@ import java.util.Set;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class CommandSenderTest {
++//Microtus - update java keyword usage
 +class CommandSenderTest {
  
      @Test
@@ -2271,7 +2294,7 @@ index fe2b5186f3b90d46b465c0ca7fb319020f0b0286..a4ff2e54c1650dae3831c07072c0f54b
  
          CommandSender sender = new SenderTest();
  
-@@ -36,7 +36,7 @@ public class CommandSenderTest {
+@@ -36,7 +37,7 @@ public class CommandSenderTest {
      }
  
      @Test
@@ -2281,12 +2304,14 @@ index fe2b5186f3b90d46b465c0ca7fb319020f0b0286..a4ff2e54c1650dae3831c07072c0f54b
  
          assertNull(sender.getMostRecentMessage());
 diff --git a/src/test/java/net/minestom/server/command/CommandSuggestionIntegrationTest.java b/src/test/java/net/minestom/server/command/CommandSuggestionIntegrationTest.java
-index fff2a33d02b9ed1cfe2e320fb1c758e0839da047..c54b9ba92b8576f625a421df8a8073474aec8bea 100644
+index fff2a33d02b9ed1cfe2e320fb1c758e0839da047..130bb03196e54e3c8b7485ee287a7287ea417525 100644
 --- a/src/test/java/net/minestom/server/command/CommandSuggestionIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/command/CommandSuggestionIntegrationTest.java
-@@ -18,10 +18,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -17,11 +17,12 @@ import static net.minestom.server.command.builder.arguments.ArgumentType.Integer
+ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class CommandSuggestionIntegrationTest {
 +class CommandSuggestionIntegrationTest {
@@ -2297,7 +2322,7 @@ index fff2a33d02b9ed1cfe2e320fb1c758e0839da047..c54b9ba92b8576f625a421df8a807347
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -52,7 +52,7 @@ public class CommandSuggestionIntegrationTest {
+@@ -52,7 +53,7 @@ public class CommandSuggestionIntegrationTest {
      }
  
      @Test
@@ -2306,7 +2331,7 @@ index fff2a33d02b9ed1cfe2e320fb1c758e0839da047..c54b9ba92b8576f625a421df8a807347
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -64,20 +64,20 @@ public class CommandSuggestionIntegrationTest {
+@@ -64,20 +65,20 @@ public class CommandSuggestionIntegrationTest {
  
          var command = new Command("foo");
  
@@ -2332,7 +2357,7 @@ index fff2a33d02b9ed1cfe2e320fb1c758e0839da047..c54b9ba92b8576f625a421df8a807347
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -86,16 +86,16 @@ public class CommandSuggestionIntegrationTest {
+@@ -86,16 +87,16 @@ public class CommandSuggestionIntegrationTest {
  
          var subCommand = new Command("bar");
  
@@ -2357,7 +2382,7 @@ index fff2a33d02b9ed1cfe2e320fb1c758e0839da047..c54b9ba92b8576f625a421df8a807347
  
          command.addSubcommand(subCommand);
  
-@@ -105,29 +105,28 @@ public class CommandSuggestionIntegrationTest {
+@@ -105,29 +106,28 @@ public class CommandSuggestionIntegrationTest {
          player.addPacketToQueue(new ClientTabCompletePacket(1, "foo bar "));
          player.interpretPacketQueue();
  
@@ -2398,7 +2423,7 @@ index fff2a33d02b9ed1cfe2e320fb1c758e0839da047..c54b9ba92b8576f625a421df8a807347
  
          env.process().command().register(command);
  
-@@ -135,9 +134,8 @@ public class CommandSuggestionIntegrationTest {
+@@ -135,9 +135,8 @@ public class CommandSuggestionIntegrationTest {
          player.addPacketToQueue(new ClientTabCompletePacket(1, "foo literal2 "));
          player.interpretPacketQueue();
  
@@ -2411,7 +2436,7 @@ index fff2a33d02b9ed1cfe2e320fb1c758e0839da047..c54b9ba92b8576f625a421df8a807347
  
  }
 diff --git a/src/test/java/net/minestom/server/command/CommandSyntaxMultiTest.java b/src/test/java/net/minestom/server/command/CommandSyntaxMultiTest.java
-index ca0fec6265f2373a96d63a7b4c402ab35aa0395e..063ad7f76714778b6e459db03e13066bb02bd13c 100644
+index ca0fec6265f2373a96d63a7b4c402ab35aa0395e..77106a978f2cb086528d717f6c879274a59478e7 100644
 --- a/src/test/java/net/minestom/server/command/CommandSyntaxMultiTest.java
 +++ b/src/test/java/net/minestom/server/command/CommandSyntaxMultiTest.java
 @@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
@@ -2422,11 +2447,12 @@ index ca0fec6265f2373a96d63a7b4c402ab35aa0395e..063ad7f76714778b6e459db03e13066b
  import java.util.concurrent.atomic.AtomicReference;
  
  import static net.minestom.server.command.builder.arguments.ArgumentType.Float;
-@@ -16,10 +15,10 @@ import static net.minestom.server.command.builder.arguments.ArgumentType.*;
+@@ -16,10 +15,11 @@ import static net.minestom.server.command.builder.arguments.ArgumentType.*;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.fail;
  
 -public class CommandSyntaxMultiTest {
++//Microtus - update java keyword usage
 +class CommandSyntaxMultiTest {
  
      @Test
@@ -2435,7 +2461,7 @@ index ca0fec6265f2373a96d63a7b4c402ab35aa0395e..063ad7f76714778b6e459db03e13066b
          List<List<Argument<?>>> args = List.of(
                  List.of(Literal("integer"), Integer("number")),
                  List.of(Literal("float"), Float("number"))
-@@ -29,7 +28,7 @@ public class CommandSyntaxMultiTest {
+@@ -29,7 +29,7 @@ public class CommandSyntaxMultiTest {
      }
  
      @Test
@@ -2444,7 +2470,7 @@ index ca0fec6265f2373a96d63a7b4c402ab35aa0395e..063ad7f76714778b6e459db03e13066b
          List<List<Argument<?>>> args = List.of(
                  List.of(Word("word")),
                  List.of(Literal("literal"))
-@@ -38,7 +37,7 @@ public class CommandSyntaxMultiTest {
+@@ -38,7 +38,7 @@ public class CommandSyntaxMultiTest {
      }
  
      @Test
@@ -2454,14 +2480,15 @@ index ca0fec6265f2373a96d63a7b4c402ab35aa0395e..063ad7f76714778b6e459db03e13066b
                  List.of(Word("a")),
                  List.of(Word("b"), Word("a"))
 diff --git a/src/test/java/net/minestom/server/command/CommandSyntaxSingleTest.java b/src/test/java/net/minestom/server/command/CommandSyntaxSingleTest.java
-index 42cfa09255a0fb576f5db0edde46233252916f11..1a56d96f878ba6cab7234a7cfbb08f9e11927cf1 100644
+index 42cfa09255a0fb576f5db0edde46233252916f11..247fd5ede85f7fbe5d1b3eb32f033089f8a5b21b 100644
 --- a/src/test/java/net/minestom/server/command/CommandSyntaxSingleTest.java
 +++ b/src/test/java/net/minestom/server/command/CommandSyntaxSingleTest.java
-@@ -18,9 +18,9 @@ import static net.minestom.server.command.builder.arguments.ArgumentType.*;
+@@ -18,9 +18,10 @@ import static net.minestom.server.command.builder.arguments.ArgumentType.*;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.fail;
  
 -public class CommandSyntaxSingleTest {
++//Microtus - update java keyword usage
 +class CommandSyntaxSingleTest {
      @Test
 -    public void singleInteger() {
@@ -2469,7 +2496,7 @@ index 42cfa09255a0fb576f5db0edde46233252916f11..1a56d96f878ba6cab7234a7cfbb08f9e
          List<Argument<?>> args = List.of(Integer("number"));
          assertSyntax(args, "5", ExpectedExecution.SYNTAX, Map.of("number", 5));
          assertSyntax(args, "5 5", ExpectedExecution.DEFAULT);
-@@ -28,7 +28,7 @@ public class CommandSyntaxSingleTest {
+@@ -28,7 +29,7 @@ public class CommandSyntaxSingleTest {
      }
  
      @Test
@@ -2478,7 +2505,7 @@ index 42cfa09255a0fb576f5db0edde46233252916f11..1a56d96f878ba6cab7234a7cfbb08f9e
          List<Argument<?>> args = List.of(Integer("number"), Integer("number2"));
          assertSyntax(args, "5", ExpectedExecution.DEFAULT);
          assertSyntax(args, "5 6", ExpectedExecution.SYNTAX, Map.of("number", 5, "number2", 6));
-@@ -36,7 +36,7 @@ public class CommandSyntaxSingleTest {
+@@ -36,7 +37,7 @@ public class CommandSyntaxSingleTest {
      }
  
      @Test
@@ -2487,7 +2514,7 @@ index 42cfa09255a0fb576f5db0edde46233252916f11..1a56d96f878ba6cab7234a7cfbb08f9e
          List<Argument<?>> args = List.of(String("string"));
          assertSyntax(args, """
                  "value"
-@@ -46,7 +46,7 @@ public class CommandSyntaxSingleTest {
+@@ -46,7 +47,7 @@ public class CommandSyntaxSingleTest {
      }
  
      @Test
@@ -2496,7 +2523,7 @@ index 42cfa09255a0fb576f5db0edde46233252916f11..1a56d96f878ba6cab7234a7cfbb08f9e
          List<Argument<?>> args = List.of(String("string"), String("string2"));
          assertSyntax(args, "test", ExpectedExecution.DEFAULT);
          assertSyntax(args, """
-@@ -60,7 +60,7 @@ public class CommandSyntaxSingleTest {
+@@ -60,7 +61,7 @@ public class CommandSyntaxSingleTest {
      }
  
      @Test
@@ -2505,7 +2532,7 @@ index 42cfa09255a0fb576f5db0edde46233252916f11..1a56d96f878ba6cab7234a7cfbb08f9e
          List<Argument<?>> args = List.of(Group("loop", Integer("first"), Integer("second")));
          // 1 2
          {
-@@ -74,7 +74,7 @@ public class CommandSyntaxSingleTest {
+@@ -74,7 +75,7 @@ public class CommandSyntaxSingleTest {
      }
  
      @Test
@@ -2514,7 +2541,7 @@ index 42cfa09255a0fb576f5db0edde46233252916f11..1a56d96f878ba6cab7234a7cfbb08f9e
          List<Argument<?>> stringLoop = List.of(Loop("loop", String("value")));
          assertSyntax(stringLoop, "one two three", ExpectedExecution.SYNTAX, Map.of("loop", List.of("one", "two", "three")));
  
-@@ -83,7 +83,7 @@ public class CommandSyntaxSingleTest {
+@@ -83,7 +84,7 @@ public class CommandSyntaxSingleTest {
      }
  
      @Test
@@ -2523,7 +2550,7 @@ index 42cfa09255a0fb576f5db0edde46233252916f11..1a56d96f878ba6cab7234a7cfbb08f9e
          List<Argument<?>> groupLoop = List.of(Loop("loop", Group("group", Integer("first"), Integer("second"))));
          // 1 2
          {
-@@ -112,7 +112,7 @@ public class CommandSyntaxSingleTest {
+@@ -112,7 +113,7 @@ public class CommandSyntaxSingleTest {
      }
  
      @Test
@@ -2533,14 +2560,15 @@ index 42cfa09255a0fb576f5db0edde46233252916f11..1a56d96f878ba6cab7234a7cfbb08f9e
                  Loop("loop",
                          Group("group", BlockState("block"), Enchantment("enchant")),
 diff --git a/src/test/java/net/minestom/server/command/CommandTest.java b/src/test/java/net/minestom/server/command/CommandTest.java
-index 420530aa47c0de56de27e1aa55d1a29395ae1c5c..d56c151d1d296776b690790573b49690cb34875e 100644
+index 420530aa47c0de56de27e1aa55d1a29395ae1c5c..68b6f164e0a69b54ffeded34b0528c235de08d53 100644
 --- a/src/test/java/net/minestom/server/command/CommandTest.java
 +++ b/src/test/java/net/minestom/server/command/CommandTest.java
-@@ -10,10 +10,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
+@@ -10,10 +10,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class CommandTest {
++//Microtus - update java keyword usage
 +class CommandTest {
  
      @Test
@@ -2549,7 +2577,7 @@ index 420530aa47c0de56de27e1aa55d1a29395ae1c5c..d56c151d1d296776b690790573b49690
          Command command = new Command("name1", "name2", "name3");
  
          assertEquals("name1", command.getName());
-@@ -27,7 +27,7 @@ public class CommandTest {
+@@ -27,7 +28,7 @@ public class CommandTest {
      }
  
      @Test
@@ -2558,15 +2586,28 @@ index 420530aa47c0de56de27e1aa55d1a29395ae1c5c..d56c151d1d296776b690790573b49690
          var manager = new CommandManager();
  
          AtomicBoolean hasRun = new AtomicBoolean(false);
+diff --git a/src/test/java/net/minestom/server/command/CommandTestUtils.java b/src/test/java/net/minestom/server/command/CommandTestUtils.java
+index ea0d9fc24acca8a2fd56a8e17c021de829bd0ff2..20e8c7db054737919f20e55c10e6dee76b77ac2d 100644
+--- a/src/test/java/net/minestom/server/command/CommandTestUtils.java
++++ b/src/test/java/net/minestom/server/command/CommandTestUtils.java
+@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.fail;
+ 
++//Microtus - update java keyword usage
+ public class CommandTestUtils {
+ 
+     public static void assertPacket(DeclareCommandsPacket packet, String expectedStructure) {
 diff --git a/src/test/java/net/minestom/server/command/GraphConversionExecutorTest.java b/src/test/java/net/minestom/server/command/GraphConversionExecutorTest.java
-index 55e5612f3e41096c6904dba1a5002af4ea2a0131..0bb5c4470c0093a8511f6e3c1d2862189eec662e 100644
+index 55e5612f3e41096c6904dba1a5002af4ea2a0131..7a20eb0a36807f0c6c2391b51db47b969ab663a3 100644
 --- a/src/test/java/net/minestom/server/command/GraphConversionExecutorTest.java
 +++ b/src/test/java/net/minestom/server/command/GraphConversionExecutorTest.java
-@@ -8,9 +8,9 @@ import org.junit.jupiter.api.Test;
+@@ -8,9 +8,10 @@ import org.junit.jupiter.api.Test;
  import static net.minestom.server.command.builder.arguments.ArgumentType.Literal;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class GraphConversionExecutorTest {
++//Microtus - update java keyword usage
 +class GraphConversionExecutorTest {
      @Test
 -    public void defaultCondition() {
@@ -2574,7 +2615,7 @@ index 55e5612f3e41096c6904dba1a5002af4ea2a0131..0bb5c4470c0093a8511f6e3c1d286218
          final Command foo = new Command("foo");
          // Constant true
          {
-@@ -31,7 +31,7 @@ public class GraphConversionExecutorTest {
+@@ -31,7 +32,7 @@ public class GraphConversionExecutorTest {
      }
  
      @Test
@@ -2583,7 +2624,7 @@ index 55e5612f3e41096c6904dba1a5002af4ea2a0131..0bb5c4470c0093a8511f6e3c1d286218
          final Command foo = new Command("foo");
          foo.addSyntax(GraphConversionExecutorTest::dummyExecutor, Literal("first"));
  
-@@ -44,7 +44,7 @@ public class GraphConversionExecutorTest {
+@@ -44,7 +45,7 @@ public class GraphConversionExecutorTest {
      }
  
      @Test
@@ -2592,7 +2633,7 @@ index 55e5612f3e41096c6904dba1a5002af4ea2a0131..0bb5c4470c0093a8511f6e3c1d286218
          final Command foo = new Command("foo");
          foo.addConditionalSyntax((sender, context) -> true,
                  GraphConversionExecutorTest::dummyExecutor, Literal("first"));
-@@ -57,7 +57,7 @@ public class GraphConversionExecutorTest {
+@@ -57,7 +58,7 @@ public class GraphConversionExecutorTest {
      }
  
      @Test
@@ -2601,7 +2642,7 @@ index 55e5612f3e41096c6904dba1a5002af4ea2a0131..0bb5c4470c0093a8511f6e3c1d286218
          final Command foo = new Command("foo");
          foo.addConditionalSyntax((sender, context) -> false,
                  GraphConversionExecutorTest::dummyExecutor, Literal("first"));
-@@ -70,7 +70,7 @@ public class GraphConversionExecutorTest {
+@@ -70,7 +71,7 @@ public class GraphConversionExecutorTest {
      }
  
      @Test
@@ -2611,14 +2652,15 @@ index 55e5612f3e41096c6904dba1a5002af4ea2a0131..0bb5c4470c0093a8511f6e3c1d286218
          foo.setCondition((sender, commandString) -> false);
          final Graph graph = Graph.fromCommand(foo);
 diff --git a/src/test/java/net/minestom/server/command/GraphConversionTest.java b/src/test/java/net/minestom/server/command/GraphConversionTest.java
-index 7c294232ed4e25e457ab95ecfcc757c7b312b184..a429406c4713708ea76b82d576f990c88b8067db 100644
+index 7c294232ed4e25e457ab95ecfcc757c7b312b184..21cfa14bfadcfdf1df6d8d2db0f9630780155b1a 100644
 --- a/src/test/java/net/minestom/server/command/GraphConversionTest.java
 +++ b/src/test/java/net/minestom/server/command/GraphConversionTest.java
-@@ -9,16 +9,16 @@ import static net.minestom.server.command.builder.arguments.ArgumentType.Integer
+@@ -9,16 +9,17 @@ import static net.minestom.server.command.builder.arguments.ArgumentType.Integer
  import static net.minestom.server.command.builder.arguments.ArgumentType.*;
  import static org.junit.jupiter.api.Assertions.assertTrue;
  
 -public class GraphConversionTest {
++//Microtus - update java keyword usage
 +class GraphConversionTest {
      @Test
 -    public void empty() {
@@ -2634,7 +2676,7 @@ index 7c294232ed4e25e457ab95ecfcc757c7b312b184..a429406c4713708ea76b82d576f990c8
          final Command foo = new Command("foo");
          var first = Literal("first");
          foo.addSyntax(GraphConversionTest::dummyExecutor, first);
-@@ -28,7 +28,7 @@ public class GraphConversionTest {
+@@ -28,7 +29,7 @@ public class GraphConversionTest {
      }
  
      @Test
@@ -2643,7 +2685,7 @@ index 7c294232ed4e25e457ab95ecfcc757c7b312b184..a429406c4713708ea76b82d576f990c8
          final Command foo = new Command("foo");
          var first = Literal("first");
          var second = Literal("second");
-@@ -43,7 +43,7 @@ public class GraphConversionTest {
+@@ -43,7 +44,7 @@ public class GraphConversionTest {
      }
  
      @Test
@@ -2652,7 +2694,7 @@ index 7c294232ed4e25e457ab95ecfcc757c7b312b184..a429406c4713708ea76b82d576f990c8
          enum A {A, B, C, D, E}
          final Command foo = new Command("foo");
  
-@@ -64,7 +64,7 @@ public class GraphConversionTest {
+@@ -64,7 +65,7 @@ public class GraphConversionTest {
      }
  
      @Test
@@ -2661,7 +2703,7 @@ index 7c294232ed4e25e457ab95ecfcc757c7b312b184..a429406c4713708ea76b82d576f990c8
          final Command foo = new Command("foo");
  
          var bar = Literal("bar");
-@@ -81,7 +81,7 @@ public class GraphConversionTest {
+@@ -81,7 +82,7 @@ public class GraphConversionTest {
      }
  
      @Test
@@ -2670,7 +2712,7 @@ index 7c294232ed4e25e457ab95ecfcc757c7b312b184..a429406c4713708ea76b82d576f990c8
          final Command main = new Command("main");
          final Command sub = new Command("sub");
  
-@@ -107,14 +107,14 @@ public class GraphConversionTest {
+@@ -107,14 +108,14 @@ public class GraphConversionTest {
      }
  
      @Test
@@ -2688,14 +2730,15 @@ index 7c294232ed4e25e457ab95ecfcc757c7b312b184..a429406c4713708ea76b82d576f990c8
          var graph = Graph.builder(Word("main").from("main", "first", "second")).build();
          assertEqualsGraph(graph, main);
 diff --git a/src/test/java/net/minestom/server/command/GraphMergeTest.java b/src/test/java/net/minestom/server/command/GraphMergeTest.java
-index d257c0bd8881037ca13fd805931d94756b268e5b..bed954ced10cc69d96986be1eac7093e7492c395 100644
+index d257c0bd8881037ca13fd805931d94756b268e5b..37b404e9d79207274a10d17b1d091cb5bec56eb6 100644
 --- a/src/test/java/net/minestom/server/command/GraphMergeTest.java
 +++ b/src/test/java/net/minestom/server/command/GraphMergeTest.java
-@@ -8,10 +8,10 @@ import java.util.List;
+@@ -8,10 +8,11 @@ import java.util.List;
  import static net.minestom.server.command.builder.arguments.ArgumentType.Literal;
  import static org.junit.jupiter.api.Assertions.assertTrue;
  
 -public class GraphMergeTest {
++//Microtus - update java keyword usage
 +class GraphMergeTest {
  
      @Test
@@ -2704,7 +2747,7 @@ index d257c0bd8881037ca13fd805931d94756b268e5b..bed954ced10cc69d96986be1eac7093e
          var foo = new Command("foo");
          var bar = new Command("bar");
          var result = Graph.builder(Literal(""))
-@@ -22,7 +22,7 @@ public class GraphMergeTest {
+@@ -22,7 +23,7 @@ public class GraphMergeTest {
      }
  
      @Test
@@ -2713,7 +2756,7 @@ index d257c0bd8881037ca13fd805931d94756b268e5b..bed954ced10cc69d96986be1eac7093e
          var graph1 = Graph.builder(Literal("foo")).build();
          var graph2 = Graph.builder(Literal("bar")).build();
          var result = Graph.builder(Literal(""))
-@@ -33,7 +33,7 @@ public class GraphMergeTest {
+@@ -33,7 +34,7 @@ public class GraphMergeTest {
      }
  
      @Test
@@ -2723,14 +2766,15 @@ index d257c0bd8881037ca13fd805931d94756b268e5b..bed954ced10cc69d96986be1eac7093e
          var graph2 = Graph.builder(Literal("bar")).append(Literal("2")).build();
          var result = Graph.builder(Literal(""))
 diff --git a/src/test/java/net/minestom/server/command/GraphTest.java b/src/test/java/net/minestom/server/command/GraphTest.java
-index 388768e3bb3eace4665eff42ff06270aa47fbdf3..91dff666e2c11c27b09406243c2b783560de3218 100644
+index 388768e3bb3eace4665eff42ff06270aa47fbdf3..d9f334d1f5b35c0e31526e04287869b16c500b2d 100644
 --- a/src/test/java/net/minestom/server/command/GraphTest.java
 +++ b/src/test/java/net/minestom/server/command/GraphTest.java
-@@ -9,9 +9,9 @@ import java.util.List;
+@@ -9,9 +9,10 @@ import java.util.List;
  import static net.minestom.server.command.builder.arguments.ArgumentType.Literal;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class GraphTest {
++//Microtus - update java keyword usage
 +class GraphTest {
      @Test
 -    public void empty() {
@@ -2738,7 +2782,7 @@ index 388768e3bb3eace4665eff42ff06270aa47fbdf3..91dff666e2c11c27b09406243c2b7835
          var result = Graph.builder(Literal(""))
                  .build();
          var node = result.root();
-@@ -20,7 +20,7 @@ public class GraphTest {
+@@ -20,7 +21,7 @@ public class GraphTest {
      }
  
      @Test
@@ -2747,7 +2791,7 @@ index 388768e3bb3eace4665eff42ff06270aa47fbdf3..91dff666e2c11c27b09406243c2b7835
          var result = Graph.builder(Literal(""))
                  .append(Literal("foo"))
                  .build();
-@@ -31,7 +31,7 @@ public class GraphTest {
+@@ -31,7 +32,7 @@ public class GraphTest {
      }
  
      @Test
@@ -2756,7 +2800,7 @@ index 388768e3bb3eace4665eff42ff06270aa47fbdf3..91dff666e2c11c27b09406243c2b7835
          var result = Graph.builder(Literal(""))
                  .append(Literal("foo"))
                  .append(Literal("bar"))
-@@ -42,7 +42,7 @@ public class GraphTest {
+@@ -42,7 +43,7 @@ public class GraphTest {
      }
  
      @Test
@@ -2765,7 +2809,7 @@ index 388768e3bb3eace4665eff42ff06270aa47fbdf3..91dff666e2c11c27b09406243c2b7835
          final Command foo = new Command("foo");
          var first = Literal("first");
          foo.addSyntax(GraphTest::dummyExecutor, first);
-@@ -54,7 +54,7 @@ public class GraphTest {
+@@ -54,7 +55,7 @@ public class GraphTest {
      }
  
      @Test
@@ -2775,14 +2819,15 @@ index 388768e3bb3eace4665eff42ff06270aa47fbdf3..91dff666e2c11c27b09406243c2b7835
  
          {
 diff --git a/src/test/java/net/minestom/server/command/SubcommandTest.java b/src/test/java/net/minestom/server/command/SubcommandTest.java
-index 6ed762fa232c741dbe0be886245e98d1515f9bd4..88968d428de85c144dafe1ed509edd30d808fa85 100644
+index 6ed762fa232c741dbe0be886245e98d1515f9bd4..9b7ee1de34867d3689b37c52326cbf275606ca8a 100644
 --- a/src/test/java/net/minestom/server/command/SubcommandTest.java
 +++ b/src/test/java/net/minestom/server/command/SubcommandTest.java
-@@ -8,10 +8,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
+@@ -8,10 +8,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
  import static org.junit.jupiter.api.Assertions.assertFalse;
  import static org.junit.jupiter.api.Assertions.assertTrue;
  
 -public class SubcommandTest {
++//Microtus - update java keyword usage
 +class SubcommandTest {
  
      @Test
@@ -2791,7 +2836,7 @@ index 6ed762fa232c741dbe0be886245e98d1515f9bd4..88968d428de85c144dafe1ed509edd30
          var manager = new CommandManager();
  
          var parent = new Command("parent");
-@@ -33,7 +33,7 @@ public class SubcommandTest {
+@@ -33,7 +34,7 @@ public class SubcommandTest {
      }
  
      @Test
@@ -2801,14 +2846,15 @@ index 6ed762fa232c741dbe0be886245e98d1515f9bd4..88968d428de85c144dafe1ed509edd30
  
          var parent = new Command("parent");
 diff --git a/src/test/java/net/minestom/server/coordinate/CoordinateTest.java b/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
-index 560cf470c2ce9b12faf5af245f13b104a3a27a6e..2ebccae5928b3f66a8e1cb683342b4fc1a3131b1 100644
+index 560cf470c2ce9b12faf5af245f13b104a3a27a6e..373cc028435570ff4f62a062a98ba5a85598a935 100644
 --- a/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
 +++ b/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
-@@ -11,10 +11,10 @@ import java.util.List;
+@@ -11,10 +11,11 @@ import java.util.List;
  import static net.minestom.server.utils.chunk.ChunkUtils.*;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class CoordinateTest {
++//Microtus - update java keyword usage
 +class CoordinateTest {
  
      @Test
@@ -2817,7 +2863,7 @@ index 560cf470c2ce9b12faf5af245f13b104a3a27a6e..2ebccae5928b3f66a8e1cb683342b4fc
          var index = getChunkIndex(2, 5);
          assertEquals(2, getChunkCoordX(index));
          assertEquals(5, getChunkCoordZ(index));
-@@ -29,7 +29,7 @@ public class CoordinateTest {
+@@ -29,7 +30,7 @@ public class CoordinateTest {
      }
  
      @Test
@@ -2826,7 +2872,7 @@ index 560cf470c2ce9b12faf5af245f13b104a3a27a6e..2ebccae5928b3f66a8e1cb683342b4fc
          assertEquals(0, getChunkCoordinate(15));
          assertEquals(1, getChunkCoordinate(16));
          assertEquals(-1, getChunkCoordinate(-16));
-@@ -43,7 +43,7 @@ public class CoordinateTest {
+@@ -43,7 +44,7 @@ public class CoordinateTest {
      }
  
      @Test
@@ -2835,7 +2881,7 @@ index 560cf470c2ce9b12faf5af245f13b104a3a27a6e..2ebccae5928b3f66a8e1cb683342b4fc
          assertEquals(289, getChunkCount(8));
          assertEquals(169, getChunkCount(6));
          assertEquals(121, getChunkCount(5));
-@@ -53,7 +53,7 @@ public class CoordinateTest {
+@@ -53,7 +54,7 @@ public class CoordinateTest {
      }
  
      @Test
@@ -2844,7 +2890,7 @@ index 560cf470c2ce9b12faf5af245f13b104a3a27a6e..2ebccae5928b3f66a8e1cb683342b4fc
          Vec temp = Vec.ZERO;
          assertEquals(0, temp.x());
          assertEquals(0, temp.y());
-@@ -81,7 +81,7 @@ public class CoordinateTest {
+@@ -81,7 +82,7 @@ public class CoordinateTest {
      }
  
      @Test
@@ -2853,7 +2899,7 @@ index 560cf470c2ce9b12faf5af245f13b104a3a27a6e..2ebccae5928b3f66a8e1cb683342b4fc
          Vec temp = Vec.ZERO.withX(1);
          assertEquals(1, temp.x());
          assertEquals(0, temp.y());
-@@ -94,7 +94,7 @@ public class CoordinateTest {
+@@ -94,7 +95,7 @@ public class CoordinateTest {
      }
  
      @Test
@@ -2862,7 +2908,7 @@ index 560cf470c2ce9b12faf5af245f13b104a3a27a6e..2ebccae5928b3f66a8e1cb683342b4fc
          assertEquals(8, ChunkUtils.toSectionRelativeCoordinate(-40));
          assertEquals(12, ChunkUtils.toSectionRelativeCoordinate(-20));
          assertEquals(0, ChunkUtils.toSectionRelativeCoordinate(0));
-@@ -107,7 +107,7 @@ public class CoordinateTest {
+@@ -107,7 +108,7 @@ public class CoordinateTest {
      }
  
      @Test
@@ -2871,7 +2917,7 @@ index 560cf470c2ce9b12faf5af245f13b104a3a27a6e..2ebccae5928b3f66a8e1cb683342b4fc
          // Test if the block index is correctly converted back and forth
  
          List<Vec> tempEquals = List.of(
-@@ -151,7 +151,7 @@ public class CoordinateTest {
+@@ -151,7 +152,7 @@ public class CoordinateTest {
      }
  
      @Test
@@ -2881,14 +2927,15 @@ index 560cf470c2ce9b12faf5af245f13b104a3a27a6e..2ebccae5928b3f66a8e1cb683342b4fc
  
          for (int x = 0; x < Chunk.CHUNK_SIZE_X; x++) {
 diff --git a/src/test/java/net/minestom/server/coordinate/PosViewDirectionTest.java b/src/test/java/net/minestom/server/coordinate/PosViewDirectionTest.java
-index e0ae029f68f7ec614d69836fdc9b84542a5b4bd5..1072819aa016c8ce3d2c47031caa084fc246186f 100644
+index e0ae029f68f7ec614d69836fdc9b84542a5b4bd5..1922b6c9f74916e252f3169c863dc18662176815 100644
 --- a/src/test/java/net/minestom/server/coordinate/PosViewDirectionTest.java
 +++ b/src/test/java/net/minestom/server/coordinate/PosViewDirectionTest.java
-@@ -4,11 +4,11 @@ import org.junit.jupiter.api.Test;
+@@ -4,11 +4,12 @@ import org.junit.jupiter.api.Test;
  
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
 -public class PosViewDirectionTest {
++//Microtus - update java keyword usage
 +class PosViewDirectionTest {
      private static final float EPSILON = 0.01f;
  
@@ -2899,12 +2946,14 @@ index e0ae029f68f7ec614d69836fdc9b84542a5b4bd5..1072819aa016c8ce3d2c47031caa084f
          Pos position;
  
 diff --git a/src/test/java/net/minestom/server/entity/EntityBoundingBoxIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityBoundingBoxIntegrationTest.java
-index dc20cd87d838a6b186180d94d7037c276fc9169c..01bbdd9065aa8e5966eaad3d788b13025455e738 100644
+index dc20cd87d838a6b186180d94d7037c276fc9169c..a870739251b09c5e0dccd9e66501909ce96c8822 100644
 --- a/src/test/java/net/minestom/server/entity/EntityBoundingBoxIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityBoundingBoxIntegrationTest.java
-@@ -13,9 +13,9 @@ import org.junit.jupiter.api.Test;
+@@ -12,10 +12,11 @@ import org.junit.jupiter.api.Test;
+ 
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class EntityBoundingBoxIntegrationTest {
 +class EntityBoundingBoxIntegrationTest {
@@ -2914,7 +2963,7 @@ index dc20cd87d838a6b186180d94d7037c276fc9169c..01bbdd9065aa8e5966eaad3d788b1302
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -36,7 +36,7 @@ public class EntityBoundingBoxIntegrationTest {
+@@ -36,7 +37,7 @@ public class EntityBoundingBoxIntegrationTest {
      }
  
      @Test
@@ -2923,7 +2972,7 @@ index dc20cd87d838a6b186180d94d7037c276fc9169c..01bbdd9065aa8e5966eaad3d788b1302
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -54,7 +54,7 @@ public class EntityBoundingBoxIntegrationTest {
+@@ -54,7 +55,7 @@ public class EntityBoundingBoxIntegrationTest {
      }
  
      @Test
@@ -2932,13 +2981,27 @@ index dc20cd87d838a6b186180d94d7037c276fc9169c..01bbdd9065aa8e5966eaad3d788b1302
          final var instance = env.createFlatInstance();
          final var listener = env.listen(PickupItemEvent.class);
          final var spawnPos = new Pos(0, 42, 0);
+diff --git a/src/test/java/net/minestom/server/entity/EntityEqualsTest.java b/src/test/java/net/minestom/server/entity/EntityEqualsTest.java
+index e11088a617e6da7b058b6c6a8a8ffb311ceebe48..0ad4a671fed6860a008a50f6be48e2bb5c07afcc 100644
+--- a/src/test/java/net/minestom/server/entity/EntityEqualsTest.java
++++ b/src/test/java/net/minestom/server/entity/EntityEqualsTest.java
+@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
++//Microtus - update java keyword usage
+ class EntityEqualsTest {
+ 
+     @Test
 diff --git a/src/test/java/net/minestom/server/entity/EntityInstanceIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityInstanceIntegrationTest.java
-index 5a9d128ef0d73a1726d6af1ed73ff1fee36a82a7..ba578f774f6787183606206ef9a435bbd147e6b3 100644
+index 5a9d128ef0d73a1726d6af1ed73ff1fee36a82a7..496a402d1c63d69e8d922e407deab47d9282bb40 100644
 --- a/src/test/java/net/minestom/server/entity/EntityInstanceIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityInstanceIntegrationTest.java
-@@ -11,10 +11,10 @@ import java.time.Duration;
+@@ -10,11 +10,12 @@ import java.time.Duration;
+ 
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class EntityInstanceIntegrationTest {
 +class EntityInstanceIntegrationTest {
@@ -2949,7 +3012,7 @@ index 5a9d128ef0d73a1726d6af1ed73ff1fee36a82a7..ba578f774f6787183606206ef9a435bb
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityTypes.ZOMBIE);
          entity.setInstance(instance, new Pos(0, 42, 0)).join();
-@@ -23,7 +23,7 @@ public class EntityInstanceIntegrationTest {
+@@ -23,7 +24,7 @@ public class EntityInstanceIntegrationTest {
      }
  
      @Test
@@ -2958,7 +3021,7 @@ index 5a9d128ef0d73a1726d6af1ed73ff1fee36a82a7..ba578f774f6787183606206ef9a435bb
          var instance = env.createFlatInstance();
          var player = env.createPlayer(instance, new Pos(0, 42, 0));
          assertEquals(instance, player.getInstance());
-@@ -31,7 +31,7 @@ public class EntityInstanceIntegrationTest {
+@@ -31,7 +32,7 @@ public class EntityInstanceIntegrationTest {
      }
  
      @Test
@@ -2968,12 +3031,14 @@ index 5a9d128ef0d73a1726d6af1ed73ff1fee36a82a7..ba578f774f6787183606206ef9a435bb
          var instance2 = env.createFlatInstance();
          var connection = env.createConnection();
 diff --git a/src/test/java/net/minestom/server/entity/EntityLineOfSightIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityLineOfSightIntegrationTest.java
-index a6bb809294a39af40ab9d89a86299d37c5e15e00..eb4c8083d2517206c90a0c598e20fce700740f1b 100644
+index a6bb809294a39af40ab9d89a86299d37c5e15e00..b4877072205311257d16cfb9f610575e817ed186 100644
 --- a/src/test/java/net/minestom/server/entity/EntityLineOfSightIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityLineOfSightIntegrationTest.java
-@@ -9,9 +9,9 @@ import org.junit.jupiter.api.Test;
+@@ -8,10 +8,11 @@ import org.junit.jupiter.api.Test;
+ 
  import static org.junit.jupiter.api.Assertions.*;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class EntityLineOfSightIntegrationTest {
 +class EntityLineOfSightIntegrationTest {
@@ -2983,7 +3048,7 @@ index a6bb809294a39af40ab9d89a86299d37c5e15e00..eb4c8083d2517206c90a0c598e20fce7
          var instance = env.createFlatInstance();
  
          var entity = new Entity(EntityTypes.ZOMBIE);
-@@ -35,7 +35,7 @@ public class EntityLineOfSightIntegrationTest {
+@@ -35,7 +36,7 @@ public class EntityLineOfSightIntegrationTest {
      }
  
      @Test
@@ -2992,7 +3057,7 @@ index a6bb809294a39af40ab9d89a86299d37c5e15e00..eb4c8083d2517206c90a0c598e20fce7
          var instance = env.createFlatInstance();
  
          var entity = new Entity(EntityTypes.ZOMBIE);
-@@ -59,7 +59,7 @@ public class EntityLineOfSightIntegrationTest {
+@@ -59,7 +60,7 @@ public class EntityLineOfSightIntegrationTest {
      }
  
      @Test
@@ -3001,7 +3066,7 @@ index a6bb809294a39af40ab9d89a86299d37c5e15e00..eb4c8083d2517206c90a0c598e20fce7
          var instance = env.createFlatInstance();
  
          var entity = new Entity(EntityTypes.ZOMBIE);
-@@ -83,7 +83,7 @@ public class EntityLineOfSightIntegrationTest {
+@@ -83,7 +84,7 @@ public class EntityLineOfSightIntegrationTest {
      }
  
      @Test
@@ -3010,7 +3075,7 @@ index a6bb809294a39af40ab9d89a86299d37c5e15e00..eb4c8083d2517206c90a0c598e20fce7
          var instance = env.createFlatInstance();
  
          var entity = new Entity(EntityTypes.ZOMBIE);
-@@ -109,7 +109,7 @@ public class EntityLineOfSightIntegrationTest {
+@@ -109,7 +110,7 @@ public class EntityLineOfSightIntegrationTest {
      }
  
      @Test
@@ -3019,7 +3084,7 @@ index a6bb809294a39af40ab9d89a86299d37c5e15e00..eb4c8083d2517206c90a0c598e20fce7
          var instance = env.createFlatInstance();
  
          var entity = new Entity(EntityTypes.ZOMBIE);
-@@ -130,7 +130,7 @@ public class EntityLineOfSightIntegrationTest {
+@@ -130,7 +131,7 @@ public class EntityLineOfSightIntegrationTest {
      }
  
      @Test
@@ -3028,7 +3093,7 @@ index a6bb809294a39af40ab9d89a86299d37c5e15e00..eb4c8083d2517206c90a0c598e20fce7
          var instance = env.createFlatInstance();
  
          var entity = new Entity(EntityTypes.ZOMBIE);
-@@ -145,7 +145,7 @@ public class EntityLineOfSightIntegrationTest {
+@@ -145,7 +146,7 @@ public class EntityLineOfSightIntegrationTest {
          assertTrue(entity.hasLineOfSight(entity2, false));
      }
      @Test
@@ -3038,12 +3103,14 @@ index a6bb809294a39af40ab9d89a86299d37c5e15e00..eb4c8083d2517206c90a0c598e20fce7
  
          var entity = new Entity(EntityTypes.ZOMBIE);
 diff --git a/src/test/java/net/minestom/server/entity/EntityMetaIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityMetaIntegrationTest.java
-index d4bc0029ea907166ea1e42cccc801828ad2829c9..570f9d13fd3795dbd8646d0803b422efa02004cf 100644
+index d4bc0029ea907166ea1e42cccc801828ad2829c9..21603a61f8213d530805d8b651a5ac6b724bea32 100644
 --- a/src/test/java/net/minestom/server/entity/EntityMetaIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityMetaIntegrationTest.java
-@@ -14,10 +14,10 @@ import java.util.function.Consumer;
+@@ -13,11 +13,12 @@ import java.util.function.Consumer;
+ 
  import static org.junit.jupiter.api.Assertions.*;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class EntityMetaIntegrationTest {
 +class EntityMetaIntegrationTest {
@@ -3054,7 +3121,7 @@ index d4bc0029ea907166ea1e42cccc801828ad2829c9..570f9d13fd3795dbd8646d0803b422ef
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var otherPlayer = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -79,7 +79,7 @@ public class EntityMetaIntegrationTest {
+@@ -79,7 +80,7 @@ public class EntityMetaIntegrationTest {
      }
  
      @Test
@@ -3064,14 +3131,15 @@ index d4bc0029ea907166ea1e42cccc801828ad2829c9..570f9d13fd3795dbd8646d0803b422ef
          var connection = env.createConnection();
          var instance = env.createFlatInstance();
 diff --git a/src/test/java/net/minestom/server/entity/EntityMetaTest.java b/src/test/java/net/minestom/server/entity/EntityMetaTest.java
-index fec36086a4cc442ab5b41fa38139011d803d8a60..3e14287168e35f62756493a12feb6a95aea34857 100644
+index fec36086a4cc442ab5b41fa38139011d803d8a60..1cda4f35f16941307c451d7c4e5d8d51eef23096 100644
 --- a/src/test/java/net/minestom/server/entity/EntityMetaTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityMetaTest.java
-@@ -7,10 +7,10 @@ import java.util.List;
+@@ -7,10 +7,11 @@ import java.util.List;
  
  import static org.junit.jupiter.api.Assertions.assertTrue;
  
 -public class EntityMetaTest {
++//Microtus - update java keyword usage
 +class EntityMetaTest {
  
      @Test
@@ -3081,12 +3149,14 @@ index fec36086a4cc442ab5b41fa38139011d803d8a60..3e14287168e35f62756493a12feb6a95
          for (var field : EntityTypes.class.getDeclaredFields()) {
              final EntityType entityType = (EntityType) field.get(this);
 diff --git a/src/test/java/net/minestom/server/entity/EntityProjectileIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityProjectileIntegrationTest.java
-index 814257ce83dcf9228df221f877bb521980e83b8a..d5f4bf0c9e56569a8b85ec8789f0fcda7240dd53 100644
+index 814257ce83dcf9228df221f877bb521980e83b8a..6db09213abec98a4dbaf7def9b2a0604d1934201 100644
 --- a/src/test/java/net/minestom/server/entity/EntityProjectileIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityProjectileIntegrationTest.java
-@@ -8,9 +8,9 @@ import org.junit.jupiter.api.Test;
+@@ -7,10 +7,11 @@ import org.junit.jupiter.api.Test;
+ 
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class EntityProjectileIntegrationTest {
 +class EntityProjectileIntegrationTest {
@@ -3096,7 +3166,7 @@ index 814257ce83dcf9228df221f877bb521980e83b8a..d5f4bf0c9e56569a8b85ec8789f0fcda
          var instance = env.createFlatInstance();
          var shooter = new EntityCreature(EntityType.SKELETON);
          shooter.setInstance(instance, new Pos(0, 42, 0)).join();
-@@ -42,7 +42,7 @@ public class EntityProjectileIntegrationTest {
+@@ -42,7 +43,7 @@ public class EntityProjectileIntegrationTest {
      }
  
      @Test
@@ -3106,12 +3176,14 @@ index 814257ce83dcf9228df221f877bb521980e83b8a..d5f4bf0c9e56569a8b85ec8789f0fcda
          var shooter = new EntityCreature(EntityType.SKELETON);
          shooter.setInstance(instance, new Pos(0, 42, 0)).join();
 diff --git a/src/test/java/net/minestom/server/entity/EntityRemovalIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityRemovalIntegrationTest.java
-index 42d6e2f23777010d59206346d9efa5158ca70dec..35387a6cdcd97079a9e6d896e305f952c15a3a1f 100644
+index 42d6e2f23777010d59206346d9efa5158ca70dec..fd3c02404358941ef54f0bb27277b312827d0fb0 100644
 --- a/src/test/java/net/minestom/server/entity/EntityRemovalIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityRemovalIntegrationTest.java
-@@ -16,10 +16,10 @@ import static net.minestom.testing.TestUtils.waitUntilCleared;
+@@ -15,11 +15,12 @@ import java.util.List;
+ import static net.minestom.testing.TestUtils.waitUntilCleared;
  import static org.junit.jupiter.api.Assertions.*;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class EntityRemovalIntegrationTest {
 +class EntityRemovalIntegrationTest {
@@ -3122,7 +3194,7 @@ index 42d6e2f23777010d59206346d9efa5158ca70dec..35387a6cdcd97079a9e6d896e305f952
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          connection.connect(instance, new Pos(0, 40, 0)).join();
-@@ -33,7 +33,7 @@ public class EntityRemovalIntegrationTest {
+@@ -33,7 +34,7 @@ public class EntityRemovalIntegrationTest {
      }
  
      @Test
@@ -3131,7 +3203,7 @@ index 42d6e2f23777010d59206346d9efa5158ca70dec..35387a6cdcd97079a9e6d896e305f952
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityType.ZOMBIE);
          entity.setInstance(instance, new Pos(0, 40, 0)).join();
-@@ -45,7 +45,7 @@ public class EntityRemovalIntegrationTest {
+@@ -45,7 +46,7 @@ public class EntityRemovalIntegrationTest {
      }
  
      @Test
@@ -3140,7 +3212,7 @@ index 42d6e2f23777010d59206346d9efa5158ca70dec..35387a6cdcd97079a9e6d896e305f952
          var instance = env.createFlatInstance();
          var entity = new TestEntity(2, TimeUnit.SERVER_TICK);
          entity.setInstance(instance, new Pos(0, 40, 0)).join();
-@@ -65,7 +65,7 @@ public class EntityRemovalIntegrationTest {
+@@ -65,7 +66,7 @@ public class EntityRemovalIntegrationTest {
      }
  
      @Test
@@ -3149,7 +3221,7 @@ index 42d6e2f23777010d59206346d9efa5158ca70dec..35387a6cdcd97079a9e6d896e305f952
          // Ensure that entities do not stay in memory after they are removed
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityType.ZOMBIE);
-@@ -80,7 +80,7 @@ public class EntityRemovalIntegrationTest {
+@@ -80,7 +81,7 @@ public class EntityRemovalIntegrationTest {
      }
  
      @Test
@@ -3158,7 +3230,7 @@ index 42d6e2f23777010d59206346d9efa5158ca70dec..35387a6cdcd97079a9e6d896e305f952
          // Ensure that the entities GCed when a local listener is present
          var node = env.process().eventHandler();
          var entity = new Entity(EntityType.ZOMBIE);
-@@ -97,7 +97,7 @@ public class EntityRemovalIntegrationTest {
+@@ -97,7 +98,7 @@ public class EntityRemovalIntegrationTest {
      }
  
      static final class TestEntity extends Entity {
@@ -3168,12 +3240,14 @@ index 42d6e2f23777010d59206346d9efa5158ca70dec..35387a6cdcd97079a9e6d896e305f952
              scheduleRemove(delay, unit);
          }
 diff --git a/src/test/java/net/minestom/server/entity/EntityTeleportIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityTeleportIntegrationTest.java
-index 22b32a5d5275ae3aca28bce8b87975aae4bd5f32..8eea5dcf24ebffc832af63308b6d6435913732a2 100644
+index 22b32a5d5275ae3aca28bce8b87975aae4bd5f32..8ddb099db0fb0e9e0fed051ecea06d3f5daa2f62 100644
 --- a/src/test/java/net/minestom/server/entity/EntityTeleportIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityTeleportIntegrationTest.java
-@@ -11,10 +11,10 @@ import org.junit.jupiter.api.Test;
+@@ -10,11 +10,12 @@ import org.junit.jupiter.api.Test;
+ 
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class EntityTeleportIntegrationTest {
 +class EntityTeleportIntegrationTest {
@@ -3184,7 +3258,7 @@ index 22b32a5d5275ae3aca28bce8b87975aae4bd5f32..8eea5dcf24ebffc832af63308b6d6435
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityTypes.ZOMBIE);
          entity.setInstance(instance, new Pos(0, 42, 0)).join();
-@@ -26,7 +26,7 @@ public class EntityTeleportIntegrationTest {
+@@ -26,7 +27,7 @@ public class EntityTeleportIntegrationTest {
      }
  
      @Test
@@ -3193,7 +3267,7 @@ index 22b32a5d5275ae3aca28bce8b87975aae4bd5f32..8eea5dcf24ebffc832af63308b6d6435
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityTypes.ZOMBIE);
          entity.setInstance(instance, new Pos(0, 42, 0)).join();
-@@ -38,7 +38,7 @@ public class EntityTeleportIntegrationTest {
+@@ -38,7 +39,7 @@ public class EntityTeleportIntegrationTest {
      }
  
      @Test
@@ -3202,7 +3276,7 @@ index 22b32a5d5275ae3aca28bce8b87975aae4bd5f32..8eea5dcf24ebffc832af63308b6d6435
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 40, 0)).join();
-@@ -65,7 +65,7 @@ public class EntityTeleportIntegrationTest {
+@@ -65,7 +66,7 @@ public class EntityTeleportIntegrationTest {
      }
  
      @Test
@@ -3212,12 +3286,14 @@ index 22b32a5d5275ae3aca28bce8b87975aae4bd5f32..8eea5dcf24ebffc832af63308b6d6435
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 40, 0)).join();
 diff --git a/src/test/java/net/minestom/server/entity/EntityVelocityIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityVelocityIntegrationTest.java
-index 2ee0bd4296cd18e9a0c243cf5606ab6ced6f81cb..b417ccc6e678d5233e5c2caf8b4c364793f2100d 100644
+index 2ee0bd4296cd18e9a0c243cf5606ab6ced6f81cb..6165e4aa6fd7a744a00375f128acf435224ef901 100644
 --- a/src/test/java/net/minestom/server/entity/EntityVelocityIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityVelocityIntegrationTest.java
-@@ -15,9 +15,9 @@ import java.util.function.BooleanSupplier;
+@@ -14,10 +14,11 @@ import java.util.function.BooleanSupplier;
+ 
  import static org.junit.jupiter.api.Assertions.*;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class EntityVelocityIntegrationTest {
 +class EntityVelocityIntegrationTest {
@@ -3227,7 +3303,7 @@ index 2ee0bd4296cd18e9a0c243cf5606ab6ced6f81cb..b417ccc6e678d5233e5c2caf8b4c3647
          var instance = env.createFlatInstance();
          loadChunks(instance);
  
-@@ -36,7 +36,7 @@ public class EntityVelocityIntegrationTest {
+@@ -36,7 +37,7 @@ public class EntityVelocityIntegrationTest {
      }
  
      @Test
@@ -3236,7 +3312,7 @@ index 2ee0bd4296cd18e9a0c243cf5606ab6ced6f81cb..b417ccc6e678d5233e5c2caf8b4c3647
          var instance = env.createFlatInstance();
          loadChunks(instance);
  
-@@ -67,7 +67,7 @@ public class EntityVelocityIntegrationTest {
+@@ -67,7 +68,7 @@ public class EntityVelocityIntegrationTest {
      }
  
      @Test
@@ -3245,7 +3321,7 @@ index 2ee0bd4296cd18e9a0c243cf5606ab6ced6f81cb..b417ccc6e678d5233e5c2caf8b4c3647
          var instance = env.createFlatInstance();
          loadChunks(instance);
  
-@@ -102,7 +102,7 @@ public class EntityVelocityIntegrationTest {
+@@ -102,7 +103,7 @@ public class EntityVelocityIntegrationTest {
      }
  
      @Test
@@ -3254,7 +3330,7 @@ index 2ee0bd4296cd18e9a0c243cf5606ab6ced6f81cb..b417ccc6e678d5233e5c2caf8b4c3647
          var instance = env.createFlatInstance();
          loadChunks(instance);
  
-@@ -127,7 +127,7 @@ public class EntityVelocityIntegrationTest {
+@@ -127,7 +128,7 @@ public class EntityVelocityIntegrationTest {
      }
  
      @Test
@@ -3263,7 +3339,7 @@ index 2ee0bd4296cd18e9a0c243cf5606ab6ced6f81cb..b417ccc6e678d5233e5c2caf8b4c3647
          // Player movement should not send velocity packets as already client predicted
          var instance = env.createFlatInstance();
          var player = env.createPlayer(instance, new Pos(0, 42, 0));
-@@ -141,7 +141,7 @@ public class EntityVelocityIntegrationTest {
+@@ -141,7 +142,7 @@ public class EntityVelocityIntegrationTest {
      }
  
      @Test
@@ -3272,7 +3348,7 @@ index 2ee0bd4296cd18e9a0c243cf5606ab6ced6f81cb..b417ccc6e678d5233e5c2caf8b4c3647
          var instance = env.createFlatInstance();
          loadChunks(instance);
  
-@@ -164,7 +164,7 @@ public class EntityVelocityIntegrationTest {
+@@ -164,7 +165,7 @@ public class EntityVelocityIntegrationTest {
      }
  
      @Test
@@ -3282,12 +3358,14 @@ index 2ee0bd4296cd18e9a0c243cf5606ab6ced6f81cb..b417ccc6e678d5233e5c2caf8b4c3647
  
          var instance = env.createFlatInstance();
 diff --git a/src/test/java/net/minestom/server/entity/EntityViewDirectionIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityViewDirectionIntegrationTest.java
-index 00d15fb47f66a452336339b59833c10bf2c03674..5ba3cb257207b4cf630ee3c24fb54f80c85a85d6 100644
+index 00d15fb47f66a452336339b59833c10bf2c03674..aea8f80657d2df38db6f1a30a5b2aa743716f4bf 100644
 --- a/src/test/java/net/minestom/server/entity/EntityViewDirectionIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityViewDirectionIntegrationTest.java
-@@ -9,11 +9,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -8,12 +8,13 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertTrue;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class EntityViewDirectionIntegrationTest {
 +class EntityViewDirectionIntegrationTest {
@@ -3299,7 +3377,7 @@ index 00d15fb47f66a452336339b59833c10bf2c03674..5ba3cb257207b4cf630ee3c24fb54f80
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityType.ZOMBIE);
          entity.setInstance(instance, new Pos(0, 40, 0)).join();
-@@ -48,7 +48,7 @@ public class EntityViewDirectionIntegrationTest {
+@@ -48,7 +49,7 @@ public class EntityViewDirectionIntegrationTest {
      }
  
      @Test
@@ -3308,7 +3386,7 @@ index 00d15fb47f66a452336339b59833c10bf2c03674..5ba3cb257207b4cf630ee3c24fb54f80
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityType.ZOMBIE);
          double eyeHeight = entity.getEyeHeight(); // adding this to some position Y coordinates, to look horizontally
-@@ -87,7 +87,7 @@ public class EntityViewDirectionIntegrationTest {
+@@ -87,7 +88,7 @@ public class EntityViewDirectionIntegrationTest {
      }
  
      @Test
@@ -3317,7 +3395,7 @@ index 00d15fb47f66a452336339b59833c10bf2c03674..5ba3cb257207b4cf630ee3c24fb54f80
          var instance = env.createFlatInstance();
          // same type, same eye height
          var e1 = new Entity(EntityType.ZOMBIE);
-@@ -121,7 +121,7 @@ public class EntityViewDirectionIntegrationTest {
+@@ -121,7 +122,7 @@ public class EntityViewDirectionIntegrationTest {
      }
  
      @Test
@@ -3327,12 +3405,14 @@ index 00d15fb47f66a452336339b59833c10bf2c03674..5ba3cb257207b4cf630ee3c24fb54f80
          // same type, same eye height
          var e1 = new Entity(EntityType.ZOMBIE);
 diff --git a/src/test/java/net/minestom/server/entity/EntityViewIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityViewIntegrationTest.java
-index 181b303252adccd24255baaa9a76ca18dc297d9b..b87d2081c413b2693f65b3d6b93814574ef377e7 100644
+index 181b303252adccd24255baaa9a76ca18dc297d9b..09ab9a26753e2e84b3f52cd8e1f4da6ac7c64ed5 100644
 --- a/src/test/java/net/minestom/server/entity/EntityViewIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityViewIntegrationTest.java
-@@ -9,10 +9,10 @@ import org.junit.jupiter.api.Test;
+@@ -8,11 +8,12 @@ import org.junit.jupiter.api.Test;
+ 
  import static org.junit.jupiter.api.Assertions.*;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class EntityViewIntegrationTest {
 +class EntityViewIntegrationTest {
@@ -3343,7 +3423,7 @@ index 181b303252adccd24255baaa9a76ca18dc297d9b..b87d2081c413b2693f65b3d6b9381457
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityType.ZOMBIE);
          entity.setInstance(instance, new Pos(0, 40, 42)).join();
-@@ -20,14 +20,14 @@ public class EntityViewIntegrationTest {
+@@ -20,14 +21,14 @@ public class EntityViewIntegrationTest {
      }
  
      @Test
@@ -3360,7 +3440,7 @@ index 181b303252adccd24255baaa9a76ca18dc297d9b..b87d2081c413b2693f65b3d6b9381457
          var instance = env.createFlatInstance();
          var p1 = env.createPlayer(instance, new Pos(0, 42, 42));
          var p2 = env.createPlayer(instance, new Pos(0, 42, 42));
-@@ -48,7 +48,7 @@ public class EntityViewIntegrationTest {
+@@ -48,7 +49,7 @@ public class EntityViewIntegrationTest {
      }
  
      @Test
@@ -3369,7 +3449,7 @@ index 181b303252adccd24255baaa9a76ca18dc297d9b..b87d2081c413b2693f65b3d6b9381457
          var instance = env.createFlatInstance();
          var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
          var p2 = env.createPlayer(instance, new Pos(0, 42, 5_000));
-@@ -65,7 +65,7 @@ public class EntityViewIntegrationTest {
+@@ -65,7 +66,7 @@ public class EntityViewIntegrationTest {
      }
  
      @Test
@@ -3378,7 +3458,7 @@ index 181b303252adccd24255baaa9a76ca18dc297d9b..b87d2081c413b2693f65b3d6b9381457
          var instance = env.createFlatInstance();
          var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
          var p2 = env.createPlayer(instance, new Pos(0, 42, 96));
-@@ -79,7 +79,7 @@ public class EntityViewIntegrationTest {
+@@ -79,7 +80,7 @@ public class EntityViewIntegrationTest {
      }
  
      @Test
@@ -3387,7 +3467,7 @@ index 181b303252adccd24255baaa9a76ca18dc297d9b..b87d2081c413b2693f65b3d6b9381457
          var instance = env.createFlatInstance();
          var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
          assertTrue(p1.isAutoViewable());
-@@ -96,7 +96,7 @@ public class EntityViewIntegrationTest {
+@@ -96,7 +97,7 @@ public class EntityViewIntegrationTest {
      }
  
      @Test
@@ -3396,7 +3476,7 @@ index 181b303252adccd24255baaa9a76ca18dc297d9b..b87d2081c413b2693f65b3d6b9381457
          var instance = env.createFlatInstance();
          var p = env.createPlayer(instance, new Pos(0, 42, 0));
          assertTrue(p.hasPredictableViewers());
-@@ -123,7 +123,7 @@ public class EntityViewIntegrationTest {
+@@ -123,7 +124,7 @@ public class EntityViewIntegrationTest {
      }
  
      @Test
@@ -3405,7 +3485,7 @@ index 181b303252adccd24255baaa9a76ca18dc297d9b..b87d2081c413b2693f65b3d6b9381457
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 40, 0)).join();
-@@ -153,7 +153,7 @@ public class EntityViewIntegrationTest {
+@@ -153,7 +154,7 @@ public class EntityViewIntegrationTest {
      }
  
      @Test
@@ -3415,12 +3495,14 @@ index 181b303252adccd24255baaa9a76ca18dc297d9b..b87d2081c413b2693f65b3d6b9381457
          var p1 = env.createPlayer(instance, new Pos(0, 40, 0));
          var p2 = env.createPlayer(instance, new Pos(0, 40, 0));
 diff --git a/src/test/java/net/minestom/server/entity/EntityViewerRuleIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityViewerRuleIntegrationTest.java
-index 40038cf6f257e058e79ffb8eacdcf96ca1e61685..6074de4b7fc26017f615bf08503dd01055ee1e39 100644
+index 40038cf6f257e058e79ffb8eacdcf96ca1e61685..cb27e3537db1ee1bcc2a8997746727931451be74 100644
 --- a/src/test/java/net/minestom/server/entity/EntityViewerRuleIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityViewerRuleIntegrationTest.java
-@@ -10,10 +10,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
+@@ -9,11 +9,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
+ 
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class EntityViewerRuleIntegrationTest {
 +class EntityViewerRuleIntegrationTest {
@@ -3431,7 +3513,7 @@ index 40038cf6f257e058e79ffb8eacdcf96ca1e61685..6074de4b7fc26017f615bf08503dd010
          var instance = env.createFlatInstance();
          var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
          p1.updateViewableRule(p -> p.getEntityId() == p1.getEntityId() + 1);
-@@ -30,7 +30,7 @@ public class EntityViewerRuleIntegrationTest {
+@@ -30,7 +31,7 @@ public class EntityViewerRuleIntegrationTest {
      }
  
      @Test
@@ -3440,7 +3522,7 @@ index 40038cf6f257e058e79ffb8eacdcf96ca1e61685..6074de4b7fc26017f615bf08503dd010
          var instance = env.createFlatInstance();
          var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
  
-@@ -48,7 +48,7 @@ public class EntityViewerRuleIntegrationTest {
+@@ -48,7 +49,7 @@ public class EntityViewerRuleIntegrationTest {
      }
  
      @Test
@@ -3449,7 +3531,7 @@ index 40038cf6f257e058e79ffb8eacdcf96ca1e61685..6074de4b7fc26017f615bf08503dd010
          var instance = env.createFlatInstance();
          var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
          var p2 = env.createPlayer(instance, new Pos(0, 42, 0));
-@@ -80,7 +80,7 @@ public class EntityViewerRuleIntegrationTest {
+@@ -80,7 +81,7 @@ public class EntityViewerRuleIntegrationTest {
      }
  
      @Test
@@ -3458,7 +3540,7 @@ index 40038cf6f257e058e79ffb8eacdcf96ca1e61685..6074de4b7fc26017f615bf08503dd010
          var instance = env.createFlatInstance();
          var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
          p1.updateViewerRule(e -> e.getEntityId() == p1.getEntityId() + 1);
-@@ -97,7 +97,7 @@ public class EntityViewerRuleIntegrationTest {
+@@ -97,7 +98,7 @@ public class EntityViewerRuleIntegrationTest {
      }
  
      @Test
@@ -3467,7 +3549,7 @@ index 40038cf6f257e058e79ffb8eacdcf96ca1e61685..6074de4b7fc26017f615bf08503dd010
          var instance = env.createFlatInstance();
          var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
          AtomicBoolean enabled = new AtomicBoolean(false);
-@@ -114,7 +114,7 @@ public class EntityViewerRuleIntegrationTest {
+@@ -114,7 +115,7 @@ public class EntityViewerRuleIntegrationTest {
      }
  
      @Test
@@ -3477,14 +3559,15 @@ index 40038cf6f257e058e79ffb8eacdcf96ca1e61685..6074de4b7fc26017f615bf08503dd010
          var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
          var p2 = env.createPlayer(instance, new Pos(0, 42, 0));
 diff --git a/src/test/java/net/minestom/server/entity/GameModeTest.java b/src/test/java/net/minestom/server/entity/GameModeTest.java
-index 2d7ea85dd0764cf052efa3ced47bab698c6c3aa4..f249cac8065fe61c163c03573b1ad2430bd4c262 100644
+index 2d7ea85dd0764cf052efa3ced47bab698c6c3aa4..1a24ecb4bb56306581cdccfb8c3107db9c3da247 100644
 --- a/src/test/java/net/minestom/server/entity/GameModeTest.java
 +++ b/src/test/java/net/minestom/server/entity/GameModeTest.java
-@@ -4,18 +4,18 @@ import org.junit.jupiter.api.Test;
+@@ -4,18 +4,19 @@ import org.junit.jupiter.api.Test;
  
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
 -public class GameModeTest {
++//Microtus - update java keyword usage
 +class GameModeTest {
  
      @Test
@@ -3507,12 +3590,14 @@ index 2d7ea85dd0764cf052efa3ced47bab698c6c3aa4..f249cac8065fe61c163c03573b1ad243
          assertEquals(GameMode.CREATIVE, GameMode.fromId(1));
          assertEquals(GameMode.ADVENTURE, GameMode.fromId(2));
 diff --git a/src/test/java/net/minestom/server/entity/PassengerIntegrationTest.java b/src/test/java/net/minestom/server/entity/PassengerIntegrationTest.java
-index 2b9402f1cbf337d38d1cc0d6ae5a68d91050b173..012ac45c68a090b8ca18b7181490313ead8d99f3 100644
+index 2b9402f1cbf337d38d1cc0d6ae5a68d91050b173..6c2c2346ba3dba836cafb28b699b3b9898dbeaa2 100644
 --- a/src/test/java/net/minestom/server/entity/PassengerIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/PassengerIntegrationTest.java
-@@ -8,10 +8,10 @@ import org.junit.jupiter.api.Test;
+@@ -7,11 +7,12 @@ import org.junit.jupiter.api.Test;
+ 
  import static org.junit.jupiter.api.Assertions.*;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class PassengerIntegrationTest {
 +class PassengerIntegrationTest {
@@ -3523,7 +3608,7 @@ index 2b9402f1cbf337d38d1cc0d6ae5a68d91050b173..012ac45c68a090b8ca18b7181490313e
          var instance = env.createFlatInstance();
          var vehicle = new Entity(EntityType.ZOMBIE);
          var passenger = new Entity(EntityType.ZOMBIE);
-@@ -28,7 +28,7 @@ public class PassengerIntegrationTest {
+@@ -28,7 +29,7 @@ public class PassengerIntegrationTest {
      }
  
      @Test
@@ -3533,12 +3618,14 @@ index 2b9402f1cbf337d38d1cc0d6ae5a68d91050b173..012ac45c68a090b8ca18b7181490313e
          var vehicle = new Entity(EntityType.ZOMBIE);
          var passenger = new Entity(EntityType.ZOMBIE);
 diff --git a/src/test/java/net/minestom/server/entity/PlayerHeldIntegrationTest.java b/src/test/java/net/minestom/server/entity/PlayerHeldIntegrationTest.java
-index efd06b005614c0bc67ed985fa56988139e714f93..feccdb951f27d6e46fe8aa4f18ded7a0d3949d21 100644
+index efd06b005614c0bc67ed985fa56988139e714f93..dd2e87aa63831d46913518a1b5695ab8175396ee 100644
 --- a/src/test/java/net/minestom/server/entity/PlayerHeldIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/PlayerHeldIntegrationTest.java
-@@ -12,10 +12,10 @@ import org.junit.jupiter.api.Test;
+@@ -11,11 +11,12 @@ import org.junit.jupiter.api.Test;
+ 
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class PlayerHeldIntegrationTest {
 +class PlayerHeldIntegrationTest {
@@ -3549,7 +3636,7 @@ index efd06b005614c0bc67ed985fa56988139e714f93..feccdb951f27d6e46fe8aa4f18ded7a0
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 40, 0)).join();
-@@ -32,7 +32,7 @@ public class PlayerHeldIntegrationTest {
+@@ -32,7 +33,7 @@ public class PlayerHeldIntegrationTest {
      }
  
      @Test
@@ -3559,14 +3646,15 @@ index efd06b005614c0bc67ed985fa56988139e714f93..feccdb951f27d6e46fe8aa4f18ded7a0
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 40, 0)).join();
 diff --git a/src/test/java/net/minestom/server/entity/PlayerSkinTest.java b/src/test/java/net/minestom/server/entity/PlayerSkinTest.java
-index 771bdca2a59bc50d53578fe7a5abe4169f2dae07..4f8e547d6a00099f8e6b5fe03dd6aee6b79a8ce3 100644
+index 771bdca2a59bc50d53578fe7a5abe4169f2dae07..119351b2d61a4c8f3201d8e9a377afeb3b95ee45 100644
 --- a/src/test/java/net/minestom/server/entity/PlayerSkinTest.java
 +++ b/src/test/java/net/minestom/server/entity/PlayerSkinTest.java
-@@ -5,16 +5,16 @@ import org.junit.jupiter.api.Test;
+@@ -5,16 +5,17 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.assertNotNull;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
 -public class PlayerSkinTest {
++//Microtus - update java keyword usage
 +class PlayerSkinTest {
  
      @Test
@@ -3583,12 +3671,14 @@ index 771bdca2a59bc50d53578fe7a5abe4169f2dae07..4f8e547d6a00099f8e6b5fe03dd6aee6
          assertNull(skin);
      }
 diff --git a/src/test/java/net/minestom/server/entity/ai/ClosestEntityTargetTest.java b/src/test/java/net/minestom/server/entity/ai/ClosestEntityTargetTest.java
-index 5c34c621e1bf3d9a9ec07b927ca8473f05278846..25d78311447f9236c78ae319899c295f9b7e2225 100644
+index 5c34c621e1bf3d9a9ec07b927ca8473f05278846..20472444bcc6381f2ab24a21d85b5356c2db694d 100644
 --- a/src/test/java/net/minestom/server/entity/ai/ClosestEntityTargetTest.java
 +++ b/src/test/java/net/minestom/server/entity/ai/ClosestEntityTargetTest.java
-@@ -12,10 +12,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -11,11 +11,12 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class ClosestEntityTargetTest {
 +class ClosestEntityTargetTest {
@@ -3600,12 +3690,14 @@ index 5c34c621e1bf3d9a9ec07b927ca8473f05278846..25d78311447f9236c78ae319899c295f
  
          var self = new EntityCreature(EntityType.ZOMBIE);
 diff --git a/src/test/java/net/minestom/server/entity/player/PlayerBlockPlacementIntegrationTest.java b/src/test/java/net/minestom/server/entity/player/PlayerBlockPlacementIntegrationTest.java
-index c2bf3603d30cfc95e5d4aa5a9669cb08dca218c6..0566d0edc971797d11df73af3772b504072545da 100644
+index c2bf3603d30cfc95e5d4aa5a9669cb08dca218c6..8163cc3553bfced069142fae010fba20abf58936 100644
 --- a/src/test/java/net/minestom/server/entity/player/PlayerBlockPlacementIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/player/PlayerBlockPlacementIntegrationTest.java
-@@ -19,11 +19,11 @@ import java.util.stream.Stream;
+@@ -18,12 +18,13 @@ import java.util.stream.Stream;
+ 
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class PlayerBlockPlacementIntegrationTest {
 +class PlayerBlockPlacementIntegrationTest {
@@ -3618,12 +3710,14 @@ index c2bf3603d30cfc95e5d4aa5a9669cb08dca218c6..0566d0edc971797d11df73af3772b504
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
 diff --git a/src/test/java/net/minestom/server/entity/player/PlayerIntegrationTest.java b/src/test/java/net/minestom/server/entity/player/PlayerIntegrationTest.java
-index b36bec3de3026ca3e1b8f7217c05407da073dfe7..8d7be19dd4d72044a99a01af4190fd2c1b5d7937 100644
+index b36bec3de3026ca3e1b8f7217c05407da073dfe7..95e615078525cfa66e7bbde9f9a9397ea80b913c 100644
 --- a/src/test/java/net/minestom/server/entity/player/PlayerIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/player/PlayerIntegrationTest.java
-@@ -23,13 +23,13 @@ import java.util.List;
+@@ -22,14 +22,15 @@ import java.util.List;
+ 
  import static org.junit.jupiter.api.Assertions.*;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class PlayerIntegrationTest {
 +class PlayerIntegrationTest {
@@ -3637,7 +3731,7 @@ index b36bec3de3026ca3e1b8f7217c05407da073dfe7..8d7be19dd4d72044a99a01af4190fd2c
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -72,7 +72,7 @@ public class PlayerIntegrationTest {
+@@ -72,7 +73,7 @@ public class PlayerIntegrationTest {
      }
  
      @Test
@@ -3646,7 +3740,7 @@ index b36bec3de3026ca3e1b8f7217c05407da073dfe7..8d7be19dd4d72044a99a01af4190fd2c
          ClientSettingsPacket packet = new ClientSettingsPacket("en_us", (byte) 16, ChatMessageType.FULL,
                  true, (byte) 127, Player.MainHand.LEFT, true, true);
  
-@@ -110,7 +110,7 @@ public class PlayerIntegrationTest {
+@@ -110,7 +111,7 @@ public class PlayerIntegrationTest {
      }
  
      @Test
@@ -3655,7 +3749,7 @@ index b36bec3de3026ca3e1b8f7217c05407da073dfe7..8d7be19dd4d72044a99a01af4190fd2c
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
  
-@@ -141,7 +141,7 @@ public class PlayerIntegrationTest {
+@@ -141,7 +142,7 @@ public class PlayerIntegrationTest {
       * when changing dimensions
       */
      @Test
@@ -3664,7 +3758,7 @@ index b36bec3de3026ca3e1b8f7217c05407da073dfe7..8d7be19dd4d72044a99a01af4190fd2c
          final int TEST_PERMISSION_LEVEL = 2;
          final var testDimension = DimensionType.builder(NamespaceID.from("minestom:test_dimension")).build();
          env.process().dimension().addDimension(testDimension);
-@@ -177,7 +177,7 @@ public class PlayerIntegrationTest {
+@@ -177,7 +178,7 @@ public class PlayerIntegrationTest {
      }
  
      @Test
@@ -3673,7 +3767,7 @@ index b36bec3de3026ca3e1b8f7217c05407da073dfe7..8d7be19dd4d72044a99a01af4190fd2c
          String dimensionNamespace = "minestom:test_dimension";
          final var testDimension = DimensionType.builder(NamespaceID.from(dimensionNamespace)).build();
          env.process().dimension().addDimension(testDimension);
-@@ -195,7 +195,7 @@ public class PlayerIntegrationTest {
+@@ -195,7 +196,7 @@ public class PlayerIntegrationTest {
      }
      // Microtus start - Fix team spam
      @Test
@@ -3682,7 +3776,7 @@ index b36bec3de3026ca3e1b8f7217c05407da073dfe7..8d7be19dd4d72044a99a01af4190fd2c
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var tracker = connection.trackIncoming(PlayerInfoUpdatePacket.class);
-@@ -228,7 +228,7 @@ public class PlayerIntegrationTest {
+@@ -228,7 +229,7 @@ public class PlayerIntegrationTest {
      }
  
      @Test
@@ -3692,12 +3786,14 @@ index b36bec3de3026ca3e1b8f7217c05407da073dfe7..8d7be19dd4d72044a99a01af4190fd2c
  
          var instance = env.createFlatInstance();
 diff --git a/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java b/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
-index 30e9977964d9d0e9732f3b6216cf1c839f7bc63c..1bd8b09c6c8f5c8ae02d398b6d44f88b6f491418 100644
+index 30e9977964d9d0e9732f3b6216cf1c839f7bc63c..ea7683856f2008e979e7f06107a81e2d7eb12782 100644
 --- a/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
-@@ -26,10 +26,10 @@ import java.util.concurrent.CompletableFuture;
+@@ -25,11 +25,12 @@ import java.util.concurrent.CompletableFuture;
+ 
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class PlayerMovementIntegrationTest {
 +class PlayerMovementIntegrationTest {
@@ -3708,7 +3804,7 @@ index 30e9977964d9d0e9732f3b6216cf1c839f7bc63c..1bd8b09c6c8f5c8ae02d398b6d44f88b
          var instance = env.createFlatInstance();
          var p1 = env.createPlayer(instance, new Pos(0, 40, 0));
          // No confirmation
-@@ -45,7 +45,7 @@ public class PlayerMovementIntegrationTest {
+@@ -45,7 +46,7 @@ public class PlayerMovementIntegrationTest {
  
      // FIXME
      //@Test
@@ -3717,7 +3813,7 @@ index 30e9977964d9d0e9732f3b6216cf1c839f7bc63c..1bd8b09c6c8f5c8ae02d398b6d44f88b
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var p1 = env.createPlayer(instance, new Pos(0, 40, 0));
-@@ -62,7 +62,7 @@ public class PlayerMovementIntegrationTest {
+@@ -62,7 +63,7 @@ public class PlayerMovementIntegrationTest {
      }
  
      @Test
@@ -3727,12 +3823,15 @@ index 30e9977964d9d0e9732f3b6216cf1c839f7bc63c..1bd8b09c6c8f5c8ae02d398b6d44f88b
          final int viewDiameter = MinecraftServer.getChunkViewDistance() * 2 + 1;
          // Preload all possible chunks to avoid issues due to async loading
 diff --git a/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkIntegrationTest.java b/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkIntegrationTest.java
-index 1dac5752d654cf22dc83d02c396dcb2c9be904e7..a4960aa5e69c4fffbe6edb12cae7fb25766a4eec 100644
+index 1dac5752d654cf22dc83d02c396dcb2c9be904e7..9015a9c37934faeeae0f42f13b910fc4773f83f7 100644
 --- a/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkIntegrationTest.java
-@@ -19,10 +19,10 @@ import static org.junit.jupiter.api.Assertions.*;
+@@ -17,12 +17,12 @@ import java.util.Set;
  
+ import static org.junit.jupiter.api.Assertions.*;
  
+-
++//Microtus - update java keyword usage
  @EnvTest
 -public class PlayerRespawnChunkIntegrationTest {
 +class PlayerRespawnChunkIntegrationTest {
@@ -3762,14 +3861,15 @@ index 1dac5752d654cf22dc83d02c396dcb2c9be904e7..a4960aa5e69c4fffbe6edb12cae7fb25
          var connection = env.createConnection();
          Player player = connection.connect(instance, new Pos(0, 40, 0)).join();
 diff --git a/src/test/java/net/minestom/server/event/EventNodeGraphTest.java b/src/test/java/net/minestom/server/event/EventNodeGraphTest.java
-index c9f650b9eca9c9ad35ccc15d61e9e4e67cd48fb4..37d8007440767e211697478d2b0cba92cf038772 100644
+index c9f650b9eca9c9ad35ccc15d61e9e4e67cd48fb4..90c5b5e8554116354d4d388d1c7c3d0d2451ec75 100644
 --- a/src/test/java/net/minestom/server/event/EventNodeGraphTest.java
 +++ b/src/test/java/net/minestom/server/event/EventNodeGraphTest.java
-@@ -6,16 +6,16 @@ import java.util.List;
+@@ -6,16 +6,17 @@ import java.util.List;
  
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
 -public class EventNodeGraphTest {
++//Microtus - update java keyword usage
 +class EventNodeGraphTest {
  
      @Test
@@ -3785,7 +3885,7 @@ index c9f650b9eca9c9ad35ccc15d61e9e4e67cd48fb4..37d8007440767e211697478d2b0cba92
          EventNode<Event> node = EventNode.all("main");
          node.addChild(EventNode.all("child"));
          verifyGraph(node, new EventNodeImpl.Graph("main", "Event", 0,
-@@ -24,7 +24,7 @@ public class EventNodeGraphTest {
+@@ -24,7 +25,7 @@ public class EventNodeGraphTest {
      }
  
      @Test
@@ -3795,11 +3895,16 @@ index c9f650b9eca9c9ad35ccc15d61e9e4e67cd48fb4..37d8007440767e211697478d2b0cba92
              EventNode<Event> node = EventNode.all("main");
              node.addChild(EventNode.all("child1").setPriority(5));
 diff --git a/src/test/java/net/minestom/server/event/EventNodeMapTest.java b/src/test/java/net/minestom/server/event/EventNodeMapTest.java
-index e803aa3e5319ba2abadd916b8e96781fc9734ed8..e14d519581c09110a5248e74c9f6a2d5dfaf8455 100644
+index e803aa3e5319ba2abadd916b8e96781fc9734ed8..fa625e3d6f5426f5c29338ee00e6cc5da1ceaabe 100644
 --- a/src/test/java/net/minestom/server/event/EventNodeMapTest.java
 +++ b/src/test/java/net/minestom/server/event/EventNodeMapTest.java
-@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.*;
- public class EventNodeMapTest {
+@@ -13,10 +13,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
+ import static net.minestom.testing.TestUtils.waitUntilCleared;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class EventNodeMapTest {
++//Microtus - update java keyword usage
++class EventNodeMapTest {
  
      @Test
 -    public void uniqueMapping() {
@@ -3807,7 +3912,7 @@ index e803aa3e5319ba2abadd916b8e96781fc9734ed8..e14d519581c09110a5248e74c9f6a2d5
          var item = ItemStack.of(Material.DIAMOND);
          var node = EventNode.all("main");
          var itemNode1 = node.map(item, EventFilter.ITEM);
-@@ -31,7 +31,7 @@ public class EventNodeMapTest {
+@@ -31,7 +32,7 @@ public class EventNodeMapTest {
      }
  
      @Test
@@ -3816,7 +3921,7 @@ index e803aa3e5319ba2abadd916b8e96781fc9734ed8..e14d519581c09110a5248e74c9f6a2d5
          var item = ItemStack.of(Material.DIAMOND);
          var node = (EventNodeImpl<Event>) EventNode.all("main");
          var itemNode = node.map(item, EventFilter.ITEM);
-@@ -42,7 +42,7 @@ public class EventNodeMapTest {
+@@ -42,7 +43,7 @@ public class EventNodeMapTest {
      }
  
      @Test
@@ -3825,7 +3930,7 @@ index e803aa3e5319ba2abadd916b8e96781fc9734ed8..e14d519581c09110a5248e74c9f6a2d5
          var item = ItemStack.of(Material.DIAMOND);
          var node = (EventNodeImpl<Event>) EventNode.all("main");
          var itemNode = node.map(item, EventFilter.ITEM);
-@@ -51,7 +51,7 @@ public class EventNodeMapTest {
+@@ -51,7 +52,7 @@ public class EventNodeMapTest {
      }
  
      @Test
@@ -3834,7 +3939,7 @@ index e803aa3e5319ba2abadd916b8e96781fc9734ed8..e14d519581c09110a5248e74c9f6a2d5
          var item = ItemStack.of(Material.DIAMOND);
          var node = EventNode.all("main");
  
-@@ -76,7 +76,7 @@ public class EventNodeMapTest {
+@@ -76,7 +77,7 @@ public class EventNodeMapTest {
      }
  
      @Test
@@ -3843,7 +3948,7 @@ index e803aa3e5319ba2abadd916b8e96781fc9734ed8..e14d519581c09110a5248e74c9f6a2d5
          var process = MinecraftServer.updateProcess();
          var node = process.eventHandler();
          var entity = new Entity(EntityType.ZOMBIE);
-@@ -102,7 +102,7 @@ public class EventNodeMapTest {
+@@ -102,7 +103,7 @@ public class EventNodeMapTest {
      }
  
      @Test
@@ -3853,14 +3958,15 @@ index e803aa3e5319ba2abadd916b8e96781fc9734ed8..e14d519581c09110a5248e74c9f6a2d5
          var item = ItemStack.of(Material.DIAMOND);
          var node = EventNode.all("main");
 diff --git a/src/test/java/net/minestom/server/event/EventNodeQueryTest.java b/src/test/java/net/minestom/server/event/EventNodeQueryTest.java
-index 9e035b0f764ee8e90cf8769edda1e87fc69af81d..fd481a2b8ff53cb174c788ac95dc071fa87ae6af 100644
+index 9e035b0f764ee8e90cf8769edda1e87fc69af81d..ddb1d863679bd1de990e6135c2339f5d9656d6d1 100644
 --- a/src/test/java/net/minestom/server/event/EventNodeQueryTest.java
 +++ b/src/test/java/net/minestom/server/event/EventNodeQueryTest.java
-@@ -9,10 +9,10 @@ import java.util.List;
+@@ -9,10 +9,11 @@ import java.util.List;
  import static net.minestom.testing.TestUtils.assertEqualsIgnoreOrder;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
 -public class EventNodeQueryTest {
++//Microtus - update java keyword usage
 +class EventNodeQueryTest {
  
      @Test
@@ -3869,7 +3975,7 @@ index 9e035b0f764ee8e90cf8769edda1e87fc69af81d..fd481a2b8ff53cb174c788ac95dc071f
          var node = EventNode.all("main");
          assertEquals(List.of(), node.findChildren("test"));
  
-@@ -33,7 +33,7 @@ public class EventNodeQueryTest {
+@@ -33,7 +34,7 @@ public class EventNodeQueryTest {
      }
  
      @Test
@@ -3878,7 +3984,7 @@ index 9e035b0f764ee8e90cf8769edda1e87fc69af81d..fd481a2b8ff53cb174c788ac95dc071f
          var node = EventNode.all("main");
          assertEquals(List.of(), node.findChildren("test", Event.class));
  
-@@ -58,7 +58,7 @@ public class EventNodeQueryTest {
+@@ -58,7 +59,7 @@ public class EventNodeQueryTest {
      }
  
      @Test
@@ -3888,19 +3994,20 @@ index 9e035b0f764ee8e90cf8769edda1e87fc69af81d..fd481a2b8ff53cb174c788ac95dc071f
  
          var child1 = EventNode.all("test");
 diff --git a/src/test/java/net/minestom/server/event/EventNodeTest.java b/src/test/java/net/minestom/server/event/EventNodeTest.java
-index 114033a08a7d9acebfd67ce535afe9e39a08262a..b1e46999c543fce8efabf4f38e3e655c5a153ef5 100644
+index 114033a08a7d9acebfd67ce535afe9e39a08262a..00f9328ff288af41c0841805b760b3856eef2239 100644
 --- a/src/test/java/net/minestom/server/event/EventNodeTest.java
 +++ b/src/test/java/net/minestom/server/event/EventNodeTest.java
-@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
+@@ -17,7 +17,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  import static net.minestom.testing.TestUtils.waitUntilCleared;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class EventNodeTest {
++//Microtus - update java keyword usage
 +class EventNodeTest {
  
      static class EventTest implements Event {
      }
-@@ -57,7 +57,7 @@ public class EventNodeTest {
+@@ -57,7 +58,7 @@ public class EventNodeTest {
      }
  
      @Test
@@ -3909,7 +4016,7 @@ index 114033a08a7d9acebfd67ce535afe9e39a08262a..b1e46999c543fce8efabf4f38e3e655c
          var node = EventNode.all("main");
          AtomicBoolean result = new AtomicBoolean(false);
          var listener = EventListener.of(EventTest.class, eventTest -> result.set(true));
-@@ -74,7 +74,7 @@ public class EventNodeTest {
+@@ -74,7 +75,7 @@ public class EventNodeTest {
      }
  
      @Test
@@ -3918,7 +4025,7 @@ index 114033a08a7d9acebfd67ce535afe9e39a08262a..b1e46999c543fce8efabf4f38e3e655c
          var node = EventNode.all("main");
          var handle = node.getHandle(EventTest.class);
          assertSame(handle, node.getHandle(EventTest.class));
-@@ -84,7 +84,7 @@ public class EventNodeTest {
+@@ -84,7 +85,7 @@ public class EventNodeTest {
      }
  
      @Test
@@ -3927,7 +4034,7 @@ index 114033a08a7d9acebfd67ce535afe9e39a08262a..b1e46999c543fce8efabf4f38e3e655c
          var node = EventNode.all("main");
          AtomicBoolean result = new AtomicBoolean(false);
          var listener = EventListener.builder(CancellableTest.class)
-@@ -103,7 +103,7 @@ public class EventNodeTest {
+@@ -103,7 +104,7 @@ public class EventNodeTest {
      }
  
      @Test
@@ -3936,7 +4043,7 @@ index 114033a08a7d9acebfd67ce535afe9e39a08262a..b1e46999c543fce8efabf4f38e3e655c
          var node = EventNode.all("main");
          AtomicBoolean result1 = new AtomicBoolean(false);
          AtomicBoolean result2 = new AtomicBoolean(false);
-@@ -144,7 +144,7 @@ public class EventNodeTest {
+@@ -144,7 +145,7 @@ public class EventNodeTest {
      //}
  
      @Test
@@ -3945,7 +4052,7 @@ index 114033a08a7d9acebfd67ce535afe9e39a08262a..b1e46999c543fce8efabf4f38e3e655c
          var node = EventNode.all("main");
          AtomicInteger result = new AtomicInteger(0);
          var child1 = EventNode.all("child1").setPriority(1)
-@@ -159,14 +159,14 @@ public class EventNodeTest {
+@@ -159,14 +160,14 @@ public class EventNodeTest {
                  });
          node.addChild(child1);
          node.addChild(child2);
@@ -3962,7 +4069,7 @@ index 114033a08a7d9acebfd67ce535afe9e39a08262a..b1e46999c543fce8efabf4f38e3e655c
          node.call(new EventTest());
          assertEquals(1, result.get(), "child2 should has been removed");
  
-@@ -178,7 +178,7 @@ public class EventNodeTest {
+@@ -178,7 +179,7 @@ public class EventNodeTest {
      }
  
      @Test
@@ -3971,7 +4078,7 @@ index 114033a08a7d9acebfd67ce535afe9e39a08262a..b1e46999c543fce8efabf4f38e3e655c
          AtomicBoolean result = new AtomicBoolean(false);
          AtomicBoolean childResult = new AtomicBoolean(false);
  
-@@ -202,7 +202,7 @@ public class EventNodeTest {
+@@ -202,7 +203,7 @@ public class EventNodeTest {
      }
  
      @Test
@@ -3980,7 +4087,7 @@ index 114033a08a7d9acebfd67ce535afe9e39a08262a..b1e46999c543fce8efabf4f38e3e655c
          var node = EventNode.all("main");
  
          AtomicBoolean result = new AtomicBoolean(false);
-@@ -224,7 +224,7 @@ public class EventNodeTest {
+@@ -224,7 +225,7 @@ public class EventNodeTest {
      }
  
      @Test
@@ -3989,7 +4096,7 @@ index 114033a08a7d9acebfd67ce535afe9e39a08262a..b1e46999c543fce8efabf4f38e3e655c
          var node = EventNode.all("main");
          var ref = new WeakReference<>(node);
  
-@@ -234,7 +234,7 @@ public class EventNodeTest {
+@@ -234,7 +235,7 @@ public class EventNodeTest {
      }
  
      @Test
@@ -3998,7 +4105,7 @@ index 114033a08a7d9acebfd67ce535afe9e39a08262a..b1e46999c543fce8efabf4f38e3e655c
          var node = EventNode.all("main");
          var ref = new WeakReference<>(node);
          node.addListener(EventTest.class, event -> {
-@@ -261,7 +261,7 @@ public class EventNodeTest {
+@@ -261,7 +262,7 @@ public class EventNodeTest {
  //    }
  
      @Test
@@ -4008,12 +4115,14 @@ index 114033a08a7d9acebfd67ce535afe9e39a08262a..b1e46999c543fce8efabf4f38e3e655c
  
          var handler = ItemStack.AIR;
 diff --git a/src/test/java/net/minestom/server/instance/AnvilLoaderIntegrationTest.java b/src/test/java/net/minestom/server/instance/AnvilLoaderIntegrationTest.java
-index 1e8f352c6dea803bbe9cea8998fb4d03535f6177..7fcb6ffa93f15baf5dc1d77f21a01068461f8115 100644
+index 1e8f352c6dea803bbe9cea8998fb4d03535f6177..6425f798ea972201d94a05ae92dfce930003dcf2 100644
 --- a/src/test/java/net/minestom/server/instance/AnvilLoaderIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/instance/AnvilLoaderIntegrationTest.java
-@@ -19,14 +19,14 @@ import java.util.function.Consumer;
+@@ -18,15 +18,16 @@ import java.util.function.Consumer;
+ 
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class AnvilLoaderIntegrationTest {
 +class AnvilLoaderIntegrationTest {
@@ -4028,7 +4137,7 @@ index 1e8f352c6dea803bbe9cea8998fb4d03535f6177..7fcb6ffa93f15baf5dc1d77f21a01068
          // https://stackoverflow.com/a/60621544
          Files.walkFileTree(testRoot, new SimpleFileVisitor<>() {
  
-@@ -48,7 +48,7 @@ public class AnvilLoaderIntegrationTest {
+@@ -48,7 +49,7 @@ public class AnvilLoaderIntegrationTest {
  
  
      @Test
@@ -4037,7 +4146,7 @@ index 1e8f352c6dea803bbe9cea8998fb4d03535f6177..7fcb6ffa93f15baf5dc1d77f21a01068
          // load a world that contains only a basic house and make sure it is loaded properly
  
          AnvilLoader chunkLoader = new AnvilLoader(worldFolder) {
-@@ -145,7 +145,7 @@ public class AnvilLoaderIntegrationTest {
+@@ -145,7 +146,7 @@ public class AnvilLoaderIntegrationTest {
      }
  
      @Test
@@ -4046,7 +4155,7 @@ index 1e8f352c6dea803bbe9cea8998fb4d03535f6177..7fcb6ffa93f15baf5dc1d77f21a01068
          Instance instance = env.createFlatInstance(new AnvilLoader(worldFolder) {
              // Force loads inside current thread
              @Override
-@@ -183,7 +183,7 @@ public class AnvilLoaderIntegrationTest {
+@@ -183,7 +184,7 @@ public class AnvilLoaderIntegrationTest {
      }
  
      @AfterAll
@@ -4056,14 +4165,15 @@ index 1e8f352c6dea803bbe9cea8998fb4d03535f6177..7fcb6ffa93f15baf5dc1d77f21a01068
  
              @Override
 diff --git a/src/test/java/net/minestom/server/instance/BlockClientNbtTest.java b/src/test/java/net/minestom/server/instance/BlockClientNbtTest.java
-index 837eda9fe513972169ed8d0e528cbcdc387e5401..96522d656031c43dce30959e90a20f6ee82905e3 100644
+index 837eda9fe513972169ed8d0e528cbcdc387e5401..3ffd0f28b520199e8130640d14f8a9cf4dcb98e5 100644
 --- a/src/test/java/net/minestom/server/instance/BlockClientNbtTest.java
 +++ b/src/test/java/net/minestom/server/instance/BlockClientNbtTest.java
-@@ -17,10 +17,10 @@ import java.util.Map;
+@@ -17,10 +17,11 @@ import java.util.Map;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
 -public class BlockClientNbtTest {
++//Microtus - update java keyword usage
 +class BlockClientNbtTest {
  
      @Test
@@ -4072,7 +4182,7 @@ index 837eda9fe513972169ed8d0e528cbcdc387e5401..96522d656031c43dce30959e90a20f6e
          assertNull(BlockUtils.extractClientNbt(Block.STONE));
          assertNull(BlockUtils.extractClientNbt(Block.GRASS));
          assertEquals(NBTCompound.EMPTY, BlockUtils.extractClientNbt(Block.CHEST));
-@@ -30,7 +30,7 @@ public class BlockClientNbtTest {
+@@ -30,7 +31,7 @@ public class BlockClientNbtTest {
      }
  
      @Test
@@ -4082,14 +4192,15 @@ index 837eda9fe513972169ed8d0e528cbcdc387e5401..96522d656031c43dce30959e90a20f6e
              @Override
              public @NotNull Collection<Tag<?>> getBlockEntityTags() {
 diff --git a/src/test/java/net/minestom/server/instance/BlockPropertiesTest.java b/src/test/java/net/minestom/server/instance/BlockPropertiesTest.java
-index 3fbe44370df7d98fa432de3a9d6eb95e2cc3fbbc..ca0bf1cf03eb11e1a9efe9e29a4464ca59a33c95 100644
+index 3fbe44370df7d98fa432de3a9d6eb95e2cc3fbbc..949c9a16a82e44bc1e402ad80e3803ebb2394d1a 100644
 --- a/src/test/java/net/minestom/server/instance/BlockPropertiesTest.java
 +++ b/src/test/java/net/minestom/server/instance/BlockPropertiesTest.java
-@@ -7,16 +7,16 @@ import java.util.Map;
+@@ -7,16 +7,17 @@ import java.util.Map;
  import static net.minestom.server.utils.block.BlockUtils.parseProperties;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
 -public class BlockPropertiesTest {
++//Microtus - update java keyword usage
 +class BlockPropertiesTest {
  
      @Test
@@ -4105,7 +4216,7 @@ index 3fbe44370df7d98fa432de3a9d6eb95e2cc3fbbc..ca0bf1cf03eb11e1a9efe9e29a4464ca
          assertEquals(Map.of(), parseProperties("random test without brackets"));
          assertEquals(Map.of(), parseProperties("["));
          assertEquals(Map.of(), parseProperties("[end"));
-@@ -27,28 +27,28 @@ public class BlockPropertiesTest {
+@@ -27,28 +28,28 @@ public class BlockPropertiesTest {
      }
  
      @Test
@@ -4139,7 +4250,7 @@ index 3fbe44370df7d98fa432de3a9d6eb95e2cc3fbbc..ca0bf1cf03eb11e1a9efe9e29a4464ca
          // Verify all length variations
          for (int i = 0; i < 13; i++) {
              StringBuilder properties = new StringBuilder("[");
-@@ -67,7 +67,7 @@ public class BlockPropertiesTest {
+@@ -67,7 +68,7 @@ public class BlockPropertiesTest {
      }
  
      @Test
@@ -4148,13 +4259,76 @@ index 3fbe44370df7d98fa432de3a9d6eb95e2cc3fbbc..ca0bf1cf03eb11e1a9efe9e29a4464ca
          final int size = 12;
          StringBuilder properties = new StringBuilder("[");
          for (int j = 0; j < size; j++) {
+diff --git a/src/test/java/net/minestom/server/instance/BlockTest.java b/src/test/java/net/minestom/server/instance/BlockTest.java
+index 5fa43d5236e483b25b94dc757b98a3a483409c70..6cf65520c5e0763d837b3d1f763717e4183980bc 100644
+--- a/src/test/java/net/minestom/server/instance/BlockTest.java
++++ b/src/test/java/net/minestom/server/instance/BlockTest.java
+@@ -13,10 +13,11 @@ import java.util.Objects;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-public class BlockTest {
++//Microtus - update java keyword usage
++class BlockTest {
+ 
+     @Test
+-    public void testNBT() {
++    void testNBT() {
+         Block block = Block.CHEST;
+         assertFalse(block.hasNbt());
+         assertNull(block.nbt());
+@@ -35,7 +36,7 @@ public class BlockTest {
+     }
+ 
+     @Test
+-    public void validProperties() {
++    void validProperties() {
+         Block block = Block.CHEST;
+         assertEquals(block.properties(), Objects.requireNonNull(Block.fromBlockId(block.id())).properties());
+ 
+@@ -53,14 +54,14 @@ public class BlockTest {
+     }
+ 
+     @Test
+-    public void invalidProperties() {
++    void invalidProperties() {
+         Block block = Block.CHEST;
+         assertThrows(Exception.class, () -> block.withProperty("random", "randomKey"));
+         assertThrows(Exception.class, () -> block.withProperties(Map.of("random", "randomKey")));
+     }
+ 
+     @Test
+-    public void testEquality() {
++    void testEquality() {
+         var nbt = new NBTCompound(Map.of("key", NBT.Int(5)));
+         Block b1 = Block.CHEST;
+         Block b2 = Block.CHEST;
+@@ -71,14 +72,14 @@ public class BlockTest {
+     }
+ 
+     @Test
+-    public void testMutability() {
++    void testMutability() {
+         Block block = Block.CHEST;
+         assertThrows(Exception.class, () -> block.properties().put("facing", "north"));
+         assertThrows(Exception.class, () -> block.withProperty("facing", "north").properties().put("facing", "south"));
+     }
+ 
+     @Test
+-    public void testShape() {
++    void testShape() {
+         Point start = Block.LANTERN.registry().collisionShape().relativeStart();
+         Point end = Block.LANTERN.registry().collisionShape().relativeEnd();
+ 
 diff --git a/src/test/java/net/minestom/server/instance/ChunkViewerIntegrationTest.java b/src/test/java/net/minestom/server/instance/ChunkViewerIntegrationTest.java
-index 429a26a0a498574bff8109bbaa8d14c9a4b477d2..5e9b92c3c5c749ad75351f97d5d9799ae6937096 100644
+index 429a26a0a498574bff8109bbaa8d14c9a4b477d2..52cedd7675ee10607a862edcb9765fd039ea451c 100644
 --- a/src/test/java/net/minestom/server/instance/ChunkViewerIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/instance/ChunkViewerIntegrationTest.java
-@@ -13,11 +13,11 @@ import org.junit.jupiter.params.provider.ValueSource;
+@@ -12,12 +12,13 @@ import org.junit.jupiter.params.provider.ValueSource;
+ 
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class ChunkViewerIntegrationTest {
 +class ChunkViewerIntegrationTest {
@@ -4166,7 +4340,7 @@ index 429a26a0a498574bff8109bbaa8d14c9a4b477d2..5e9b92c3c5c749ad75351f97d5d9799a
          Instance instance = env.createFlatInstance();
          if (sharedInstance) {
              // Chunks get their viewers from the instance
-@@ -36,7 +36,7 @@ public class ChunkViewerIntegrationTest {
+@@ -36,7 +37,7 @@ public class ChunkViewerIntegrationTest {
      }
  
      @Test
@@ -4176,12 +4350,14 @@ index 429a26a0a498574bff8109bbaa8d14c9a4b477d2..5e9b92c3c5c749ad75351f97d5d9799a
          final int count = ChunkUtils.getChunkCount(viewRadius);
          var instance = env.createFlatInstance();
 diff --git a/src/test/java/net/minestom/server/instance/EntityTrackerIntegrationTest.java b/src/test/java/net/minestom/server/instance/EntityTrackerIntegrationTest.java
-index 23c78ab95cf4c1d33bbec7a7ded112bf90e5d643..54cf27ff081129e662126ccdeff4e0333dbb4f46 100644
+index 23c78ab95cf4c1d33bbec7a7ded112bf90e5d643..6cd3483cc32d0876d5210df9c7e7042ed6aabb8e 100644
 --- a/src/test/java/net/minestom/server/instance/EntityTrackerIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/instance/EntityTrackerIntegrationTest.java
-@@ -20,10 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -19,11 +19,12 @@ import java.util.concurrent.atomic.AtomicInteger;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertSame;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class EntityTrackerIntegrationTest {
 +class EntityTrackerIntegrationTest {
@@ -4192,7 +4368,7 @@ index 23c78ab95cf4c1d33bbec7a7ded112bf90e5d643..54cf27ff081129e662126ccdeff4e033
          final Instance instance = env.createFlatInstance();
          final Instance anotherInstance = env.createFlatInstance();
          final Pos spawnPos = new Pos(0, 41, 0);
-@@ -55,7 +55,7 @@ public class EntityTrackerIntegrationTest {
+@@ -55,7 +56,7 @@ public class EntityTrackerIntegrationTest {
      }
  
      @Test
@@ -4201,7 +4377,7 @@ index 23c78ab95cf4c1d33bbec7a7ded112bf90e5d643..54cf27ff081129e662126ccdeff4e033
          final Instance instance = env.createFlatInstance();
          final Instance anotherInstance = env.createFlatInstance();
          final Pos spawnPos = new Pos(0, 41, 0);
-@@ -87,7 +87,7 @@ public class EntityTrackerIntegrationTest {
+@@ -87,7 +88,7 @@ public class EntityTrackerIntegrationTest {
      }
  
      @Test
@@ -4210,7 +4386,7 @@ index 23c78ab95cf4c1d33bbec7a7ded112bf90e5d643..54cf27ff081129e662126ccdeff4e033
          final Instance instance = env.createFlatInstance();
          final Pos spawnPos = new Pos(0, 41, 0);
          var viewable = instance.getEntityTracker().viewable(spawnPos.chunkX(), spawnPos.chunkZ());
-@@ -105,7 +105,7 @@ public class EntityTrackerIntegrationTest {
+@@ -105,7 +106,7 @@ public class EntityTrackerIntegrationTest {
      }
  
      @Test
@@ -4220,14 +4396,15 @@ index 23c78ab95cf4c1d33bbec7a7ded112bf90e5d643..54cf27ff081129e662126ccdeff4e033
          var shared = env.process().instance().createSharedInstance(instance);
          var sharedList = instance.getSharedInstances();
 diff --git a/src/test/java/net/minestom/server/instance/EntityTrackerTest.java b/src/test/java/net/minestom/server/instance/EntityTrackerTest.java
-index 45508ef388c32099b2bdac4a7a75808be3ce6d6c..fa1ed75e21bb788e634b9202605c26b2fa594d46 100644
+index 45508ef388c32099b2bdac4a7a75808be3ce6d6c..05114ef736b74b1783c200ff7b2785adb76f6090 100644
 --- a/src/test/java/net/minestom/server/instance/EntityTrackerTest.java
 +++ b/src/test/java/net/minestom/server/instance/EntityTrackerTest.java
-@@ -11,9 +11,9 @@ import java.util.Set;
+@@ -11,9 +11,10 @@ import java.util.Set;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class EntityTrackerTest {
++//Microtus - update java keyword usage
 +class EntityTrackerTest {
      @Test
 -    public void register() {
@@ -4235,7 +4412,7 @@ index 45508ef388c32099b2bdac4a7a75808be3ce6d6c..fa1ed75e21bb788e634b9202605c26b2
          var ent1 = new Entity(EntityType.ZOMBIE);
          var updater = new EntityTracker.Update<>() {
              @Override
-@@ -40,7 +40,7 @@ public class EntityTrackerTest {
+@@ -40,7 +41,7 @@ public class EntityTrackerTest {
      }
  
      @Test
@@ -4244,7 +4421,7 @@ index 45508ef388c32099b2bdac4a7a75808be3ce6d6c..fa1ed75e21bb788e634b9202605c26b2
          var ent1 = new Entity(EntityType.ZOMBIE);
          var updater = new EntityTracker.Update<>() {
              @Override
-@@ -65,7 +65,7 @@ public class EntityTrackerTest {
+@@ -65,7 +66,7 @@ public class EntityTrackerTest {
      }
  
      @Test
@@ -4253,7 +4430,7 @@ index 45508ef388c32099b2bdac4a7a75808be3ce6d6c..fa1ed75e21bb788e634b9202605c26b2
          var ent1 = new Entity(EntityType.ZOMBIE);
          var ent2 = new Entity(EntityType.ZOMBIE);
  
-@@ -124,7 +124,7 @@ public class EntityTrackerTest {
+@@ -124,7 +125,7 @@ public class EntityTrackerTest {
      }
  
      @Test
@@ -4262,7 +4439,7 @@ index 45508ef388c32099b2bdac4a7a75808be3ce6d6c..fa1ed75e21bb788e634b9202605c26b2
          var ent1 = new Entity(EntityType.ZOMBIE);
          var ent2 = new Entity(EntityType.ZOMBIE);
          var ent3 = new Entity(EntityType.ZOMBIE);
-@@ -177,7 +177,7 @@ public class EntityTrackerTest {
+@@ -177,7 +178,7 @@ public class EntityTrackerTest {
      }
  
      @Test
@@ -4271,7 +4448,7 @@ index 45508ef388c32099b2bdac4a7a75808be3ce6d6c..fa1ed75e21bb788e634b9202605c26b2
          var ent1 = new Entity(EntityType.ZOMBIE);
          var ent2 = new Entity(EntityType.ZOMBIE);
          var ent3 = new Entity(EntityType.ZOMBIE);
-@@ -217,7 +217,7 @@ public class EntityTrackerTest {
+@@ -217,7 +218,7 @@ public class EntityTrackerTest {
      }
  
      @Test
@@ -4281,12 +4458,14 @@ index 45508ef388c32099b2bdac4a7a75808be3ce6d6c..fa1ed75e21bb788e634b9202605c26b2
          var updater = new EntityTracker.Update<>() {
              @Override
 diff --git a/src/test/java/net/minestom/server/instance/GeneratorForkConsumerIntegrationTest.java b/src/test/java/net/minestom/server/instance/GeneratorForkConsumerIntegrationTest.java
-index d4a50690b4a443799941034fd6124078a9336565..8cdd2f611a9228e3fa50449689625ba6a52ea23e 100644
+index d4a50690b4a443799941034fd6124078a9336565..844af7f0967761875d5a216dba93f88479f9d1a2 100644
 --- a/src/test/java/net/minestom/server/instance/GeneratorForkConsumerIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/instance/GeneratorForkConsumerIntegrationTest.java
-@@ -14,10 +14,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -13,11 +13,12 @@ import java.util.concurrent.atomic.AtomicReference;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class GeneratorForkConsumerIntegrationTest {
 +class GeneratorForkConsumerIntegrationTest {
@@ -4297,7 +4476,7 @@ index d4a50690b4a443799941034fd6124078a9336565..8cdd2f611a9228e3fa50449689625ba6
          var manager = env.process().instance();
          var instance = manager.createInstanceContainer();
          AtomicReference<Exception> failed = new AtomicReference<>();
-@@ -34,61 +34,55 @@ public class GeneratorForkConsumerIntegrationTest {
+@@ -34,61 +35,55 @@ public class GeneratorForkConsumerIntegrationTest {
      }
  
      @Test
@@ -4391,7 +4570,7 @@ index d4a50690b4a443799941034fd6124078a9336565..8cdd2f611a9228e3fa50449689625ba6
          instance.loadChunk(0, 0).join();
          instance.setGenerator(null);
          instance.loadChunk(0, 1).join();
-@@ -97,24 +91,22 @@ public class GeneratorForkConsumerIntegrationTest {
+@@ -97,24 +92,22 @@ public class GeneratorForkConsumerIntegrationTest {
      }
  
      @Test
@@ -4430,7 +4609,7 @@ index d4a50690b4a443799941034fd6124078a9336565..8cdd2f611a9228e3fa50449689625ba6
          instance.loadChunk(0, 0).join();
          instance.setGenerator(null);
          instance.loadChunk(1, 0).join();
-@@ -123,31 +115,29 @@ public class GeneratorForkConsumerIntegrationTest {
+@@ -123,31 +116,29 @@ public class GeneratorForkConsumerIntegrationTest {
      }
  
      @Test
@@ -4478,12 +4657,14 @@ index d4a50690b4a443799941034fd6124078a9336565..8cdd2f611a9228e3fa50449689625ba6
          var instance = manager.createInstanceContainer();
          Set<Point> points = ConcurrentHashMap.newKeySet();
 diff --git a/src/test/java/net/minestom/server/instance/GeneratorForkIntegrationTest.java b/src/test/java/net/minestom/server/instance/GeneratorForkIntegrationTest.java
-index ec9b91cebac942d77f6e027b5be9fc04bf2f7eb9..3580264ac43c7268834e53315d968afe480e707c 100644
+index ec9b91cebac942d77f6e027b5be9fc04bf2f7eb9..666e13eb96c80c14bc8778041137dd207961b8e7 100644
 --- a/src/test/java/net/minestom/server/instance/GeneratorForkIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/instance/GeneratorForkIntegrationTest.java
-@@ -11,10 +11,10 @@ import org.junit.jupiter.api.Test;
+@@ -10,11 +10,12 @@ import org.junit.jupiter.api.Test;
+ 
  import static org.junit.jupiter.api.Assertions.*;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class GeneratorForkIntegrationTest {
 +class GeneratorForkIntegrationTest {
@@ -4494,7 +4675,7 @@ index ec9b91cebac942d77f6e027b5be9fc04bf2f7eb9..3580264ac43c7268834e53315d968afe
          var manager = env.process().instance();
          var instance = manager.createInstanceContainer();
          var block = Block.STONE;
-@@ -29,7 +29,7 @@ public class GeneratorForkIntegrationTest {
+@@ -29,7 +30,7 @@ public class GeneratorForkIntegrationTest {
      }
  
      @Test
@@ -4503,7 +4684,7 @@ index ec9b91cebac942d77f6e027b5be9fc04bf2f7eb9..3580264ac43c7268834e53315d968afe
          var manager = env.process().instance();
          var instance = manager.createInstanceContainer();
          // Set the Generator
-@@ -46,7 +46,7 @@ public class GeneratorForkIntegrationTest {
+@@ -46,7 +47,7 @@ public class GeneratorForkIntegrationTest {
      }
  
      @Test
@@ -4512,7 +4693,7 @@ index ec9b91cebac942d77f6e027b5be9fc04bf2f7eb9..3580264ac43c7268834e53315d968afe
          var manager = env.process().instance();
          var instance = manager.createInstanceContainer();
          var block = Block.STONE;
-@@ -65,7 +65,7 @@ public class GeneratorForkIntegrationTest {
+@@ -65,7 +66,7 @@ public class GeneratorForkIntegrationTest {
      }
  
      @Test
@@ -4521,7 +4702,7 @@ index ec9b91cebac942d77f6e027b5be9fc04bf2f7eb9..3580264ac43c7268834e53315d968afe
          var manager = env.process().instance();
          var instance = manager.createInstanceContainer();
          instance.setGenerator(unit -> {
-@@ -79,7 +79,7 @@ public class GeneratorForkIntegrationTest {
+@@ -79,7 +80,7 @@ public class GeneratorForkIntegrationTest {
      }
  
      @Test
@@ -4530,7 +4711,7 @@ index ec9b91cebac942d77f6e027b5be9fc04bf2f7eb9..3580264ac43c7268834e53315d968afe
          var manager = env.process().instance();
          var instance = manager.createInstanceContainer();
          instance.setGenerator(unit -> {
-@@ -95,7 +95,7 @@ public class GeneratorForkIntegrationTest {
+@@ -95,7 +96,7 @@ public class GeneratorForkIntegrationTest {
      }
  
      @Test
@@ -4540,12 +4721,14 @@ index ec9b91cebac942d77f6e027b5be9fc04bf2f7eb9..3580264ac43c7268834e53315d968afe
          var instance = manager.createInstanceContainer();
          instance.setGenerator(unit -> {
 diff --git a/src/test/java/net/minestom/server/instance/GeneratorIntegrationTest.java b/src/test/java/net/minestom/server/instance/GeneratorIntegrationTest.java
-index e2ddf7d46b58c61ed33dd81c275428736dcf23b6..ce1e765ee0f3f0cc4319b63933d62511999d222e 100644
+index e2ddf7d46b58c61ed33dd81c275428736dcf23b6..cc7972f9e39f8825ad922eca29dc678e6483f56d 100644
 --- a/src/test/java/net/minestom/server/instance/GeneratorIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/instance/GeneratorIntegrationTest.java
-@@ -15,11 +15,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -14,12 +14,13 @@ import java.util.concurrent.atomic.AtomicReference;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertSame;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class GeneratorIntegrationTest {
 +class GeneratorIntegrationTest {
@@ -4557,7 +4740,7 @@ index e2ddf7d46b58c61ed33dd81c275428736dcf23b6..ce1e765ee0f3f0cc4319b63933d62511
          var manager = env.process().instance();
          var block = data ? Block.STONE.withNbt(NBT.Compound(Map.of("key", NBT.String("value")))) : Block.STONE;
          var instance = manager.createInstanceContainer();
-@@ -32,7 +32,7 @@ public class GeneratorIntegrationTest {
+@@ -32,7 +33,7 @@ public class GeneratorIntegrationTest {
      }
  
      @Test
@@ -4566,7 +4749,7 @@ index e2ddf7d46b58c61ed33dd81c275428736dcf23b6..ce1e765ee0f3f0cc4319b63933d62511
          var manager = env.process().instance();
          var instance = manager.createInstanceContainer();
  
-@@ -50,7 +50,7 @@ public class GeneratorIntegrationTest {
+@@ -50,7 +51,7 @@ public class GeneratorIntegrationTest {
      }
  
      @Test
@@ -4575,7 +4758,7 @@ index e2ddf7d46b58c61ed33dd81c275428736dcf23b6..ce1e765ee0f3f0cc4319b63933d62511
          var manager = env.process().instance();
          var instance = manager.createInstanceContainer();
          instance.setGenerator(unit -> unit.modifier().fillHeight(-64, -60, Block.STONE));
-@@ -64,7 +64,7 @@ public class GeneratorIntegrationTest {
+@@ -64,7 +65,7 @@ public class GeneratorIntegrationTest {
      }
  
      @Test
@@ -4584,7 +4767,7 @@ index e2ddf7d46b58c61ed33dd81c275428736dcf23b6..ce1e765ee0f3f0cc4319b63933d62511
          var manager = env.process().instance();
          var instance = manager.createInstanceContainer();
          instance.setGenerator(unit -> unit.modifier().fillHeight(0, 16, Block.GRASS_BLOCK));
-@@ -75,7 +75,7 @@ public class GeneratorIntegrationTest {
+@@ -75,7 +76,7 @@ public class GeneratorIntegrationTest {
      }
  
      @Test
@@ -4593,7 +4776,7 @@ index e2ddf7d46b58c61ed33dd81c275428736dcf23b6..ce1e765ee0f3f0cc4319b63933d62511
          var manager = env.process().instance();
          var instance = manager.createInstanceContainer();
          instance.setGenerator(unit -> unit.modifier().fillHeight(4, 5, Block.GRASS_BLOCK));
-@@ -86,7 +86,7 @@ public class GeneratorIntegrationTest {
+@@ -86,7 +87,7 @@ public class GeneratorIntegrationTest {
      }
  
      @Test
@@ -4603,14 +4786,15 @@ index e2ddf7d46b58c61ed33dd81c275428736dcf23b6..ce1e765ee0f3f0cc4319b63933d62511
          var instance = manager.createInstanceContainer();
          instance.setGenerator(unit -> {
 diff --git a/src/test/java/net/minestom/server/instance/GeneratorTest.java b/src/test/java/net/minestom/server/instance/GeneratorTest.java
-index 4a53ede725c99c4448e28d11625476eed34189c5..ad3ba534f6a91b90a713518aba46ac260fbcdd72 100644
+index 4a53ede725c99c4448e28d11625476eed34189c5..8040d8bcd2c7a7f2751e10d44ab738db9a574be7 100644
 --- a/src/test/java/net/minestom/server/instance/GeneratorTest.java
 +++ b/src/test/java/net/minestom/server/instance/GeneratorTest.java
-@@ -25,10 +25,10 @@ import static net.minestom.server.utils.chunk.ChunkUtils.ceilSection;
+@@ -25,10 +25,11 @@ import static net.minestom.server.utils.chunk.ChunkUtils.ceilSection;
  import static net.minestom.server.utils.chunk.ChunkUtils.floorSection;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class GeneratorTest {
++//Microtus - update java keyword usage
 +class GeneratorTest {
  
      @Test
@@ -4619,7 +4803,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..ad3ba534f6a91b90a713518aba46ac26
          assertDoesNotThrow(() -> dummyUnit(Vec.ZERO, new Vec(16)));
          assertDoesNotThrow(() -> dummyUnit(new Vec(16), new Vec(32)));
          assertThrows(IllegalArgumentException.class, () -> dummyUnit(new Vec(15), Vec.ZERO));
-@@ -39,7 +39,7 @@ public class GeneratorTest {
+@@ -39,7 +40,7 @@ public class GeneratorTest {
  
      @ParameterizedTest
      @MethodSource("sectionFloorParam")
@@ -4628,7 +4812,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..ad3ba534f6a91b90a713518aba46ac26
          assertEquals(expected, floorSection(input), "floorSection(" + input + ")");
      }
  
-@@ -58,7 +58,7 @@ public class GeneratorTest {
+@@ -58,7 +59,7 @@ public class GeneratorTest {
  
      @ParameterizedTest
      @MethodSource("sectionCeilParam")
@@ -4637,7 +4821,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..ad3ba534f6a91b90a713518aba46ac26
          assertEquals(expected, ceilSection(input), "ceilSection(" + input + ")");
      }
  
-@@ -76,7 +76,7 @@ public class GeneratorTest {
+@@ -76,7 +77,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4646,7 +4830,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..ad3ba534f6a91b90a713518aba46ac26
          final int minSection = 0;
          final int maxSection = 5;
          final int chunkX = 3;
-@@ -91,7 +91,7 @@ public class GeneratorTest {
+@@ -91,7 +92,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4655,7 +4839,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..ad3ba534f6a91b90a713518aba46ac26
          final int minSection = -1;
          final int maxSection = 5;
          final int chunkX = 3;
-@@ -106,7 +106,7 @@ public class GeneratorTest {
+@@ -106,7 +107,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4664,7 +4848,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..ad3ba534f6a91b90a713518aba46ac26
          final int sectionX = 3;
          final int sectionY = -5;
          final int sectionZ = -2;
-@@ -117,7 +117,7 @@ public class GeneratorTest {
+@@ -117,7 +118,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4673,7 +4857,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..ad3ba534f6a91b90a713518aba46ac26
          final int minSection = -1;
          final int maxSection = 5;
          final int chunkX = 3;
-@@ -137,7 +137,7 @@ public class GeneratorTest {
+@@ -137,7 +138,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4682,7 +4866,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..ad3ba534f6a91b90a713518aba46ac26
          final int minSection = 0;
          final int maxSection = 5;
          final int chunkX = 3;
-@@ -158,7 +158,7 @@ public class GeneratorTest {
+@@ -158,7 +159,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4691,7 +4875,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..ad3ba534f6a91b90a713518aba46ac26
          final int minSection = 0;
          final int maxSection = 5;
          final int chunkX = 3;
-@@ -186,7 +186,7 @@ public class GeneratorTest {
+@@ -186,7 +187,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4700,7 +4884,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..ad3ba534f6a91b90a713518aba46ac26
          final int minSection = -1;
          final int maxSection = 5;
          final int chunkX = 3;
-@@ -213,7 +213,7 @@ public class GeneratorTest {
+@@ -213,7 +214,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4709,7 +4893,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..ad3ba534f6a91b90a713518aba46ac26
          final int minSection = -1;
          final int maxSection = 5;
          final int chunkX = 3;
-@@ -242,7 +242,7 @@ public class GeneratorTest {
+@@ -242,7 +243,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4718,7 +4902,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..ad3ba534f6a91b90a713518aba46ac26
          final int minSection = -1;
          final int maxSection = 5;
          final int chunkX = 3;
-@@ -263,7 +263,7 @@ public class GeneratorTest {
+@@ -263,7 +264,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4727,7 +4911,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..ad3ba534f6a91b90a713518aba46ac26
          final int minSection = -1;
          final int maxSection = 5;
          final int chunkX = 3;
-@@ -284,7 +284,7 @@ public class GeneratorTest {
+@@ -284,7 +285,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4736,7 +4920,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..ad3ba534f6a91b90a713518aba46ac26
          final int minSection = -1;
          final int maxSection = 5;
          final int sectionCount = maxSection - minSection;
-@@ -308,7 +308,7 @@ public class GeneratorTest {
+@@ -308,7 +309,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4745,7 +4929,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..ad3ba534f6a91b90a713518aba46ac26
          final int minSection = -1;
          final int maxSection = 5;
          final int sectionCount = maxSection - minSection;
-@@ -346,7 +346,7 @@ public class GeneratorTest {
+@@ -346,7 +347,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4755,12 +4939,14 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..ad3ba534f6a91b90a713518aba46ac26
          var chunkUnit = GeneratorImpl.section(section, -1, -1, 0);
          Generator generator = chunk -> chunk.modifier().fill(Block.STONE);
 diff --git a/src/test/java/net/minestom/server/instance/InstanceBlockIntegrationTest.java b/src/test/java/net/minestom/server/instance/InstanceBlockIntegrationTest.java
-index 5b0d774bc9d87540382de3b88f48f7542f8f473c..fc21a2c8e00e201b266f6e71d90249dc71b1cce6 100644
+index 5b0d774bc9d87540382de3b88f48f7542f8f473c..8f58c740b5e38ba2a44e0d08d4379bd53f7aa99b 100644
 --- a/src/test/java/net/minestom/server/instance/InstanceBlockIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/instance/InstanceBlockIntegrationTest.java
-@@ -11,10 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -10,11 +10,12 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertThrows;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class InstanceBlockIntegrationTest {
 +class InstanceBlockIntegrationTest {
@@ -4771,7 +4957,7 @@ index 5b0d774bc9d87540382de3b88f48f7542f8f473c..fc21a2c8e00e201b266f6e71d90249dc
          var instance = env.createFlatInstance();
          assertThrows(NullPointerException.class, () -> instance.getBlock(0, 0, 0),
                  "No exception throw when getting a block in an unloaded chunk");
-@@ -35,7 +35,7 @@ public class InstanceBlockIntegrationTest {
+@@ -35,7 +36,7 @@ public class InstanceBlockIntegrationTest {
      }
  
      @Test
@@ -4780,7 +4966,7 @@ index 5b0d774bc9d87540382de3b88f48f7542f8f473c..fc21a2c8e00e201b266f6e71d90249dc
          var instance = env.createFlatInstance();
          instance.loadChunk(0, 0).join();
  
-@@ -51,7 +51,7 @@ public class InstanceBlockIntegrationTest {
+@@ -51,7 +52,7 @@ public class InstanceBlockIntegrationTest {
      }
  
      @Test
@@ -4790,12 +4976,14 @@ index 5b0d774bc9d87540382de3b88f48f7542f8f473c..fc21a2c8e00e201b266f6e71d90249dc
          assertThrows(NullPointerException.class, () -> instance.getBlock(0, 0, 0),
                  "No exception throw when getting a block in an unloaded chunk");
 diff --git a/src/test/java/net/minestom/server/instance/InstanceBlockPacketIntegrationTest.java b/src/test/java/net/minestom/server/instance/InstanceBlockPacketIntegrationTest.java
-index 32e9b8703842e4e46428f99dc9fed81071e0743d..8b1d5556d34625eaa516499b1c9a702914f4fbf6 100644
+index 32e9b8703842e4e46428f99dc9fed81071e0743d..461e1897b5b834b8bcc7498665ebae02dae26994 100644
 --- a/src/test/java/net/minestom/server/instance/InstanceBlockPacketIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/instance/InstanceBlockPacketIntegrationTest.java
-@@ -22,10 +22,10 @@ import java.util.List;
+@@ -21,11 +21,12 @@ import java.util.List;
+ 
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class InstanceBlockPacketIntegrationTest {
 +class InstanceBlockPacketIntegrationTest {
@@ -4806,7 +4994,7 @@ index 32e9b8703842e4e46428f99dc9fed81071e0743d..8b1d5556d34625eaa516499b1c9a7029
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          connection.connect(instance, new Pos(0, 40, 0)).join();
-@@ -45,7 +45,7 @@ public class InstanceBlockPacketIntegrationTest {
+@@ -45,7 +46,7 @@ public class InstanceBlockPacketIntegrationTest {
      }
  
      @Test
@@ -4815,13 +5003,27 @@ index 32e9b8703842e4e46428f99dc9fed81071e0743d..8b1d5556d34625eaa516499b1c9a7029
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          connection.connect(instance, new Pos(0, 40, 0)).join();
+diff --git a/src/test/java/net/minestom/server/instance/InstanceEqualsTest.java b/src/test/java/net/minestom/server/instance/InstanceEqualsTest.java
+index 305be82a87d514f18510d13364f0574f193a093a..9b89ce0d85c07b9a042ea3b241c23e84a507856d 100644
+--- a/src/test/java/net/minestom/server/instance/InstanceEqualsTest.java
++++ b/src/test/java/net/minestom/server/instance/InstanceEqualsTest.java
+@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
+ 
+ import static org.junit.jupiter.api.Assertions.*;
+ 
++//Microtus - update java keyword usage
+ @EnvTest
+ class InstanceEqualsTest {
+ 
 diff --git a/src/test/java/net/minestom/server/instance/InstanceEventsIntegrationTest.java b/src/test/java/net/minestom/server/instance/InstanceEventsIntegrationTest.java
-index 8f2404e5a4c06d98955ac7e2218ceb203f8b4fe5..7fd9f89ee545d55b58c35135ca502cdccadd9cac 100644
+index 8f2404e5a4c06d98955ac7e2218ceb203f8b4fe5..9bf8ad84c264a87c854741f93bac920a660f6621 100644
 --- a/src/test/java/net/minestom/server/instance/InstanceEventsIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/instance/InstanceEventsIntegrationTest.java
-@@ -7,9 +7,9 @@ import net.minestom.testing.EnvTest;
+@@ -6,10 +6,11 @@ import net.minestom.testing.Env;
+ import net.minestom.testing.EnvTest;
  import org.junit.jupiter.api.Test;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class InstanceEventsIntegrationTest {
 +class InstanceEventsIntegrationTest {
@@ -4832,12 +5034,14 @@ index 8f2404e5a4c06d98955ac7e2218ceb203f8b4fe5..7fd9f89ee545d55b58c35135ca502cdc
          var unregisterListener = env.listen(InstanceUnregisterEvent.class);
  
 diff --git a/src/test/java/net/minestom/server/instance/InstanceUnregisterIntegrationTest.java b/src/test/java/net/minestom/server/instance/InstanceUnregisterIntegrationTest.java
-index ed7173f89fe078072270f4f41e66c22e1c8766a6..c830e87e18e6039b5b644945d8e909d987e4bed6 100644
+index ed7173f89fe078072270f4f41e66c22e1c8766a6..df4f3d3bb1b79ad84e20525f2c1140df838ad3d9 100644
 --- a/src/test/java/net/minestom/server/instance/InstanceUnregisterIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/instance/InstanceUnregisterIntegrationTest.java
-@@ -15,10 +15,10 @@ import java.util.UUID;
+@@ -14,11 +14,12 @@ import java.util.UUID;
+ 
  import static net.minestom.testing.TestUtils.waitUntilCleared;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class InstanceUnregisterIntegrationTest {
 +class InstanceUnregisterIntegrationTest {
@@ -4848,7 +5052,7 @@ index ed7173f89fe078072270f4f41e66c22e1c8766a6..c830e87e18e6039b5b644945d8e909d9
          // Ensure that unregistering a shared instance does not unload the container chunks
          var instanceManager = env.process().instance();
          var instance = instanceManager.createInstanceContainer();
-@@ -40,7 +40,7 @@ public class InstanceUnregisterIntegrationTest {
+@@ -40,7 +41,7 @@ public class InstanceUnregisterIntegrationTest {
      }
  
      @Test
@@ -4857,7 +5061,7 @@ index ed7173f89fe078072270f4f41e66c22e1c8766a6..c830e87e18e6039b5b644945d8e909d9
          var instance = env.createFlatInstance();
          var ref = new WeakReference<>(instance);
          env.process().instance().unregisterInstance(instance);
-@@ -51,7 +51,7 @@ public class InstanceUnregisterIntegrationTest {
+@@ -51,7 +52,7 @@ public class InstanceUnregisterIntegrationTest {
      }
  
      @Test
@@ -4866,7 +5070,7 @@ index ed7173f89fe078072270f4f41e66c22e1c8766a6..c830e87e18e6039b5b644945d8e909d9
          final class Game {
              final Instance instance;
  
-@@ -70,7 +70,7 @@ public class InstanceUnregisterIntegrationTest {
+@@ -70,7 +71,7 @@ public class InstanceUnregisterIntegrationTest {
      }
  
      @Test
@@ -4875,7 +5079,7 @@ index ed7173f89fe078072270f4f41e66c22e1c8766a6..c830e87e18e6039b5b644945d8e909d9
          // Ensure that unregistering an instance does release its chunks
          var instance = env.createFlatInstance();
          var chunk = instance.loadChunk(0, 0).join();
-@@ -85,7 +85,7 @@ public class InstanceUnregisterIntegrationTest {
+@@ -85,7 +86,7 @@ public class InstanceUnregisterIntegrationTest {
      }
  
      @Test
@@ -4885,12 +5089,14 @@ index ed7173f89fe078072270f4f41e66c22e1c8766a6..c830e87e18e6039b5b644945d8e909d9
          env.process().instance().registerInstance(ref.get());
  
 diff --git a/src/test/java/net/minestom/server/instance/WorldBorderIntegrationTest.java b/src/test/java/net/minestom/server/instance/WorldBorderIntegrationTest.java
-index 01c4c935fec5e312f6043106acac4d16520a3b9a..01c68deb717f2ce5f43406c93adda353c40cf397 100644
+index 01c4c935fec5e312f6043106acac4d16520a3b9a..143c48b0abd06131bcef1c3733387d3274416f2c 100644
 --- a/src/test/java/net/minestom/server/instance/WorldBorderIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/instance/WorldBorderIntegrationTest.java
-@@ -7,10 +7,10 @@ import org.junit.jupiter.api.Test;
+@@ -6,11 +6,12 @@ import org.junit.jupiter.api.Test;
+ 
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class WorldBorderIntegrationTest {
 +class WorldBorderIntegrationTest {
@@ -4901,7 +5107,7 @@ index 01c4c935fec5e312f6043106acac4d16520a3b9a..01c68deb717f2ce5f43406c93adda353
          Instance instance = env.createFlatInstance();
  
          instance.getWorldBorder().setDiameter(50.0);
-@@ -20,7 +20,7 @@ public class WorldBorderIntegrationTest {
+@@ -20,7 +21,7 @@ public class WorldBorderIntegrationTest {
      }
  
      @Test
@@ -4911,14 +5117,15 @@ index 01c4c935fec5e312f6043106acac4d16520a3b9a..01c68deb717f2ce5f43406c93adda353
  
          instance.getWorldBorder().setDiameter(50.0);
 diff --git a/src/test/java/net/minestom/server/instance/palette/PaletteOptimizationTest.java b/src/test/java/net/minestom/server/instance/palette/PaletteOptimizationTest.java
-index 9916d52ab23c645388ed4c6c215bf7203fb4bdc0..877f265955d81dba590da8166e994c0e4ec8854a 100644
+index 9916d52ab23c645388ed4c6c215bf7203fb4bdc0..a66d0a083aaa9d8b5064ec4bd34be2b72b8cd279 100644
 --- a/src/test/java/net/minestom/server/instance/palette/PaletteOptimizationTest.java
 +++ b/src/test/java/net/minestom/server/instance/palette/PaletteOptimizationTest.java
-@@ -8,23 +8,23 @@ import java.util.Random;
+@@ -8,23 +8,24 @@ import java.util.Random;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertTrue;
  
 -public class PaletteOptimizationTest {
++//Microtus - update java keyword usage
 +class PaletteOptimizationTest {
  
      @Test
@@ -4942,7 +5149,7 @@ index 9916d52ab23c645388ed4c6c215bf7203fb4bdc0..877f265955d81dba590da8166e994c0e
          var random = new Random(12345);
          var palette = createPalette();
          palette.setAll((x, y, z) -> random.nextInt(256));
-@@ -34,7 +34,7 @@ public class PaletteOptimizationTest {
+@@ -34,7 +35,7 @@ public class PaletteOptimizationTest {
      }
  
      @Test
@@ -4952,14 +5159,15 @@ index 9916d52ab23c645388ed4c6c215bf7203fb4bdc0..877f265955d81dba590da8166e994c0e
          palette.setAll((x, y, z) -> 1);
          paletteEquals(palette.palette, palette.optimizedPalette());
 diff --git a/src/test/java/net/minestom/server/instance/palette/PaletteTest.java b/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
-index 3372ade456530be692de5f74e8c9515d32614df2..583214ea6d1a4bb59956ee727644f571bba6484c 100644
+index 3372ade456530be692de5f74e8c9515d32614df2..f4d164d0295d6a5272eb24f2b2d8b10cdc1db2fc 100644
 --- a/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
 +++ b/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
-@@ -11,17 +11,17 @@ import java.util.concurrent.atomic.AtomicInteger;
+@@ -11,17 +11,18 @@ import java.util.concurrent.atomic.AtomicInteger;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class PaletteTest {
++//Microtus - update java keyword usage
 +class PaletteTest {
  
      @Test
@@ -4976,7 +5184,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..583214ea6d1a4bb59956ee727644f571
          var palettes = testPalettes();
          for (Palette palette : palettes) {
              final int dimension = palette.dimension();
-@@ -56,7 +56,7 @@ public class PaletteTest {
+@@ -56,7 +57,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -4985,7 +5193,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..583214ea6d1a4bb59956ee727644f571
          final int value = 250_000;
          for (Palette palette : testPalettes()) {
              palette.set(0, 0, 1, value);
-@@ -65,7 +65,7 @@ public class PaletteTest {
+@@ -65,7 +66,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -4994,7 +5202,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..583214ea6d1a4bb59956ee727644f571
          var palettes = testPalettes();
          for (Palette palette : palettes) {
              assertThrows(IllegalArgumentException.class, () -> palette.set(-1, 0, 0, 64));
-@@ -79,7 +79,7 @@ public class PaletteTest {
+@@ -79,7 +80,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -5003,7 +5211,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..583214ea6d1a4bb59956ee727644f571
          Palette palette = Palette.newPalette(16, 5, 2);
          palette.set(0, 0, 0, 1);
          assertEquals(2, palette.bitsPerEntry());
-@@ -98,7 +98,7 @@ public class PaletteTest {
+@@ -98,7 +99,7 @@ public class PaletteTest {
  
  
      @Test
@@ -5012,7 +5220,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..583214ea6d1a4bb59956ee727644f571
          var palettes = testPalettes();
          for (Palette palette : palettes) {
              assertEquals(0, palette.count());
-@@ -129,7 +129,7 @@ public class PaletteTest {
+@@ -129,7 +130,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -5021,7 +5229,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..583214ea6d1a4bb59956ee727644f571
          var palettes = testPalettes();
          for (Palette palette : palettes) {
              final int dimension = palette.dimension();
-@@ -154,7 +154,7 @@ public class PaletteTest {
+@@ -154,7 +155,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -5030,7 +5238,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..583214ea6d1a4bb59956ee727644f571
          var palettes = testPalettes();
          for (Palette palette : palettes) {
              // Fill all entries
-@@ -172,7 +172,7 @@ public class PaletteTest {
+@@ -172,7 +173,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -5039,7 +5247,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..583214ea6d1a4bb59956ee727644f571
          var palettes = testPalettes();
          for (Palette palette : palettes) {
              AtomicInteger count = new AtomicInteger();
-@@ -210,7 +210,7 @@ public class PaletteTest {
+@@ -210,7 +211,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -5048,7 +5256,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..583214ea6d1a4bb59956ee727644f571
          var palettes = testPalettes();
          for (Palette palette : palettes) {
              palette.setAll((x, y, z) -> 1);
-@@ -219,7 +219,7 @@ public class PaletteTest {
+@@ -219,7 +220,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -5057,7 +5265,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..583214ea6d1a4bb59956ee727644f571
          var palettes = testPalettes();
          for (Palette palette : palettes) {
              palette.getAllPresent((x, y, z, value) -> fail("The palette should be empty"));
-@@ -234,7 +234,7 @@ public class PaletteTest {
+@@ -234,7 +235,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -5066,7 +5274,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..583214ea6d1a4bb59956ee727644f571
          var palettes = testPalettes();
          for (Palette palette : palettes) {
              palette.setAll((x, y, z) -> x + y + z + 1);
-@@ -247,7 +247,7 @@ public class PaletteTest {
+@@ -247,7 +248,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -5075,7 +5283,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..583214ea6d1a4bb59956ee727644f571
          var palettes = testPalettes();
          for (Palette palette : palettes) {
              palette.set(0, 0, 0, 1);
-@@ -260,7 +260,7 @@ public class PaletteTest {
+@@ -260,7 +261,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -5084,7 +5292,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..583214ea6d1a4bb59956ee727644f571
          var palette = Palette.newPalette(2, 15, 4);
          palette.setAll((x, y, z) -> x + y + z);
          final int dimension = palette.dimension();
-@@ -274,7 +274,7 @@ public class PaletteTest {
+@@ -274,7 +275,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -5094,12 +5302,14 @@ index 3372ade456530be692de5f74e8c9515d32614df2..583214ea6d1a4bb59956ee727644f571
          assertThrows(Exception.class, () -> Palette.newPalette(0, 5, 3));
          assertThrows(Exception.class, () -> Palette.newPalette(1, 5, 3));
 diff --git a/src/test/java/net/minestom/server/inventory/InventoryIntegrationTest.java b/src/test/java/net/minestom/server/inventory/InventoryIntegrationTest.java
-index d0df75b49e882760cc1813ff813c2882a5870c61..ed95d0daf7d90aa7e7ab926500766416aacfc21b 100644
+index d0df75b49e882760cc1813ff813c2882a5870c61..c571ed725611a8cb3648b33ed02e3ed95403b914 100644
 --- a/src/test/java/net/minestom/server/inventory/InventoryIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/inventory/InventoryIntegrationTest.java
-@@ -15,12 +15,12 @@ import org.junit.jupiter.api.Test;
+@@ -14,13 +14,14 @@ import org.junit.jupiter.api.Test;
+ 
  import static org.junit.jupiter.api.Assertions.*;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class InventoryIntegrationTest {
 +class InventoryIntegrationTest {
@@ -5112,7 +5322,7 @@ index d0df75b49e882760cc1813ff813c2882a5870c61..ed95d0daf7d90aa7e7ab926500766416
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -44,7 +44,7 @@ public class InventoryIntegrationTest {
+@@ -44,7 +45,7 @@ public class InventoryIntegrationTest {
      }
  
      @Test
@@ -5121,7 +5331,7 @@ index d0df75b49e882760cc1813ff813c2882a5870c61..ed95d0daf7d90aa7e7ab926500766416
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -68,7 +68,7 @@ public class InventoryIntegrationTest {
+@@ -68,7 +69,7 @@ public class InventoryIntegrationTest {
      }
  
      @Test
@@ -5130,7 +5340,7 @@ index d0df75b49e882760cc1813ff813c2882a5870c61..ed95d0daf7d90aa7e7ab926500766416
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -111,7 +111,7 @@ public class InventoryIntegrationTest {
+@@ -111,7 +112,7 @@ public class InventoryIntegrationTest {
      }
  
      @Test
@@ -5139,7 +5349,7 @@ index d0df75b49e882760cc1813ff813c2882a5870c61..ed95d0daf7d90aa7e7ab926500766416
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -123,7 +123,7 @@ public class InventoryIntegrationTest {
+@@ -123,7 +124,7 @@ public class InventoryIntegrationTest {
      }
  
      @Test
@@ -5149,19 +5359,20 @@ index d0df75b49e882760cc1813ff813c2882a5870c61..ed95d0daf7d90aa7e7ab926500766416
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
 diff --git a/src/test/java/net/minestom/server/inventory/InventoryTest.java b/src/test/java/net/minestom/server/inventory/InventoryTest.java
-index 612e3b162f38d6367dc016530270e38d46913281..2f3e637b8939987726dd15fdfedafdca51b9cf48 100644
+index 612e3b162f38d6367dc016530270e38d46913281..890593bc7df9ec1ceadf871d4872bde53894e2d7 100644
 --- a/src/test/java/net/minestom/server/inventory/InventoryTest.java
 +++ b/src/test/java/net/minestom/server/inventory/InventoryTest.java
-@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
+@@ -8,7 +8,8 @@ import org.junit.jupiter.api.Test;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class InventoryTest {
++//Microtus - update java keyword usage
 +class InventoryTest {
  
      static {
          // Required to prevent initialization error during event call
-@@ -16,7 +16,7 @@ public class InventoryTest {
+@@ -16,7 +17,7 @@ public class InventoryTest {
      }
  
      @Test
@@ -5170,7 +5381,7 @@ index 612e3b162f38d6367dc016530270e38d46913281..2f3e637b8939987726dd15fdfedafdca
          Inventory inventory = new Inventory(InventoryType.CHEST_1_ROW, "title");
          assertEquals(InventoryType.CHEST_1_ROW, inventory.getInventoryType());
          assertEquals(Component.text("title"), inventory.getTitle());
-@@ -26,7 +26,7 @@ public class InventoryTest {
+@@ -26,7 +27,7 @@ public class InventoryTest {
      }
  
      @Test
@@ -5179,7 +5390,7 @@ index 612e3b162f38d6367dc016530270e38d46913281..2f3e637b8939987726dd15fdfedafdca
          var item1 = ItemStack.of(Material.DIAMOND);
          var item2 = ItemStack.of(Material.GOLD_INGOT);
  
-@@ -52,7 +52,7 @@ public class InventoryTest {
+@@ -52,7 +53,7 @@ public class InventoryTest {
      }
  
      @Test
@@ -5188,7 +5399,7 @@ index 612e3b162f38d6367dc016530270e38d46913281..2f3e637b8939987726dd15fdfedafdca
          ItemStack item = ItemStack.of(Material.DIAMOND, 32);
          Inventory inventory = new Inventory(InventoryType.CHEST_1_ROW, "title");
          inventory.setItemStack(0, item);
-@@ -66,7 +66,7 @@ public class InventoryTest {
+@@ -66,7 +67,7 @@ public class InventoryTest {
      }
  
      @Test
@@ -5197,7 +5408,7 @@ index 612e3b162f38d6367dc016530270e38d46913281..2f3e637b8939987726dd15fdfedafdca
          Inventory inventory = new Inventory(InventoryType.HOPPER, "title");
          assertTrue(inventory.addItemStack(ItemStack.of(Material.DIAMOND, 32), TransactionOption.ALL_OR_NOTHING));
          assertTrue(inventory.addItemStack(ItemStack.of(Material.GOLD_BLOCK, 32), TransactionOption.ALL_OR_NOTHING));
-@@ -77,7 +77,7 @@ public class InventoryTest {
+@@ -77,7 +78,7 @@ public class InventoryTest {
      }
  
      @Test
@@ -5207,12 +5418,14 @@ index 612e3b162f38d6367dc016530270e38d46913281..2f3e637b8939987726dd15fdfedafdca
              final byte windowId = new Inventory(InventoryType.CHEST_1_ROW, "title").getWindowId();
              assertTrue(windowId > 0);
 diff --git a/src/test/java/net/minestom/server/inventory/PlayerInventoryIntegrationTest.java b/src/test/java/net/minestom/server/inventory/PlayerInventoryIntegrationTest.java
-index 268a34a27684778f116dbbed910a67fff8ffbfc7..762d5e53f5ee07b36ecda7e68ca6e1b4fb95ccfd 100644
+index 268a34a27684778f116dbbed910a67fff8ffbfc7..3d9f5c323bfef881f647116f66713b847ccf856f 100644
 --- a/src/test/java/net/minestom/server/inventory/PlayerInventoryIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/inventory/PlayerInventoryIntegrationTest.java
-@@ -16,12 +16,12 @@ import java.util.Map;
+@@ -15,13 +15,14 @@ import java.util.Map;
+ 
  import static org.junit.jupiter.api.Assertions.*;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class PlayerInventoryIntegrationTest {
 +class PlayerInventoryIntegrationTest {
@@ -5225,7 +5438,7 @@ index 268a34a27684778f116dbbed910a67fff8ffbfc7..762d5e53f5ee07b36ecda7e68ca6e1b4
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -41,7 +41,7 @@ public class PlayerInventoryIntegrationTest {
+@@ -41,7 +42,7 @@ public class PlayerInventoryIntegrationTest {
      }
  
      @Test
@@ -5234,7 +5447,7 @@ index 268a34a27684778f116dbbed910a67fff8ffbfc7..762d5e53f5ee07b36ecda7e68ca6e1b4
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -61,7 +61,7 @@ public class PlayerInventoryIntegrationTest {
+@@ -61,7 +62,7 @@ public class PlayerInventoryIntegrationTest {
      }
  
      @Test
@@ -5243,7 +5456,7 @@ index 268a34a27684778f116dbbed910a67fff8ffbfc7..762d5e53f5ee07b36ecda7e68ca6e1b4
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -105,7 +105,7 @@ public class PlayerInventoryIntegrationTest {
+@@ -105,7 +106,7 @@ public class PlayerInventoryIntegrationTest {
      }
  
      @Test
@@ -5252,7 +5465,7 @@ index 268a34a27684778f116dbbed910a67fff8ffbfc7..762d5e53f5ee07b36ecda7e68ca6e1b4
          var instance = env.createFlatInstance();
          var connectionArmored = env.createConnection();
          var playerArmored = connectionArmored.connect(instance, new Pos(0, 42, 0)).join();
-@@ -119,9 +119,7 @@ public class PlayerInventoryIntegrationTest {
+@@ -119,9 +120,7 @@ public class PlayerInventoryIntegrationTest {
  
          // Setting to an item should send EntityEquipmentPacket to viewer
          playerArmored.getInventory().setEquipment(EquipmentSlot.HELMET, MAGIC_STACK);
@@ -5263,7 +5476,7 @@ index 268a34a27684778f116dbbed910a67fff8ffbfc7..762d5e53f5ee07b36ecda7e68ca6e1b4
  
          // Setting to the same item shouldn't send packet
          equipmentTracker = connectionViewer.trackIncoming(EntityEquipmentPacket.class);
-@@ -131,13 +129,11 @@ public class PlayerInventoryIntegrationTest {
+@@ -131,13 +130,11 @@ public class PlayerInventoryIntegrationTest {
          // Setting to air should send packet
          equipmentTracker = connectionViewer.trackIncoming(EntityEquipmentPacket.class);
          playerArmored.getInventory().setEquipment(EquipmentSlot.HELMET, ItemStack.AIR);
@@ -5279,7 +5492,7 @@ index 268a34a27684778f116dbbed910a67fff8ffbfc7..762d5e53f5ee07b36ecda7e68ca6e1b4
          var instance = env.createFlatInstance();
          var connectionHolder = env.createConnection();
          var playerHolder = connectionHolder.connect(instance, new Pos(0, 42, 0)).join();
-@@ -152,23 +148,17 @@ public class PlayerInventoryIntegrationTest {
+@@ -152,23 +149,17 @@ public class PlayerInventoryIntegrationTest {
          // Setting held item
          var equipmentTracker = connectionViewer.trackIncoming(EntityEquipmentPacket.class);
          playerHolder.setItemInMainHand(MAGIC_STACK);
@@ -5307,14 +5520,15 @@ index 268a34a27684778f116dbbed910a67fff8ffbfc7..762d5e53f5ee07b36ecda7e68ca6e1b4
  
  }
 diff --git a/src/test/java/net/minestom/server/inventory/PlayerSlotConversionTest.java b/src/test/java/net/minestom/server/inventory/PlayerSlotConversionTest.java
-index 992051039124e3bf50dd4d667cb7433195f8c735..20e112920723b6046de91875a49757bf2c8a4058 100644
+index 992051039124e3bf50dd4d667cb7433195f8c735..3809de5a1c13c69d36b550ff68037af91f9ebd66 100644
 --- a/src/test/java/net/minestom/server/inventory/PlayerSlotConversionTest.java
 +++ b/src/test/java/net/minestom/server/inventory/PlayerSlotConversionTest.java
-@@ -8,10 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -8,10 +8,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  /**
   * Test conversion from packet slots to internal ones (used in events and inventory methods)
   */
 -public class PlayerSlotConversionTest {
++//Microtus - update java keyword usage
 +class PlayerSlotConversionTest {
  
      @Test
@@ -5323,7 +5537,7 @@ index 992051039124e3bf50dd4d667cb7433195f8c735..20e112920723b6046de91875a49757bf
          // Convert 36-44 into 0-8
          for (int i = 0; i < 9; i++) {
              assertEquals(i, convertPlayerInventorySlot(i + 36, OFFSET));
-@@ -19,7 +19,7 @@ public class PlayerSlotConversionTest {
+@@ -19,7 +20,7 @@ public class PlayerSlotConversionTest {
      }
  
      @Test
@@ -5332,7 +5546,7 @@ index 992051039124e3bf50dd4d667cb7433195f8c735..20e112920723b6046de91875a49757bf
          // No conversion, slots should stay 9-35
          for (int i = 9; i < 9 * 4; i++) {
              assertEquals(i, convertPlayerInventorySlot(i, OFFSET));
-@@ -27,7 +27,7 @@ public class PlayerSlotConversionTest {
+@@ -27,7 +28,7 @@ public class PlayerSlotConversionTest {
      }
  
      @Test
@@ -5341,7 +5555,7 @@ index 992051039124e3bf50dd4d667cb7433195f8c735..20e112920723b6046de91875a49757bf
          assertEquals(HELMET_SLOT, 41);
          assertEquals(CHESTPLATE_SLOT, 42);
          assertEquals(LEGGINGS_SLOT, 43);
-@@ -43,7 +43,7 @@ public class PlayerSlotConversionTest {
+@@ -43,7 +44,7 @@ public class PlayerSlotConversionTest {
      }
  
      @Test
@@ -5351,12 +5565,14 @@ index 992051039124e3bf50dd4d667cb7433195f8c735..20e112920723b6046de91875a49757bf
          assertEquals(CRAFT_SLOT_1, 37);
          assertEquals(CRAFT_SLOT_2, 38);
 diff --git a/src/test/java/net/minestom/server/inventory/click/integration/HeldClickIntegrationTest.java b/src/test/java/net/minestom/server/inventory/click/integration/HeldClickIntegrationTest.java
-index 93069a5a925fda0d289e03b72281b92d795ac4c2..55145c0001750c019f83135800e4481e7f89bd28 100644
+index 93069a5a925fda0d289e03b72281b92d795ac4c2..2061eda80fd9024e8684d8eb66457727767bc9dc 100644
 --- a/src/test/java/net/minestom/server/inventory/click/integration/HeldClickIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/inventory/click/integration/HeldClickIntegrationTest.java
-@@ -19,10 +19,10 @@ import java.util.List;
+@@ -18,11 +18,12 @@ import java.util.List;
+ 
  import static org.junit.jupiter.api.Assertions.*;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class HeldClickIntegrationTest {
 +class HeldClickIntegrationTest {
@@ -5367,7 +5583,7 @@ index 93069a5a925fda0d289e03b72281b92d795ac4c2..55145c0001750c019f83135800e4481e
          var instance = env.createFlatInstance();
          var player = env.createPlayer(instance, new Pos(0, 40, 0));
          var inventory = player.getInventory();
-@@ -96,7 +96,7 @@ public class HeldClickIntegrationTest {
+@@ -96,7 +97,7 @@ public class HeldClickIntegrationTest {
      }
  
      @Test
@@ -5377,12 +5593,14 @@ index 93069a5a925fda0d289e03b72281b92d795ac4c2..55145c0001750c019f83135800e4481e
          var player = env.createPlayer(instance, new Pos(0, 40, 0));
          var inventory = new Inventory(InventoryType.HOPPER, "test");
 diff --git a/src/test/java/net/minestom/server/inventory/click/integration/LeftClickIntegrationTest.java b/src/test/java/net/minestom/server/inventory/click/integration/LeftClickIntegrationTest.java
-index 87a81674699095298ef8614417497025bb70b479..57639fad9010c6e1d271bf27d83efed5d2026af9 100644
+index 87a81674699095298ef8614417497025bb70b479..17584cba14f4e071255bbb8db863be071f34de9a 100644
 --- a/src/test/java/net/minestom/server/inventory/click/integration/LeftClickIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/inventory/click/integration/LeftClickIntegrationTest.java
-@@ -21,10 +21,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -20,11 +20,12 @@ import java.util.List;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class LeftClickIntegrationTest {
 +class LeftClickIntegrationTest {
@@ -5393,7 +5611,7 @@ index 87a81674699095298ef8614417497025bb70b479..57639fad9010c6e1d271bf27d83efed5
          var instance = env.createFlatInstance();
          var player = env.createPlayer(instance, new Pos(0, 40, 0));
          var inventory = player.getInventory();
-@@ -82,7 +82,7 @@ public class LeftClickIntegrationTest {
+@@ -82,7 +83,7 @@ public class LeftClickIntegrationTest {
      }
  
      @Test
@@ -5403,12 +5621,14 @@ index 87a81674699095298ef8614417497025bb70b479..57639fad9010c6e1d271bf27d83efed5
          var player = env.createPlayer(instance, new Pos(0, 40, 0));
          var inventory = new Inventory(InventoryType.HOPPER, "test");
 diff --git a/src/test/java/net/minestom/server/inventory/click/integration/RightClickIntegrationTest.java b/src/test/java/net/minestom/server/inventory/click/integration/RightClickIntegrationTest.java
-index c4e4b6e403c628346273597f87507870e62860d3..ca2706d6dd9aa201043c921ee187bbb48c8df3bd 100644
+index c4e4b6e403c628346273597f87507870e62860d3..aaa1c0012e96426897a7fc3c2d8fe1a37a6db892 100644
 --- a/src/test/java/net/minestom/server/inventory/click/integration/RightClickIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/inventory/click/integration/RightClickIntegrationTest.java
-@@ -20,10 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -19,11 +19,12 @@ import java.util.List;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class RightClickIntegrationTest {
 +class RightClickIntegrationTest {
@@ -5419,7 +5639,7 @@ index c4e4b6e403c628346273597f87507870e62860d3..ca2706d6dd9aa201043c921ee187bbb4
          var instance = env.createFlatInstance();
          var player = env.createPlayer(instance, new Pos(0, 40, 0));
          var inventory = player.getInventory();
-@@ -104,7 +104,7 @@ public class RightClickIntegrationTest {
+@@ -104,7 +105,7 @@ public class RightClickIntegrationTest {
      }
  
      @Test
@@ -5429,14 +5649,15 @@ index c4e4b6e403c628346273597f87507870e62860d3..ca2706d6dd9aa201043c921ee187bbb4
          var player = env.createPlayer(instance, new Pos(0, 40, 0));
          var inventory = new Inventory(InventoryType.HOPPER, "test");
 diff --git a/src/test/java/net/minestom/server/item/ItemAirTest.java b/src/test/java/net/minestom/server/item/ItemAirTest.java
-index db3d855f8114fe9cf0e2e61e834dd3de1157a135..17720b6b3b43d6b92c590864467dbfbac547609e 100644
+index db3d855f8114fe9cf0e2e61e834dd3de1157a135..e715204e06627e37634cc3f89d1ca4dbbef3e588 100644
 --- a/src/test/java/net/minestom/server/item/ItemAirTest.java
 +++ b/src/test/java/net/minestom/server/item/ItemAirTest.java
-@@ -4,9 +4,9 @@ import org.junit.jupiter.api.Test;
+@@ -4,9 +4,10 @@ import org.junit.jupiter.api.Test;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class ItemAirTest {
++//Microtus - update java keyword usage
 +class ItemAirTest {
      @Test
 -    public void testAir() {
@@ -5445,7 +5666,7 @@ index db3d855f8114fe9cf0e2e61e834dd3de1157a135..17720b6b3b43d6b92c590864467dbfba
          assertFalse(item.isAir());
          assertTrue(ItemStack.AIR.isAir());
 diff --git a/src/test/java/net/minestom/server/item/ItemAttributeTest.java b/src/test/java/net/minestom/server/item/ItemAttributeTest.java
-index 4111ba13173056cfc36b9c9602f62e33f6ae98a5..f8ea7c7d8c1b68b1914732c290f6936a318a12ee 100644
+index 4111ba13173056cfc36b9c9602f62e33f6ae98a5..c8b96d5576948b74ba6f07ea88a5c0f66fbf2f59 100644
 --- a/src/test/java/net/minestom/server/item/ItemAttributeTest.java
 +++ b/src/test/java/net/minestom/server/item/ItemAttributeTest.java
 @@ -5,9 +5,6 @@ import net.minestom.server.attribute.AttributeOperation;
@@ -5458,11 +5679,12 @@ index 4111ba13173056cfc36b9c9602f62e33f6ae98a5..f8ea7c7d8c1b68b1914732c290f6936a
  import org.junit.jupiter.api.Test;
  
  import java.util.List;
-@@ -16,10 +13,10 @@ import java.util.UUID;
+@@ -16,10 +13,11 @@ import java.util.UUID;
  import static net.minestom.testing.TestUtils.assertEqualsSNBT;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
 -public class ItemAttributeTest {
++//Microtus - update java keyword usage
 +class ItemAttributeTest {
  
      @Test
@@ -5471,7 +5693,7 @@ index 4111ba13173056cfc36b9c9602f62e33f6ae98a5..f8ea7c7d8c1b68b1914732c290f6936a
          var attributes = List.of(new ItemAttribute(
                  new UUID(0, 0), "generic.attack_damage", Attribute.ATTACK_DAMAGE,
                  AttributeOperation.ADDITION, 2, AttributeSlot.MAINHAND));
-@@ -30,7 +27,7 @@ public class ItemAttributeTest {
+@@ -30,7 +28,7 @@ public class ItemAttributeTest {
      }
  
      @Test
@@ -5480,7 +5702,7 @@ index 4111ba13173056cfc36b9c9602f62e33f6ae98a5..f8ea7c7d8c1b68b1914732c290f6936a
          var attributes = List.of(new ItemAttribute(
                  new UUID(0, 0), "generic.attack_damage", Attribute.ATTACK_DAMAGE,
                  AttributeOperation.ADDITION, 2, AttributeSlot.MAINHAND));
-@@ -43,7 +40,7 @@ public class ItemAttributeTest {
+@@ -43,7 +41,7 @@ public class ItemAttributeTest {
      }
  
      @Test
@@ -5490,14 +5712,15 @@ index 4111ba13173056cfc36b9c9602f62e33f6ae98a5..f8ea7c7d8c1b68b1914732c290f6936a
                  .meta(builder -> builder.attributes(
                          List.of(new ItemAttribute(
 diff --git a/src/test/java/net/minestom/server/item/ItemBlockTest.java b/src/test/java/net/minestom/server/item/ItemBlockTest.java
-index 495e3de4962bdae90b9392c9ea4629d09eb966c2..5eda2abf47994345b2be8a7fe4dbf511039ae4aa 100644
+index 495e3de4962bdae90b9392c9ea4629d09eb966c2..363686964e904b3762cc4dd2181ecb4b4477ef01 100644
 --- a/src/test/java/net/minestom/server/item/ItemBlockTest.java
 +++ b/src/test/java/net/minestom/server/item/ItemBlockTest.java
-@@ -6,10 +6,10 @@ import org.junit.jupiter.api.Test;
+@@ -6,10 +6,11 @@ import org.junit.jupiter.api.Test;
  import static net.minestom.testing.TestUtils.assertEqualsSNBT;
  import static org.junit.jupiter.api.Assertions.assertTrue;
  
 -public class ItemBlockTest {
++//Microtus - update java keyword usage
 +class ItemBlockTest {
  
      @Test
@@ -5506,7 +5729,7 @@ index 495e3de4962bdae90b9392c9ea4629d09eb966c2..5eda2abf47994345b2be8a7fe4dbf511
          var item = ItemStack.builder(Material.STONE)
                  .meta(builder -> builder.canPlaceOn(Block.STONE))
                  .build();
-@@ -18,7 +18,7 @@ public class ItemBlockTest {
+@@ -18,7 +19,7 @@ public class ItemBlockTest {
      }
  
      @Test
@@ -5515,7 +5738,7 @@ index 495e3de4962bdae90b9392c9ea4629d09eb966c2..5eda2abf47994345b2be8a7fe4dbf511
          var item = ItemStack.builder(Material.STONE)
                  .meta(builder -> builder.canPlaceOn(Block.STONE))
                  .build();
-@@ -28,7 +28,7 @@ public class ItemBlockTest {
+@@ -28,7 +29,7 @@ public class ItemBlockTest {
      }
  
      @Test
@@ -5524,7 +5747,7 @@ index 495e3de4962bdae90b9392c9ea4629d09eb966c2..5eda2abf47994345b2be8a7fe4dbf511
          var item = ItemStack.builder(Material.STONE)
                  .meta(builder -> builder.canPlaceOn(Block.SANDSTONE_STAIRS.withProperty("facing", "south")))
                  .build();
-@@ -38,7 +38,7 @@ public class ItemBlockTest {
+@@ -38,7 +39,7 @@ public class ItemBlockTest {
      }
  
      @Test
@@ -5533,7 +5756,7 @@ index 495e3de4962bdae90b9392c9ea4629d09eb966c2..5eda2abf47994345b2be8a7fe4dbf511
          var item = ItemStack.builder(Material.STONE)
                  .meta(builder -> builder.canDestroy(Block.STONE))
                  .build();
-@@ -47,7 +47,7 @@ public class ItemBlockTest {
+@@ -47,7 +48,7 @@ public class ItemBlockTest {
      }
  
      @Test
@@ -5542,7 +5765,7 @@ index 495e3de4962bdae90b9392c9ea4629d09eb966c2..5eda2abf47994345b2be8a7fe4dbf511
          var item = ItemStack.builder(Material.STONE)
                  .meta(builder -> builder.canDestroy(Block.STONE))
                  .build();
-@@ -57,7 +57,7 @@ public class ItemBlockTest {
+@@ -57,7 +58,7 @@ public class ItemBlockTest {
      }
  
      @Test
@@ -5552,14 +5775,15 @@ index 495e3de4962bdae90b9392c9ea4629d09eb966c2..5eda2abf47994345b2be8a7fe4dbf511
                  .meta(builder -> builder.canDestroy(Block.SANDSTONE_STAIRS.withProperty("facing", "south")))
                  .build();
 diff --git a/src/test/java/net/minestom/server/item/ItemDisplayTest.java b/src/test/java/net/minestom/server/item/ItemDisplayTest.java
-index 87700dc15cf193078b0da417f1129a41d80fec7e..98072ec96294ae4d61fee6252b446bbe2d5d4167 100644
+index 87700dc15cf193078b0da417f1129a41d80fec7e..d02e09758b75d8c3d5dfc20ee4cf3a221b87b8a0 100644
 --- a/src/test/java/net/minestom/server/item/ItemDisplayTest.java
 +++ b/src/test/java/net/minestom/server/item/ItemDisplayTest.java
-@@ -10,10 +10,10 @@ import java.util.stream.Stream;
+@@ -10,10 +10,11 @@ import java.util.stream.Stream;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class ItemDisplayTest {
++//Microtus - update java keyword usage
 +class ItemDisplayTest {
  
      @Test
@@ -5569,14 +5793,15 @@ index 87700dc15cf193078b0da417f1129a41d80fec7e..98072ec96294ae4d61fee6252b446bbe
          assertEquals(List.of(), item.getLore());
          assertNull(item.meta().toNBT().get("display"));
 diff --git a/src/test/java/net/minestom/server/item/ItemEnchantTest.java b/src/test/java/net/minestom/server/item/ItemEnchantTest.java
-index 46f818bcb3e2c8651be5dcf9e9e8fabb0a73cea7..bae7902020fa913c163c25966cc13a7245bf907b 100644
+index 46f818bcb3e2c8651be5dcf9e9e8fabb0a73cea7..6d2797cf6f15e60e72b8048ad008883ed384a9c9 100644
 --- a/src/test/java/net/minestom/server/item/ItemEnchantTest.java
 +++ b/src/test/java/net/minestom/server/item/ItemEnchantTest.java
-@@ -7,22 +7,22 @@ import java.util.Map;
+@@ -7,22 +7,23 @@ import java.util.Map;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertTrue;
  
 -public class ItemEnchantTest {
++//Microtus - update java keyword usage
 +class ItemEnchantTest {
  
      @Test
@@ -5600,14 +5825,15 @@ index 46f818bcb3e2c8651be5dcf9e9e8fabb0a73cea7..bae7902020fa913c163c25966cc13a72
          assertEquals(enchantments.get(Enchantment.INFINITY), (short) 5);
  
 diff --git a/src/test/java/net/minestom/server/item/ItemMetaTest.java b/src/test/java/net/minestom/server/item/ItemMetaTest.java
-index fc8d2b7faf989c1e5003e3fc24de98ef25151430..43b17d140000b1d1341293adc7cf263d33557319 100644
+index fc8d2b7faf989c1e5003e3fc24de98ef25151430..931a2be1b4888bfd1c65cfbde61b8161fcb6b49c 100644
 --- a/src/test/java/net/minestom/server/item/ItemMetaTest.java
 +++ b/src/test/java/net/minestom/server/item/ItemMetaTest.java
-@@ -18,22 +18,22 @@ import java.util.UUID;
+@@ -18,22 +18,23 @@ import java.util.UUID;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNotNull;
  
 -public class ItemMetaTest {
++//Microtus - update java keyword usage
 +class ItemMetaTest {
      @Test
 -    public void defaultMeta() {
@@ -5630,7 +5856,7 @@ index fc8d2b7faf989c1e5003e3fc24de98ef25151430..43b17d140000b1d1341293adc7cf263d
          var item = ItemStack.builder(Material.BUNDLE)
                  .meta(BundleMeta.class, bundleMetaBuilder -> {
                      bundleMetaBuilder.addItem(ItemStack.of(Material.DIAMOND, 5));
-@@ -44,7 +44,7 @@ public class ItemMetaTest {
+@@ -44,7 +45,7 @@ public class ItemMetaTest {
      }
  
      @Test
@@ -5640,14 +5866,15 @@ index fc8d2b7faf989c1e5003e3fc24de98ef25151430..43b17d140000b1d1341293adc7cf263d
          var skin = new PlayerSkin("xx", "yy");
          var meta = new PlayerHeadMeta.Builder()
 diff --git a/src/test/java/net/minestom/server/item/ItemMetaViewTest.java b/src/test/java/net/minestom/server/item/ItemMetaViewTest.java
-index 4c20e7b822990b4e2e0baeb1de0a2a6d9ddd53ab..d39bb6024fc06807a14ac9db52bac54e1fb5b358 100644
+index 4c20e7b822990b4e2e0baeb1de0a2a6d9ddd53ab..2a4eb1244f12111827d7ceddc81bdd2eec647aab 100644
 --- a/src/test/java/net/minestom/server/item/ItemMetaViewTest.java
 +++ b/src/test/java/net/minestom/server/item/ItemMetaViewTest.java
-@@ -7,14 +7,14 @@ import org.junit.jupiter.api.Test;
+@@ -7,14 +7,15 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertInstanceOf;
  
 -public class ItemMetaViewTest {
++//Microtus - update java keyword usage
 +class ItemMetaViewTest {
      @Test
 -    public void viewType() {
@@ -5662,14 +5889,15 @@ index 4c20e7b822990b4e2e0baeb1de0a2a6d9ddd53ab..d39bb6024fc06807a14ac9db52bac54e
      }
  }
 diff --git a/src/test/java/net/minestom/server/item/ItemMetaWrittenBookTest.java b/src/test/java/net/minestom/server/item/ItemMetaWrittenBookTest.java
-index f8eb46b2fb547a5052659fe963223ef1e5adecc4..fc6891e20469de757dcc05d5e861cdc0a7a3be2f 100644
+index f8eb46b2fb547a5052659fe963223ef1e5adecc4..d7494c40c2a2c541d8749aa556fd4b261cd432fa 100644
 --- a/src/test/java/net/minestom/server/item/ItemMetaWrittenBookTest.java
 +++ b/src/test/java/net/minestom/server/item/ItemMetaWrittenBookTest.java
-@@ -18,9 +18,9 @@ import java.util.List;
+@@ -18,9 +18,10 @@ import java.util.List;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.fail;
  
 -public class ItemMetaWrittenBookTest {
++//Microtus - update java keyword usage
 +class ItemMetaWrittenBookTest {
      @Test
 -    public void testPages() {
@@ -5677,7 +5905,7 @@ index f8eb46b2fb547a5052659fe963223ef1e5adecc4..fc6891e20469de757dcc05d5e861cdc0
          ItemStack book = ItemStack.of(Material.WRITTEN_BOOK);
  
          Component pageA = Component.text("Page A");
-@@ -36,7 +36,7 @@ public class ItemMetaWrittenBookTest {
+@@ -36,7 +37,7 @@ public class ItemMetaWrittenBookTest {
      }
  
      @Test
@@ -5686,7 +5914,7 @@ index f8eb46b2fb547a5052659fe963223ef1e5adecc4..fc6891e20469de757dcc05d5e861cdc0
          List<TextColor> colors = List.of(NamedTextColor.BLUE, NamedTextColor.WHITE, NamedTextColor.DARK_BLUE);
          List<TextDecoration> decorations = List.of(TextDecoration.UNDERLINED, TextDecoration.STRIKETHROUGH, TextDecoration.ITALIC);
          List<ClickEvent> clicks = List.of(
-@@ -79,7 +79,7 @@ public class ItemMetaWrittenBookTest {
+@@ -79,7 +80,7 @@ public class ItemMetaWrittenBookTest {
      }
  
      @Test
@@ -5696,14 +5924,15 @@ index f8eb46b2fb547a5052659fe963223ef1e5adecc4..fc6891e20469de757dcc05d5e861cdc0
  {
      pages:['[
 diff --git a/src/test/java/net/minestom/server/item/ItemTest.java b/src/test/java/net/minestom/server/item/ItemTest.java
-index c7fa1ca1fd0a6d4a8180581e8f1aa3962ab51f01..4171f07682bf707e5e314d15a4c79e8e0e941d4a 100644
+index c7fa1ca1fd0a6d4a8180581e8f1aa3962ab51f01..86cc7e967d323c2f057b769474fa258afd3fc6c8 100644
 --- a/src/test/java/net/minestom/server/item/ItemTest.java
 +++ b/src/test/java/net/minestom/server/item/ItemTest.java
-@@ -9,40 +9,40 @@ import java.util.Map;
+@@ -9,40 +9,41 @@ import java.util.Map;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class ItemTest {
++//Microtus - update java keyword usage
 +class ItemTest {
  
      @Test
@@ -5750,7 +5979,7 @@ index c7fa1ca1fd0a6d4a8180581e8f1aa3962ab51f01..4171f07682bf707e5e314d15a4c79e8e
          var item1 = ItemStack.of(Material.DIAMOND_SWORD);
          var item2 = ItemStack.of(Material.DIAMOND_SWORD);
          assertEquals(item1, item2);
-@@ -54,7 +54,7 @@ public class ItemTest {
+@@ -54,7 +55,7 @@ public class ItemTest {
      }
  
      @Test
@@ -5759,7 +5988,7 @@ index c7fa1ca1fd0a6d4a8180581e8f1aa3962ab51f01..4171f07682bf707e5e314d15a4c79e8e
          var itemNbt = createItem().toItemNBT();
          assertEquals(itemNbt.getString("id"), createItem().material().name(), "id string should be the material name");
          assertEquals(itemNbt.getByte("Count"), (byte) createItem().amount(), "Count byte should be the item amount");
-@@ -64,7 +64,7 @@ public class ItemTest {
+@@ -64,7 +65,7 @@ public class ItemTest {
      }
  
      @Test
@@ -5768,7 +5997,7 @@ index c7fa1ca1fd0a6d4a8180581e8f1aa3962ab51f01..4171f07682bf707e5e314d15a4c79e8e
          var itemNbt = createItem().toItemNBT();
          var item = ItemStack.fromItemNBT(itemNbt);
          assertEquals(createItem(), item, "Items must be equal if created from the same item nbt");
-@@ -76,7 +76,7 @@ public class ItemTest {
+@@ -76,7 +77,7 @@ public class ItemTest {
      }
  
      @Test
@@ -5777,7 +6006,7 @@ index c7fa1ca1fd0a6d4a8180581e8f1aa3962ab51f01..4171f07682bf707e5e314d15a4c79e8e
          var builder = ItemStack.builder(Material.DIAMOND);
          var item1 = builder.build();
          var item2 = builder.displayName(Component.text("Name")).build();
-@@ -86,7 +86,7 @@ public class ItemTest {
+@@ -86,7 +87,7 @@ public class ItemTest {
      }
  
      @Test
@@ -5786,7 +6015,7 @@ index c7fa1ca1fd0a6d4a8180581e8f1aa3962ab51f01..4171f07682bf707e5e314d15a4c79e8e
          var nbt = NBT.Compound(Map.of("key", NBT.String("value")));
          var item1 = ItemStack.fromNBT(Material.DIAMOND, nbt, 5);
          var item2 = item1.withMaterial(Material.GOLD_INGOT);
-@@ -102,7 +102,7 @@ public class ItemTest {
+@@ -102,7 +103,7 @@ public class ItemTest {
      }
  
      @Test
@@ -5796,14 +6025,15 @@ index c7fa1ca1fd0a6d4a8180581e8f1aa3962ab51f01..4171f07682bf707e5e314d15a4c79e8e
          assertEquals(5, item1.amount());
          assertEquals(6, item1.withAmount(6).amount());
 diff --git a/src/test/java/net/minestom/server/network/NetworkBufferTest.java b/src/test/java/net/minestom/server/network/NetworkBufferTest.java
-index 107e1c53a77414a300beb46143875dda25a4503f..ac349777f80d2711dcb120908ea8dd9b0e095fa3 100644
+index 107e1c53a77414a300beb46143875dda25a4503f..a6dfda4e5c7ce9f9c6aaafd2fe7f3d1b2330b446 100644
 --- a/src/test/java/net/minestom/server/network/NetworkBufferTest.java
 +++ b/src/test/java/net/minestom/server/network/NetworkBufferTest.java
-@@ -15,10 +15,10 @@ import static net.minestom.server.network.NetworkBuffer.*;
+@@ -15,10 +15,11 @@ import static net.minestom.server.network.NetworkBuffer.*;
  import static org.junit.jupiter.api.Assertions.assertArrayEquals;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
 -public class NetworkBufferTest {
++//Microtus - update java keyword usage
 +class NetworkBufferTest {
  
      @Test
@@ -5812,7 +6042,7 @@ index 107e1c53a77414a300beb46143875dda25a4503f..ac349777f80d2711dcb120908ea8dd9b
          var buffer = new NetworkBuffer(6);
          buffer.write(INT, 6);
          assertEquals(4, buffer.writeIndex());
-@@ -42,7 +42,7 @@ public class NetworkBufferTest {
+@@ -42,7 +43,7 @@ public class NetworkBufferTest {
      }
  
      @Test
@@ -5821,7 +6051,7 @@ index 107e1c53a77414a300beb46143875dda25a4503f..ac349777f80d2711dcb120908ea8dd9b
          var buffer = new NetworkBuffer();
          assertEquals(0, buffer.readableBytes());
  
-@@ -60,7 +60,7 @@ public class NetworkBufferTest {
+@@ -60,7 +61,7 @@ public class NetworkBufferTest {
      }
  
      @Test
@@ -5830,7 +6060,7 @@ index 107e1c53a77414a300beb46143875dda25a4503f..ac349777f80d2711dcb120908ea8dd9b
          var buffer = new NetworkBuffer();
  
          buffer.write(BYTE, (byte) 25);
-@@ -87,7 +87,7 @@ public class NetworkBufferTest {
+@@ -87,7 +88,7 @@ public class NetworkBufferTest {
      }
  
      @Test
@@ -5839,7 +6069,7 @@ index 107e1c53a77414a300beb46143875dda25a4503f..ac349777f80d2711dcb120908ea8dd9b
          assertArrayEquals(new byte[0], NetworkBuffer.makeArray(buffer -> {
          }));
  
-@@ -100,7 +100,7 @@ public class NetworkBufferTest {
+@@ -100,7 +101,7 @@ public class NetworkBufferTest {
      }
  
      @Test
@@ -5848,7 +6078,7 @@ index 107e1c53a77414a300beb46143875dda25a4503f..ac349777f80d2711dcb120908ea8dd9b
          assertBufferType(BOOLEAN, false, new byte[]{0x00});
          assertBufferType(BOOLEAN, true, new byte[]{0x01});
  
-@@ -193,7 +193,7 @@ public class NetworkBufferTest {
+@@ -193,7 +194,7 @@ public class NetworkBufferTest {
      }
  
      @Test
@@ -5857,7 +6087,7 @@ index 107e1c53a77414a300beb46143875dda25a4503f..ac349777f80d2711dcb120908ea8dd9b
          assertBufferType(VAR_INT, 0, new byte[]{0});
          assertBufferType(VAR_INT, 1, new byte[]{0x01});
          assertBufferType(VAR_INT, 2, new byte[]{0x02});
-@@ -209,7 +209,7 @@ public class NetworkBufferTest {
+@@ -209,7 +210,7 @@ public class NetworkBufferTest {
      }
  
      @Test
@@ -5866,7 +6096,7 @@ index 107e1c53a77414a300beb46143875dda25a4503f..ac349777f80d2711dcb120908ea8dd9b
          assertBufferType(VAR_LONG, 0L, new byte[]{0});
          assertBufferType(VAR_LONG, 1L, new byte[]{0x01});
          assertBufferType(VAR_LONG, 2L, new byte[]{0x02});
-@@ -224,49 +224,49 @@ public class NetworkBufferTest {
+@@ -224,49 +225,49 @@ public class NetworkBufferTest {
      }
  
      @Test
@@ -5925,7 +6155,7 @@ index 107e1c53a77414a300beb46143875dda25a4503f..ac349777f80d2711dcb120908ea8dd9b
          assertBufferTypeCollection(BOOLEAN, List.of(true), new byte[]{0x01, 0x01});
      }
 diff --git a/src/test/java/net/minestom/server/network/PacketWriteReadTest.java b/src/test/java/net/minestom/server/network/PacketWriteReadTest.java
-index 3e424c24f5c7064992c469439a0049f040ef038c..eb265352ab3a27a6bb8fb31df610027789570b83 100644
+index 3e424c24f5c7064992c469439a0049f040ef038c..57d14448eab5a9f1fba8ae6a5730ee6690cfc6f6 100644
 --- a/src/test/java/net/minestom/server/network/PacketWriteReadTest.java
 +++ b/src/test/java/net/minestom/server/network/PacketWriteReadTest.java
 @@ -1,15 +1,9 @@
@@ -5963,7 +6193,15 @@ index 3e424c24f5c7064992c469439a0049f040ef038c..eb265352ab3a27a6bb8fb31df6100277
  import java.util.ArrayList;
  import java.util.List;
  import java.util.Map;
-@@ -148,12 +135,12 @@ public class PacketWriteReadTest {
+@@ -50,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.fail;
+ /**
+  * Ensures that packet can be written and read correctly.
+  */
++//Microtus - update java keyword usage
+ public class PacketWriteReadTest {
+     private static final List<ServerPacket> SERVER_PACKETS = new ArrayList<>();
+     private static final List<ClientPacket> CLIENT_PACKETS = new ArrayList<>();
+@@ -148,12 +136,12 @@ public class PacketWriteReadTest {
      }
  
      @Test
@@ -5979,14 +6217,15 @@ index 3e424c24f5c7064992c469439a0049f040ef038c..eb265352ab3a27a6bb8fb31df6100277
      }
  
 diff --git a/src/test/java/net/minestom/server/network/SendablePacketTest.java b/src/test/java/net/minestom/server/network/SendablePacketTest.java
-index e1f05206055e80600e5fc3dcfb45599c081ab337..05527ae21b137891c54990d8a76f577bb47ad91b 100644
+index e1f05206055e80600e5fc3dcfb45599c081ab337..831a922cbc0f3256a4114f2df12a9227d03963c9 100644
 --- a/src/test/java/net/minestom/server/network/SendablePacketTest.java
 +++ b/src/test/java/net/minestom/server/network/SendablePacketTest.java
-@@ -11,10 +11,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
+@@ -11,10 +11,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class SendablePacketTest {
++//Microtus - update java keyword usage
 +class SendablePacketTest {
  
      @Test
@@ -5995,7 +6234,7 @@ index e1f05206055e80600e5fc3dcfb45599c081ab337..05527ae21b137891c54990d8a76f577b
          var packet = new SystemChatPacket(Component.text("Hello World!"), false);
          AtomicBoolean called = new AtomicBoolean(false);
          var lazy = new LazyPacket(() -> {
-@@ -27,7 +27,7 @@ public class SendablePacketTest {
+@@ -27,7 +28,7 @@ public class SendablePacketTest {
      }
  
      @Test
@@ -6005,14 +6244,15 @@ index e1f05206055e80600e5fc3dcfb45599c081ab337..05527ae21b137891c54990d8a76f577b
          var cached = new CachedPacket(packet);
          assertSame(packet, cached.packet());
 diff --git a/src/test/java/net/minestom/server/network/SocketReadTest.java b/src/test/java/net/minestom/server/network/SocketReadTest.java
-index 0f168ab61b905901d8aaca71d16526bcd8473d42..b86f9f16335d294f5ab0fe2b8211713aa99ad052 100644
+index 0f168ab61b905901d8aaca71d16526bcd8473d42..0e97d1e73c3fe60549fb202438a75a5a606f315e 100644
 --- a/src/test/java/net/minestom/server/network/SocketReadTest.java
 +++ b/src/test/java/net/minestom/server/network/SocketReadTest.java
-@@ -16,11 +16,11 @@ import java.util.zip.DataFormatException;
+@@ -16,11 +16,12 @@ import java.util.zip.DataFormatException;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class SocketReadTest {
++//Microtus - update java keyword usage
 +class SocketReadTest {
  
      @ParameterizedTest
@@ -6022,7 +6262,7 @@ index 0f168ab61b905901d8aaca71d16526bcd8473d42..b86f9f16335d294f5ab0fe2b8211713a
          var packet = new ClientPluginMessagePacket("channel", new byte[2000]);
  
          var buffer = ObjectPool.PACKET_POOL.get();
-@@ -44,7 +44,7 @@ public class SocketReadTest {
+@@ -44,7 +45,7 @@ public class SocketReadTest {
  
      @ParameterizedTest
      @ValueSource(booleans = {false, true})
@@ -6031,7 +6271,7 @@ index 0f168ab61b905901d8aaca71d16526bcd8473d42..b86f9f16335d294f5ab0fe2b8211713a
          var packet = new ClientPluginMessagePacket("channel", new byte[2000]);
  
          var buffer = ObjectPool.PACKET_POOL.get();
-@@ -70,7 +70,7 @@ public class SocketReadTest {
+@@ -70,7 +71,7 @@ public class SocketReadTest {
  
      @ParameterizedTest
      @ValueSource(booleans = {false, true})
@@ -6040,7 +6280,7 @@ index 0f168ab61b905901d8aaca71d16526bcd8473d42..b86f9f16335d294f5ab0fe2b8211713a
          // Write a complete packet then the next packet length without any payload
  
          var packet = new ClientPluginMessagePacket("channel", new byte[2000]);
-@@ -98,7 +98,7 @@ public class SocketReadTest {
+@@ -98,7 +99,7 @@ public class SocketReadTest {
  
      @ParameterizedTest
      @ValueSource(booleans = {false, true})
@@ -6050,19 +6290,20 @@ index 0f168ab61b905901d8aaca71d16526bcd8473d42..b86f9f16335d294f5ab0fe2b8211713a
  
          var packet = new ClientPluginMessagePacket("channel", new byte[2000]);
 diff --git a/src/test/java/net/minestom/server/network/SocketWriteTest.java b/src/test/java/net/minestom/server/network/SocketWriteTest.java
-index 1202eeb1f2e1d9d11f82ddd99e9da43dec5d2f96..8f8aee350f584b5ef886f8529f56f21fa922be12 100644
+index 1202eeb1f2e1d9d11f82ddd99e9da43dec5d2f96..674d72f5879d9f7e2bf695e6590dbbfb3011b102 100644
 --- a/src/test/java/net/minestom/server/network/SocketWriteTest.java
 +++ b/src/test/java/net/minestom/server/network/SocketWriteTest.java
-@@ -14,7 +14,7 @@ import static net.minestom.server.network.NetworkBuffer.STRING;
+@@ -14,7 +14,8 @@ import static net.minestom.server.network.NetworkBuffer.STRING;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNotEquals;
  
 -public class SocketWriteTest {
++//Microtus - update java keyword usage
 +class SocketWriteTest {
  
      record IntPacket(int value) implements ServerPacket {
          @Override
-@@ -41,7 +41,7 @@ public class SocketWriteTest {
+@@ -41,7 +42,7 @@ public class SocketWriteTest {
      }
  
      @Test
@@ -6071,7 +6312,7 @@ index 1202eeb1f2e1d9d11f82ddd99e9da43dec5d2f96..8f8aee350f584b5ef886f8529f56f21f
          var packet = new IntPacket(5);
  
          var buffer = ObjectPool.PACKET_POOL.get();
-@@ -53,7 +53,7 @@ public class SocketWriteTest {
+@@ -53,7 +54,7 @@ public class SocketWriteTest {
      }
  
      @Test
@@ -6080,7 +6321,7 @@ index 1202eeb1f2e1d9d11f82ddd99e9da43dec5d2f96..8f8aee350f584b5ef886f8529f56f21f
          var packet = new IntPacket(5);
  
          var buffer = ObjectPool.PACKET_POOL.get();
-@@ -66,7 +66,7 @@ public class SocketWriteTest {
+@@ -66,7 +67,7 @@ public class SocketWriteTest {
      }
  
      @Test
@@ -6089,7 +6330,7 @@ index 1202eeb1f2e1d9d11f82ddd99e9da43dec5d2f96..8f8aee350f584b5ef886f8529f56f21f
          var string = "Hello world!".repeat(200);
          var stringLength = string.getBytes(StandardCharsets.UTF_8).length;
          var lengthLength = Utils.getVarIntSize(stringLength);
-@@ -82,7 +82,7 @@ public class SocketWriteTest {
+@@ -82,7 +83,7 @@ public class SocketWriteTest {
      }
  
      @Test
@@ -6098,7 +6339,7 @@ index 1202eeb1f2e1d9d11f82ddd99e9da43dec5d2f96..8f8aee350f584b5ef886f8529f56f21f
          var packet = new IntPacket(5);
  
          var buffer = ObjectPool.PACKET_POOL.get();
-@@ -94,7 +94,7 @@ public class SocketWriteTest {
+@@ -94,7 +95,7 @@ public class SocketWriteTest {
      }
  
      @Test
@@ -6108,14 +6349,15 @@ index 1202eeb1f2e1d9d11f82ddd99e9da43dec5d2f96..8f8aee350f584b5ef886f8529f56f21f
  
          var buffer = ObjectPool.PACKET_POOL.get();
 diff --git a/src/test/java/net/minestom/server/network/socket/ServerAddressTest.java b/src/test/java/net/minestom/server/network/socket/ServerAddressTest.java
-index 1836cf2b698dbbc8004a3a168448f1e13f3edd92..75680c92345e95f46e0528e618080f3217315381 100644
+index 1836cf2b698dbbc8004a3a168448f1e13f3edd92..a922911e74f2efd98bdfa3954291005cd6b861f6 100644
 --- a/src/test/java/net/minestom/server/network/socket/ServerAddressTest.java
 +++ b/src/test/java/net/minestom/server/network/socket/ServerAddressTest.java
-@@ -10,10 +10,10 @@ import java.nio.file.Files;
+@@ -10,10 +10,11 @@ import java.nio.file.Files;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class ServerAddressTest {
++//Microtus - update java keyword usage
 +class ServerAddressTest {
  
      @Test
@@ -6124,7 +6366,7 @@ index 1836cf2b698dbbc8004a3a168448f1e13f3edd92..75680c92345e95f46e0528e618080f32
          InetSocketAddress address = new InetSocketAddress("localhost", 25565);
          var server = new Server(new PacketProcessor());
          server.init(address);
-@@ -26,7 +26,7 @@ public class ServerAddressTest {
+@@ -26,7 +27,7 @@ public class ServerAddressTest {
      }
  
      @Test
@@ -6133,7 +6375,7 @@ index 1836cf2b698dbbc8004a3a168448f1e13f3edd92..75680c92345e95f46e0528e618080f32
          InetSocketAddress address = new InetSocketAddress("localhost", 0);
          var server = new Server(new PacketProcessor());
          server.init(address);
-@@ -39,7 +39,7 @@ public class ServerAddressTest {
+@@ -39,7 +40,7 @@ public class ServerAddressTest {
      }
  
      @Test
@@ -6142,7 +6384,7 @@ index 1836cf2b698dbbc8004a3a168448f1e13f3edd92..75680c92345e95f46e0528e618080f32
          UnixDomainSocketAddress address = UnixDomainSocketAddress.of("minestom.sock");
          var server = new Server(new PacketProcessor());
          server.init(address);
-@@ -54,7 +54,7 @@ public class ServerAddressTest {
+@@ -54,7 +55,7 @@ public class ServerAddressTest {
      }
  
      @Test
@@ -6152,14 +6394,15 @@ index 1836cf2b698dbbc8004a3a168448f1e13f3edd92..75680c92345e95f46e0528e618080f32
          assertDoesNotThrow(server::stop);
      }
 diff --git a/src/test/java/net/minestom/server/permission/TestPermissions.java b/src/test/java/net/minestom/server/permission/TestPermissions.java
-index c5604540d92ca2b579b79a8b2f1c33c89d5efe80..38c785b7dcf897634932897a538de40534b2f529 100644
+index c5604540d92ca2b579b79a8b2f1c33c89d5efe80..133796acdbce4a892f66d3d11aae597be1abd929 100644
 --- a/src/test/java/net/minestom/server/permission/TestPermissions.java
 +++ b/src/test/java/net/minestom/server/permission/TestPermissions.java
-@@ -14,14 +14,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
+@@ -14,14 +14,15 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  import static org.junit.jupiter.api.Assertions.assertTrue;
  
  // TODO: more tests
 -public class TestPermissions {
++//Microtus - update java keyword usage
 +class TestPermissions {
  
      private Player player;
@@ -6172,7 +6415,7 @@ index c5604540d92ca2b579b79a8b2f1c33c89d5efe80..38c785b7dcf897634932897a538de405
          MinecraftServer.init(); // for entity manager
          player = new Player(UUID.randomUUID(), "TestPlayer", null) {
              @Override
-@@ -49,13 +49,13 @@ public class TestPermissions {
+@@ -49,13 +50,13 @@ public class TestPermissions {
      }
  
      @Test
@@ -6188,7 +6431,7 @@ index c5604540d92ca2b579b79a8b2f1c33c89d5efe80..38c785b7dcf897634932897a538de405
  
          assertFalse(player.hasPermission(permission1));
          player.addPermission(permission1);
-@@ -67,7 +67,7 @@ public class TestPermissions {
+@@ -67,7 +68,7 @@ public class TestPermissions {
      }
  
      @Test
@@ -6197,7 +6440,7 @@ index c5604540d92ca2b579b79a8b2f1c33c89d5efe80..38c785b7dcf897634932897a538de405
          player.addPermission(permission1);
          assertTrue(player.hasPermission("perm.name"));
          assertTrue(player.hasPermission("perm.name",
-@@ -81,7 +81,7 @@ public class TestPermissions {
+@@ -81,7 +82,7 @@ public class TestPermissions {
      }
  
      @Test
@@ -6206,7 +6449,7 @@ index c5604540d92ca2b579b79a8b2f1c33c89d5efe80..38c785b7dcf897634932897a538de405
          Permission permission = new Permission("foo.b*r.baz");
          Permission match = new Permission("foo.baaar.baz");
          Permission match2 = new Permission("foo.br.baz");
-@@ -105,7 +105,7 @@ public class TestPermissions {
+@@ -105,7 +106,7 @@ public class TestPermissions {
      }
  
      @Test
@@ -6215,7 +6458,7 @@ index c5604540d92ca2b579b79a8b2f1c33c89d5efe80..38c785b7dcf897634932897a538de405
          Permission permission = new Permission("foo.b*");
          Permission match = new Permission("foo.baaar.baz");
          Permission match2 = new Permission("foo.b");
-@@ -129,7 +129,7 @@ public class TestPermissions {
+@@ -129,7 +130,7 @@ public class TestPermissions {
      }
  
      @Test
@@ -6224,7 +6467,7 @@ index c5604540d92ca2b579b79a8b2f1c33c89d5efe80..38c785b7dcf897634932897a538de405
          assertFalse(player.hasPermission(permission2));
          assertFalse(player.hasPermission(permission3));
          player.addPermission(wildcard);
-@@ -138,7 +138,7 @@ public class TestPermissions {
+@@ -138,7 +139,7 @@ public class TestPermissions {
      }
  
      @AfterEach
@@ -6234,12 +6477,14 @@ index c5604540d92ca2b579b79a8b2f1c33c89d5efe80..38c785b7dcf897634932897a538de405
      }
  }
 diff --git a/src/test/java/net/minestom/server/snapshot/ChunkSnapshotIntegrationTest.java b/src/test/java/net/minestom/server/snapshot/ChunkSnapshotIntegrationTest.java
-index 6f0809d0cbabffda885bea76a0eb8a8c9cefaf77..35ffcf8aa1139c530ce37ff34b9412795abd4d3b 100644
+index 6f0809d0cbabffda885bea76a0eb8a8c9cefaf77..b7a3bc80f7d745cf3736b55abb2d08bb9b2af4eb 100644
 --- a/src/test/java/net/minestom/server/snapshot/ChunkSnapshotIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/snapshot/ChunkSnapshotIntegrationTest.java
-@@ -8,10 +8,10 @@ import org.junit.jupiter.api.Test;
+@@ -7,11 +7,12 @@ import org.junit.jupiter.api.Test;
+ 
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class ChunkSnapshotIntegrationTest {
 +class ChunkSnapshotIntegrationTest {
@@ -6251,12 +6496,14 @@ index 6f0809d0cbabffda885bea76a0eb8a8c9cefaf77..35ffcf8aa1139c530ce37ff34b941279
          instance.setBlock(0, 0, 0, Block.STONE);
          var snapshot = ServerSnapshot.update();
 diff --git a/src/test/java/net/minestom/server/snapshot/EntitySnapshotIntegrationTest.java b/src/test/java/net/minestom/server/snapshot/EntitySnapshotIntegrationTest.java
-index 734b3c8889285b157dc081061db3cdd161ad40bc..c471c4873159e18d10db004fdb03a1fa2c0c1c08 100644
+index 734b3c8889285b157dc081061db3cdd161ad40bc..473191437cfa99dde50c0b554d53fcd1673b0a9c 100644
 --- a/src/test/java/net/minestom/server/snapshot/EntitySnapshotIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/snapshot/EntitySnapshotIntegrationTest.java
-@@ -10,10 +10,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -9,11 +9,12 @@ import org.junit.jupiter.api.Test;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class EntitySnapshotIntegrationTest {
 +class EntitySnapshotIntegrationTest {
@@ -6268,12 +6515,14 @@ index 734b3c8889285b157dc081061db3cdd161ad40bc..c471c4873159e18d10db004fdb03a1fa
          var ent = new Entity(EntityType.ZOMBIE);
          ent.setInstance(instance).join();
 diff --git a/src/test/java/net/minestom/server/snapshot/InstanceSnapshotIntegrationTest.java b/src/test/java/net/minestom/server/snapshot/InstanceSnapshotIntegrationTest.java
-index 7863e30ea16ca00b351222b71f731836792c4e27..973a3401ae0aae9e97dde19c11db9cf12754e73d 100644
+index 7863e30ea16ca00b351222b71f731836792c4e27..f7f27d631c780d7f14850c1cd7da023933844c45 100644
 --- a/src/test/java/net/minestom/server/snapshot/InstanceSnapshotIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/snapshot/InstanceSnapshotIntegrationTest.java
-@@ -7,10 +7,10 @@ import org.junit.jupiter.api.Test;
+@@ -6,11 +6,12 @@ import org.junit.jupiter.api.Test;
+ 
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class InstanceSnapshotIntegrationTest {
 +class InstanceSnapshotIntegrationTest {
@@ -6285,14 +6534,15 @@ index 7863e30ea16ca00b351222b71f731836792c4e27..973a3401ae0aae9e97dde19c11db9cf1
          var snapshot = ServerSnapshot.update();
  
 diff --git a/src/test/java/net/minestom/server/tag/TagComponentTest.java b/src/test/java/net/minestom/server/tag/TagComponentTest.java
-index 44c126e1795196110fc799a7d5cf5d8536cf393d..55a37fd275dd3a1bf92476c21124f7df778d5c62 100644
+index 44c126e1795196110fc799a7d5cf5d8536cf393d..f4e89d8e339f88cf84719d6ea38378071d343b4d 100644
 --- a/src/test/java/net/minestom/server/tag/TagComponentTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagComponentTest.java
-@@ -6,10 +6,10 @@ import org.junit.jupiter.api.Test;
+@@ -6,10 +6,11 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
 -public class TagComponentTest {
++//Microtus - update java keyword usage
 +class TagComponentTest {
  
      @Test
@@ -6301,7 +6551,7 @@ index 44c126e1795196110fc799a7d5cf5d8536cf393d..55a37fd275dd3a1bf92476c21124f7df
          var component = Component.text("Hey");
          var tag = Tag.Component("component");
          var handler = TagHandler.newHandler();
-@@ -18,14 +18,14 @@ public class TagComponentTest {
+@@ -18,14 +19,14 @@ public class TagComponentTest {
      }
  
      @Test
@@ -6318,7 +6568,7 @@ index 44c126e1795196110fc799a7d5cf5d8536cf393d..55a37fd275dd3a1bf92476c21124f7df
          var tag = Tag.Component("entry");
          var handler = TagHandler.newHandler();
          handler.setTag(Tag.Integer("entry"), 1);
-@@ -33,7 +33,7 @@ public class TagComponentTest {
+@@ -33,7 +34,7 @@ public class TagComponentTest {
      }
  
      @Test
@@ -6328,14 +6578,15 @@ index 44c126e1795196110fc799a7d5cf5d8536cf393d..55a37fd275dd3a1bf92476c21124f7df
          var tag = Tag.Component("component");
          var handler = TagHandler.newHandler();
 diff --git a/src/test/java/net/minestom/server/tag/TagEqualityTest.java b/src/test/java/net/minestom/server/tag/TagEqualityTest.java
-index 79905d4ee8e881b547e8c754ad1f1838f30e7f55..5bba1cbbbc77a12eab24abd0b5efb4297569f67e 100644
+index 79905d4ee8e881b547e8c754ad1f1838f30e7f55..960456c44e8e35761e328a1638a89f3497ed05d8 100644
 --- a/src/test/java/net/minestom/server/tag/TagEqualityTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagEqualityTest.java
-@@ -5,10 +5,10 @@ import org.junit.jupiter.api.Test;
+@@ -5,10 +5,11 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNotEquals;
  
 -public class TagEqualityTest {
++//Microtus - update java keyword usage
 +class TagEqualityTest {
  
      @Test
@@ -6344,7 +6595,7 @@ index 79905d4ee8e881b547e8c754ad1f1838f30e7f55..5bba1cbbbc77a12eab24abd0b5efb429
          var tag1 = Tag.Integer("key");
          var tag2 = Tag.Integer("key");
          assertEquals(tag1, tag1);
-@@ -17,49 +17,49 @@ public class TagEqualityTest {
+@@ -17,49 +18,49 @@ public class TagEqualityTest {
      }
  
      @Test
@@ -6402,14 +6653,15 @@ index 79905d4ee8e881b547e8c754ad1f1838f30e7f55..5bba1cbbbc77a12eab24abd0b5efb429
          var tag2 = Tag.Integer("key").path("path");
          assertNotEquals(tag1, tag2);
 diff --git a/src/test/java/net/minestom/server/tag/TagHandlerCopyTest.java b/src/test/java/net/minestom/server/tag/TagHandlerCopyTest.java
-index 11b8660c3502e61735195931bd24377d773f7bbc..aca9523ad96a04af17b301257a46c26ac723582a 100644
+index 11b8660c3502e61735195931bd24377d773f7bbc..48f8d5f8375b04fede5fab3386eaa0352db645c4 100644
 --- a/src/test/java/net/minestom/server/tag/TagHandlerCopyTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagHandlerCopyTest.java
-@@ -6,10 +6,10 @@ import static net.minestom.testing.TestUtils.assertEqualsSNBT;
+@@ -6,10 +6,11 @@ import static net.minestom.testing.TestUtils.assertEqualsSNBT;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
 -public class TagHandlerCopyTest {
++//Microtus - update java keyword usage
 +class TagHandlerCopyTest {
  
      @Test
@@ -6418,7 +6670,7 @@ index 11b8660c3502e61735195931bd24377d773f7bbc..aca9523ad96a04af17b301257a46c26a
          var handler = TagHandler.newHandler();
          handler.setTag(Tag.String("key"), "test");
  
-@@ -18,7 +18,7 @@ public class TagHandlerCopyTest {
+@@ -18,7 +19,7 @@ public class TagHandlerCopyTest {
      }
  
      @Test
@@ -6427,7 +6679,7 @@ index 11b8660c3502e61735195931bd24377d773f7bbc..aca9523ad96a04af17b301257a46c26a
          var tag = Tag.String("key").path("path");
          var handler = TagHandler.newHandler();
          handler.setTag(tag, "test");
-@@ -43,7 +43,7 @@ public class TagHandlerCopyTest {
+@@ -43,7 +44,7 @@ public class TagHandlerCopyTest {
      }
  
      @Test
@@ -6436,7 +6688,7 @@ index 11b8660c3502e61735195931bd24377d773f7bbc..aca9523ad96a04af17b301257a46c26a
          var tag = Tag.String("key");
          var handler = TagHandler.newHandler();
          handler.setTag(tag, "test");
-@@ -71,7 +71,7 @@ public class TagHandlerCopyTest {
+@@ -71,7 +72,7 @@ public class TagHandlerCopyTest {
      }
  
      @Test
@@ -6446,14 +6698,15 @@ index 11b8660c3502e61735195931bd24377d773f7bbc..aca9523ad96a04af17b301257a46c26a
          TagHandler handlerCopy;
          for (int i = 0; i < 1000; i++) {
 diff --git a/src/test/java/net/minestom/server/tag/TagHandlerReadableCopyTest.java b/src/test/java/net/minestom/server/tag/TagHandlerReadableCopyTest.java
-index 90d4a6466541c6aeb3f0d0ac75201c1ef7c7507f..82774de7c0083501796f42b3cc11c8a36b8d44a1 100644
+index 90d4a6466541c6aeb3f0d0ac75201c1ef7c7507f..501f7c905b755b590199083fb90e7df16df5f992 100644
 --- a/src/test/java/net/minestom/server/tag/TagHandlerReadableCopyTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagHandlerReadableCopyTest.java
-@@ -6,10 +6,10 @@ import static net.minestom.testing.TestUtils.assertEqualsSNBT;
+@@ -6,10 +6,11 @@ import static net.minestom.testing.TestUtils.assertEqualsSNBT;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertSame;
  
 -public class TagHandlerReadableCopyTest {
++//Microtus - update java keyword usage
 +class TagHandlerReadableCopyTest {
  
      @Test
@@ -6462,7 +6715,7 @@ index 90d4a6466541c6aeb3f0d0ac75201c1ef7c7507f..82774de7c0083501796f42b3cc11c8a3
          var tag = Tag.String("key");
          var handler = TagHandler.newHandler();
          handler.setTag(tag, "test");
-@@ -23,7 +23,7 @@ public class TagHandlerReadableCopyTest {
+@@ -23,7 +24,7 @@ public class TagHandlerReadableCopyTest {
      }
  
      @Test
@@ -6471,7 +6724,7 @@ index 90d4a6466541c6aeb3f0d0ac75201c1ef7c7507f..82774de7c0083501796f42b3cc11c8a3
          var tag = Tag.String("key").path("path");
          var handler = TagHandler.newHandler();
          handler.setTag(tag, "test");
-@@ -38,14 +38,14 @@ public class TagHandlerReadableCopyTest {
+@@ -38,14 +39,14 @@ public class TagHandlerReadableCopyTest {
      }
  
      @Test
@@ -6489,14 +6742,15 @@ index 90d4a6466541c6aeb3f0d0ac75201c1ef7c7507f..82774de7c0083501796f42b3cc11c8a3
          var handler = TagHandler.newHandler();
          handler.setTag(tag, "test");
 diff --git a/src/test/java/net/minestom/server/tag/TagItemTest.java b/src/test/java/net/minestom/server/tag/TagItemTest.java
-index d3ab11a63bb4bec693621031c0b2fa711ef10e4b..862ab326cef5bb0ac14a91ef7b94c31720e7a263 100644
+index d3ab11a63bb4bec693621031c0b2fa711ef10e4b..b57cdfc40e9fba4fed7f5b15ea2605aec245f36e 100644
 --- a/src/test/java/net/minestom/server/tag/TagItemTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagItemTest.java
-@@ -11,10 +11,10 @@ import static net.minestom.testing.TestUtils.waitUntilCleared;
+@@ -11,10 +11,11 @@ import static net.minestom.testing.TestUtils.waitUntilCleared;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
 -public class TagItemTest {
++//Microtus - update java keyword usage
 +class TagItemTest {
  
      @Test
@@ -6505,7 +6759,7 @@ index d3ab11a63bb4bec693621031c0b2fa711ef10e4b..862ab326cef5bb0ac14a91ef7b94c317
          var item = ItemStack.of(Material.DIAMOND);
          var tag = Tag.ItemStack("item");
          var handler = TagHandler.newHandler();
-@@ -24,7 +24,7 @@ public class TagItemTest {
+@@ -24,7 +25,7 @@ public class TagItemTest {
      }
  
      @Test
@@ -6514,7 +6768,7 @@ index d3ab11a63bb4bec693621031c0b2fa711ef10e4b..862ab326cef5bb0ac14a91ef7b94c317
          var item = ItemStack.of(Material.DIAMOND);
          var handler = TagHandler.newHandler();
          handler.setTag(Tag.ItemStack("item"), item);
-@@ -33,7 +33,7 @@ public class TagItemTest {
+@@ -33,7 +34,7 @@ public class TagItemTest {
      }
  
      @Test
@@ -6523,7 +6777,7 @@ index d3ab11a63bb4bec693621031c0b2fa711ef10e4b..862ab326cef5bb0ac14a91ef7b94c317
          var item = ItemStack.of(Material.DIAMOND);
          var tag = Tag.ItemStack("item");
          var handler = TagHandler.newHandler();
-@@ -45,7 +45,7 @@ public class TagItemTest {
+@@ -45,7 +46,7 @@ public class TagItemTest {
      }
  
      @Test
@@ -6532,7 +6786,7 @@ index d3ab11a63bb4bec693621031c0b2fa711ef10e4b..862ab326cef5bb0ac14a91ef7b94c317
          var item = ItemStack.of(Material.DIAMOND);
          var tag = Tag.ItemStack("item");
          var handler = TagHandler.newHandler();
-@@ -60,7 +60,7 @@ public class TagItemTest {
+@@ -60,7 +61,7 @@ public class TagItemTest {
      }
  
      @Test
@@ -6541,7 +6795,7 @@ index d3ab11a63bb4bec693621031c0b2fa711ef10e4b..862ab326cef5bb0ac14a91ef7b94c317
          var item = ItemStack.of(Material.DIAMOND);
          var item2 = ItemStack.of(Material.DIAMOND, 2);
          var handler = TagHandler.newHandler();
-@@ -73,7 +73,7 @@ public class TagItemTest {
+@@ -73,7 +74,7 @@ public class TagItemTest {
      }
  
      @Test
@@ -6550,7 +6804,7 @@ index d3ab11a63bb4bec693621031c0b2fa711ef10e4b..862ab326cef5bb0ac14a91ef7b94c317
          var item = ItemStack.of(Material.DIAMOND);
          var item2 = ItemStack.of(Material.DIAMOND, 2);
          var handler = TagHandler.newHandler();
-@@ -95,7 +95,7 @@ public class TagItemTest {
+@@ -95,7 +96,7 @@ public class TagItemTest {
      }
  
      @Test
@@ -6560,14 +6814,15 @@ index d3ab11a63bb4bec693621031c0b2fa711ef10e4b..862ab326cef5bb0ac14a91ef7b94c317
          var tag = Tag.ItemStack("item");
          handler.setTag(tag, ItemStack.of(Material.DIAMOND));
 diff --git a/src/test/java/net/minestom/server/tag/TagListTest.java b/src/test/java/net/minestom/server/tag/TagListTest.java
-index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..ae025e28379b91947e6d665d2d788f3eb5c6d106 100644
+index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..04e4f4d515d5900acdb45367ef62bc795485f4fa 100644
 --- a/src/test/java/net/minestom/server/tag/TagListTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagListTest.java
-@@ -9,10 +9,10 @@ import java.util.List;
+@@ -9,10 +9,11 @@ import java.util.List;
  import static net.minestom.testing.TestUtils.assertEqualsSNBT;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class TagListTest {
++//Microtus - update java keyword usage
 +class TagListTest {
  
      @Test
@@ -6576,7 +6831,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..ae025e28379b91947e6d665d2d788f3e
          var handler = TagHandler.newHandler();
          Tag<Integer> tag = Tag.Integer("number");
          Tag<List<Integer>> list = tag.list();
-@@ -27,7 +27,7 @@ public class TagListTest {
+@@ -27,7 +28,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6585,7 +6840,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..ae025e28379b91947e6d665d2d788f3e
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("number").list();
          var val = List.of(1, 2, 3);
-@@ -37,7 +37,7 @@ public class TagListTest {
+@@ -37,7 +38,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6594,7 +6849,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..ae025e28379b91947e6d665d2d788f3e
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("number").list().list();
          var val = List.of(List.of(1, 2, 3), List.of(4, 5, 6));
-@@ -49,7 +49,7 @@ public class TagListTest {
+@@ -49,7 +50,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6603,7 +6858,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..ae025e28379b91947e6d665d2d788f3e
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("number").list().list();
          var val = List.of(List.of(1, 2, 3), new ArrayList<>(Arrays.asList(4, 5, 6)));
-@@ -62,7 +62,7 @@ public class TagListTest {
+@@ -62,7 +63,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6612,7 +6867,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..ae025e28379b91947e6d665d2d788f3e
          var handler = TagHandler.newHandler();
          Tag<List<Integer>> tag = Tag.Integer("numbers").list();
  
-@@ -75,7 +75,7 @@ public class TagListTest {
+@@ -75,7 +76,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6621,7 +6876,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..ae025e28379b91947e6d665d2d788f3e
          var handler = TagHandler.newHandler();
          Tag<List<Integer>> tag = Tag.Integer("numbers").list();
          handler.setTag(tag, List.of());
-@@ -83,7 +83,7 @@ public class TagListTest {
+@@ -83,7 +84,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6630,7 +6885,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..ae025e28379b91947e6d665d2d788f3e
          var handler = TagHandler.newHandler();
          Tag<List<Integer>> tag = Tag.Integer("numbers").list();
          handler.setTag(tag, List.of());
-@@ -95,7 +95,7 @@ public class TagListTest {
+@@ -95,7 +96,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6639,7 +6894,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..ae025e28379b91947e6d665d2d788f3e
          var handler = TagHandler.newHandler();
          Tag<List<Integer>> tag = Tag.Integer("numbers").list();
          handler.setTag(tag, List.of(1));
-@@ -105,7 +105,7 @@ public class TagListTest {
+@@ -105,7 +106,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6648,7 +6903,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..ae025e28379b91947e6d665d2d788f3e
          var handler = TagHandler.newHandler();
          Tag<List<Integer>> tag = Tag.Integer("numbers").list();
          handler.setTag(tag, List.of(1));
-@@ -119,7 +119,7 @@ public class TagListTest {
+@@ -119,7 +120,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6657,7 +6912,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..ae025e28379b91947e6d665d2d788f3e
          var handler = TagHandler.newHandler();
          Tag<List<List<Integer>>> tag = Tag.Integer("numbers").list().list();
          var integers = List.of(List.of(1, 2, 3), List.of(4, 5, 6));
-@@ -130,7 +130,7 @@ public class TagListTest {
+@@ -130,7 +131,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6666,7 +6921,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..ae025e28379b91947e6d665d2d788f3e
          var handler = TagHandler.newHandler();
          Tag<List<List<Integer>>> tag = Tag.Integer("numbers").list().list();
          var integers = List.of(List.of(1, 2, 3), List.of(4, 5, 6));
-@@ -148,7 +148,7 @@ public class TagListTest {
+@@ -148,7 +149,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6675,7 +6930,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..ae025e28379b91947e6d665d2d788f3e
          var handler = TagHandler.newHandler();
          var val = List.of(1, 2, 3);
          var tag = Tag.Integer("number").list().defaultValue(val);
-@@ -156,7 +156,7 @@ public class TagListTest {
+@@ -156,7 +157,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6684,7 +6939,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..ae025e28379b91947e6d665d2d788f3e
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("number").defaultValue(5);
          var list = tag.list();
-@@ -165,7 +165,7 @@ public class TagListTest {
+@@ -165,7 +166,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6693,7 +6948,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..ae025e28379b91947e6d665d2d788f3e
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("number").list();
          List<Integer> val = new ArrayList<>();
-@@ -181,7 +181,7 @@ public class TagListTest {
+@@ -181,7 +182,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6702,7 +6957,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..ae025e28379b91947e6d665d2d788f3e
          var handler = TagHandler.newHandler();
          Tag<List<List<Integer>>> tag = Tag.Integer("numbers").list().list();
          List<List<Integer>> val = new ArrayList<>();
-@@ -201,7 +201,7 @@ public class TagListTest {
+@@ -201,7 +202,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6711,7 +6966,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..ae025e28379b91947e6d665d2d788f3e
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("numbers").list();
          List<Integer> val = new ArrayList<>();
-@@ -223,7 +223,7 @@ public class TagListTest {
+@@ -223,7 +224,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6721,14 +6976,15 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..ae025e28379b91947e6d665d2d788f3e
          Tag<List<List<Integer>>> tag = Tag.Integer("numbers").list().list();
          List<List<Integer>> val = new ArrayList<>();
 diff --git a/src/test/java/net/minestom/server/tag/TagMapTest.java b/src/test/java/net/minestom/server/tag/TagMapTest.java
-index 08595008d38f29988b368940439c46f1994d1a5a..c2ea9ead15f1e86dfc31829c1b8cc234ce9bba8f 100644
+index 08595008d38f29988b368940439c46f1994d1a5a..e658dec07e3a3955ce0338bc782b4bde8a4604fd 100644
 --- a/src/test/java/net/minestom/server/tag/TagMapTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagMapTest.java
-@@ -5,13 +5,13 @@ import org.junit.jupiter.api.Test;
+@@ -5,13 +5,14 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
 -public class TagMapTest {
++//Microtus - update java keyword usage
 +class TagMapTest {
  
      private record Entry(int value) {
@@ -6740,7 +6996,7 @@ index 08595008d38f29988b368940439c46f1994d1a5a..c2ea9ead15f1e86dfc31829c1b8cc234
          var handler = TagHandler.newHandler();
          var intTag = Tag.Integer("key");
          var tag = intTag.map(Entry::new, Entry::value);
-@@ -22,7 +22,7 @@ public class TagMapTest {
+@@ -22,7 +23,7 @@ public class TagMapTest {
      }
  
      @Test
@@ -6749,7 +7005,7 @@ index 08595008d38f29988b368940439c46f1994d1a5a..c2ea9ead15f1e86dfc31829c1b8cc234
          var handler = TagHandler.newHandler();
          var intTag = Tag.Integer("key");
          var tag = intTag.map(Entry::new, Entry::value);
-@@ -35,7 +35,7 @@ public class TagMapTest {
+@@ -35,7 +36,7 @@ public class TagMapTest {
      }
  
      @Test
@@ -6759,14 +7015,15 @@ index 08595008d38f29988b368940439c46f1994d1a5a..c2ea9ead15f1e86dfc31829c1b8cc234
          var tag = Tag.Integer("key").map(Entry::new, Entry::value);
          assertNull(handler.getTag(tag));
 diff --git a/src/test/java/net/minestom/server/tag/TagNbtSeparatorTest.java b/src/test/java/net/minestom/server/tag/TagNbtSeparatorTest.java
-index 4e9f46c4143323f403ca2d2cf4fb419681323261..ed0d861d3abf80094695479cfdad7a3b9b960e2d 100644
+index 4e9f46c4143323f403ca2d2cf4fb419681323261..3c0056c06d64aa929388dbf3fb1e8ae239c485e7 100644
 --- a/src/test/java/net/minestom/server/tag/TagNbtSeparatorTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagNbtSeparatorTest.java
-@@ -11,10 +11,10 @@ import java.util.Set;
+@@ -11,10 +11,11 @@ import java.util.Set;
  
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
 -public class TagNbtSeparatorTest {
++//Microtus - update java keyword usage
 +class TagNbtSeparatorTest {
  
      @Test
@@ -6775,7 +7032,7 @@ index 4e9f46c4143323f403ca2d2cf4fb419681323261..ed0d861d3abf80094695479cfdad7a3b
          assertSeparation(new TagNbtSeparator.Entry<>(Tag.Byte("key"), (byte) 1),
                  "key", NBT.Byte(1));
          assertSeparation(new TagNbtSeparator.Entry<>(Tag.Short("key"), (short) 1),
-@@ -30,20 +30,20 @@ public class TagNbtSeparatorTest {
+@@ -30,20 +31,20 @@ public class TagNbtSeparatorTest {
      }
  
      @Test
@@ -6800,14 +7057,15 @@ index 4e9f46c4143323f403ca2d2cf4fb419681323261..ed0d861d3abf80094695479cfdad7a3b
                  "key", NBT.List(NBTType.TAG_Int, NBT.Int(1)));
      }
 diff --git a/src/test/java/net/minestom/server/tag/TagNbtTest.java b/src/test/java/net/minestom/server/tag/TagNbtTest.java
-index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..40c970ef055dec4955fdd93e62f6e9dd58d34a10 100644
+index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..b96c618d13a0f84f430b61a9296d90b7beca361b 100644
 --- a/src/test/java/net/minestom/server/tag/TagNbtTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagNbtTest.java
-@@ -15,10 +15,10 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
+@@ -15,10 +15,11 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
  /**
   * Ensure that NBT tag can be read from other tags properly.
   */
 -public class TagNbtTest {
++//Microtus - update java keyword usage
 +class TagNbtTest {
  
      @Test
@@ -6816,7 +7074,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..40c970ef055dec4955fdd93e62f6e9dd
          var handler = TagHandler.newHandler();
          var tag = Tag.NBT("nbt").list();
          List<NBT> list = List.of(NBT.Int(1), NBT.Int(2), NBT.Int(3));
-@@ -35,7 +35,7 @@ public class TagNbtTest {
+@@ -35,7 +36,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -6825,7 +7083,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..40c970ef055dec4955fdd93e62f6e9dd
          var handler = TagHandler.newHandler();
          var tag = Tag.NBT("nbt").map(nbt -> ((NBTInt) nbt).getValue(), NBT::Int);
          handler.setTag(tag, 5);
-@@ -51,7 +51,7 @@ public class TagNbtTest {
+@@ -51,7 +52,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -6834,7 +7092,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..40c970ef055dec4955fdd93e62f6e9dd
          var compound = NBT.Compound(Map.of("key", NBT.Int(5)));
          var handler = TagHandler.fromCompound(compound);
          assertEquals(compound, handler.asCompound());
-@@ -71,7 +71,7 @@ public class TagNbtTest {
+@@ -71,7 +72,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -6843,7 +7101,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..40c970ef055dec4955fdd93e62f6e9dd
          var compound = NBT.Compound(Map.of("path", NBT.Compound(Map.of("key", NBT.Int(5)))));
          var handler = TagHandler.fromCompound(compound);
          var tag = Tag.Integer("key").path("path");
-@@ -88,7 +88,7 @@ public class TagNbtTest {
+@@ -88,7 +89,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -6852,7 +7110,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..40c970ef055dec4955fdd93e62f6e9dd
          var compound = NBT.Compound(Map.of("path", NBT.Compound(Map.of("path2",
                  NBT.Compound(Map.of("key", NBT.Int(5)))))));
          var handler = TagHandler.fromCompound(compound);
-@@ -106,7 +106,7 @@ public class TagNbtTest {
+@@ -106,7 +107,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -6861,7 +7119,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..40c970ef055dec4955fdd93e62f6e9dd
          var handler = TagHandler.newHandler();
          var nbtTag = Tag.NBT("path1");
  
-@@ -120,7 +120,7 @@ public class TagNbtTest {
+@@ -120,7 +121,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -6870,7 +7128,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..40c970ef055dec4955fdd93e62f6e9dd
          var handler = TagHandler.newHandler();
          var nbtTag = Tag.NBT("path1");
  
-@@ -133,7 +133,7 @@ public class TagNbtTest {
+@@ -133,7 +134,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -6879,7 +7137,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..40c970ef055dec4955fdd93e62f6e9dd
          var handler = TagHandler.newHandler();
          var nbtTag = Tag.NBT("compound").path("path");
  
-@@ -146,7 +146,7 @@ public class TagNbtTest {
+@@ -146,7 +147,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -6888,7 +7146,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..40c970ef055dec4955fdd93e62f6e9dd
          var handler = TagHandler.newHandler();
          var nbtTag = Tag.NBT("path1");
  
-@@ -159,7 +159,7 @@ public class TagNbtTest {
+@@ -159,7 +160,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -6897,7 +7155,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..40c970ef055dec4955fdd93e62f6e9dd
          var handler = TagHandler.newHandler();
          var nbtTag = Tag.NBT("path1");
  
-@@ -174,7 +174,7 @@ public class TagNbtTest {
+@@ -174,7 +175,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -6906,7 +7164,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..40c970ef055dec4955fdd93e62f6e9dd
          var handler = TagHandler.newHandler();
          var nbtTag = Tag.NBT("list");
          var list = NBT.List(NBTType.TAG_Int, NBT.Int(1));
-@@ -183,7 +183,7 @@ public class TagNbtTest {
+@@ -183,7 +184,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -6915,7 +7173,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..40c970ef055dec4955fdd93e62f6e9dd
          var handler = TagHandler.newHandler();
          var nbtTag = Tag.NBT("list");
          var listTag = Tag.Integer("list").list();
-@@ -196,7 +196,7 @@ public class TagNbtTest {
+@@ -196,7 +197,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -6925,14 +7183,15 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..40c970ef055dec4955fdd93e62f6e9dd
          var nbtTag = Tag.NBT("array");
          var array = NBT.IntArray(1, 2, 3);
 diff --git a/src/test/java/net/minestom/server/tag/TagPathTest.java b/src/test/java/net/minestom/server/tag/TagPathTest.java
-index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..53d6ade4e248c72c811e3057e8e0d42bfeee1190 100644
+index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..197e3c394a54395bc41c9e271880dbb114b7526c 100644
 --- a/src/test/java/net/minestom/server/tag/TagPathTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagPathTest.java
-@@ -7,10 +7,10 @@ import org.junit.jupiter.api.Test;
+@@ -7,10 +7,11 @@ import org.junit.jupiter.api.Test;
  import static net.minestom.testing.TestUtils.assertEqualsSNBT;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class TagPathTest {
++//Microtus - update java keyword usage
 +class TagPathTest {
  
      @Test
@@ -6941,7 +7200,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..53d6ade4e248c72c811e3057e8e0d42b
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("number");
          var path = tag.path("display");
-@@ -28,13 +28,13 @@ public class TagPathTest {
+@@ -28,13 +29,13 @@ public class TagPathTest {
      }
  
      @Test
@@ -6957,7 +7216,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..53d6ade4e248c72c811e3057e8e0d42b
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("number").path("display");
          handler.removeTag(tag);
-@@ -43,7 +43,7 @@ public class TagPathTest {
+@@ -43,7 +44,7 @@ public class TagPathTest {
      }
  
      @Test
@@ -6966,7 +7225,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..53d6ade4e248c72c811e3057e8e0d42b
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("number").path("display");
          handler.setTag(tag, 5);
-@@ -60,7 +60,7 @@ public class TagPathTest {
+@@ -60,7 +61,7 @@ public class TagPathTest {
      }
  
      @Test
@@ -6975,7 +7234,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..53d6ade4e248c72c811e3057e8e0d42b
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("number").path("display");
          var tag1 = Tag.String("string").path("display");
-@@ -90,7 +90,7 @@ public class TagPathTest {
+@@ -90,7 +91,7 @@ public class TagPathTest {
      }
  
      @Test
@@ -6984,7 +7243,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..53d6ade4e248c72c811e3057e8e0d42b
          var handler = TagHandler.newHandler();
          var numberTag = Tag.Integer("number").path("path1", "path2");
          var stringTag = Tag.String("string").path("path1");
-@@ -118,7 +118,7 @@ public class TagPathTest {
+@@ -118,7 +119,7 @@ public class TagPathTest {
      }
  
      @Test
@@ -6993,7 +7252,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..53d6ade4e248c72c811e3057e8e0d42b
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("number");
          var path = tag.path("display");
-@@ -150,7 +150,7 @@ public class TagPathTest {
+@@ -150,7 +151,7 @@ public class TagPathTest {
      }
  
      @Test
@@ -7002,7 +7261,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..53d6ade4e248c72c811e3057e8e0d42b
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("key");
          var tag1 = Tag.Integer("value").path("key");
-@@ -172,7 +172,7 @@ public class TagPathTest {
+@@ -172,7 +173,7 @@ public class TagPathTest {
      }
  
      @Test
@@ -7011,7 +7270,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..53d6ade4e248c72c811e3057e8e0d42b
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("key");
          var path = Tag.Integer("value").path("key");
-@@ -181,7 +181,7 @@ public class TagPathTest {
+@@ -181,7 +182,7 @@ public class TagPathTest {
      }
  
      @Test
@@ -7020,7 +7279,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..53d6ade4e248c72c811e3057e8e0d42b
          var handler = TagHandler.newHandler();
          var tag1 = Tag.Integer("pathInvalidClear1").path("key");
          var tag2 = Tag.Integer("pathInvalidClear2").path("key");
-@@ -190,7 +190,7 @@ public class TagPathTest {
+@@ -190,7 +191,7 @@ public class TagPathTest {
      }
  
      @Test
@@ -7029,7 +7288,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..53d6ade4e248c72c811e3057e8e0d42b
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("key");
          var path = Tag.Integer("key").path("first", "second");
-@@ -213,7 +213,7 @@ public class TagPathTest {
+@@ -213,7 +214,7 @@ public class TagPathTest {
      }
  
      @Test
@@ -7038,7 +7297,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..53d6ade4e248c72c811e3057e8e0d42b
          var handler = TagHandler.newHandler();
          var path = Tag.Integer("key").path("first", "second");
          var path1 = Tag.Integer("key").path("first");
-@@ -257,7 +257,7 @@ public class TagPathTest {
+@@ -257,7 +258,7 @@ public class TagPathTest {
      }
  
      @Test
@@ -7047,7 +7306,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..53d6ade4e248c72c811e3057e8e0d42b
          record Entry(int value) {
          }
  
-@@ -311,7 +311,7 @@ public class TagPathTest {
+@@ -311,7 +312,7 @@ public class TagPathTest {
      }
  
      @Test
@@ -7057,14 +7316,15 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..53d6ade4e248c72c811e3057e8e0d42b
          var tag = Tag.Integer("key");
          var path = Tag.Integer("value").path("key", "second");
 diff --git a/src/test/java/net/minestom/server/tag/TagRecordTest.java b/src/test/java/net/minestom/server/tag/TagRecordTest.java
-index 1dfed907baf20311a82d5d4094500703454893e6..b189f7aa45fb74477dd54abbbeac7b1ca731be47 100644
+index 1dfed907baf20311a82d5d4094500703454893e6..c0e60ad81d4b6d8e64e4a3fffb95e1d8c3c40f31 100644
 --- a/src/test/java/net/minestom/server/tag/TagRecordTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagRecordTest.java
-@@ -13,10 +13,10 @@ import java.util.Map;
+@@ -13,10 +13,11 @@ import java.util.Map;
  import static net.minestom.testing.TestUtils.assertEqualsSNBT;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class TagRecordTest {
++//Microtus - update java keyword usage
 +class TagRecordTest {
  
      @Test
@@ -7073,7 +7333,7 @@ index 1dfed907baf20311a82d5d4094500703454893e6..b189f7aa45fb74477dd54abbbeac7b1c
          var handler = TagHandler.newHandler();
          var tag = Tag.Structure("vec", Vec.class);
          var vec = new Vec(1, 2, 3);
-@@ -26,7 +26,7 @@ public class TagRecordTest {
+@@ -26,7 +27,7 @@ public class TagRecordTest {
      }
  
      @Test
@@ -7082,7 +7342,7 @@ index 1dfed907baf20311a82d5d4094500703454893e6..b189f7aa45fb74477dd54abbbeac7b1c
          var vecCompound = NBT.Compound(Map.of(
                  "x", NBT.Double(1),
                  "y", NBT.Double(2),
-@@ -37,7 +37,7 @@ public class TagRecordTest {
+@@ -37,7 +38,7 @@ public class TagRecordTest {
      }
  
      @Test
@@ -7091,7 +7351,7 @@ index 1dfed907baf20311a82d5d4094500703454893e6..b189f7aa45fb74477dd54abbbeac7b1c
          var handler = TagHandler.fromCompound(NBT.Compound(Map.of(
                  "x", NBT.Double(1),
                  "y", NBT.Double(2),
-@@ -47,7 +47,7 @@ public class TagRecordTest {
+@@ -47,7 +48,7 @@ public class TagRecordTest {
      }
  
      @Test
@@ -7100,7 +7360,7 @@ index 1dfed907baf20311a82d5d4094500703454893e6..b189f7aa45fb74477dd54abbbeac7b1c
          var handler = TagHandler.newHandler();
          var serializer = TagRecord.serializer(Vec.class);
          serializer.write(handler, new Vec(1, 2, 3));
-@@ -55,7 +55,7 @@ public class TagRecordTest {
+@@ -55,7 +56,7 @@ public class TagRecordTest {
      }
  
      @Test
@@ -7109,7 +7369,7 @@ index 1dfed907baf20311a82d5d4094500703454893e6..b189f7aa45fb74477dd54abbbeac7b1c
          var handler = TagHandler.newHandler();
          var tag = Tag.Structure("vec", Vec.class);
          var vec = new Vec(1, 2, 3);
-@@ -74,7 +74,7 @@ public class TagRecordTest {
+@@ -74,7 +75,7 @@ public class TagRecordTest {
      }
  
      @Test
@@ -7118,7 +7378,7 @@ index 1dfed907baf20311a82d5d4094500703454893e6..b189f7aa45fb74477dd54abbbeac7b1c
          record CompoundRecord(NBTCompound compound) {
          }
          var test = new CompoundRecord(NBT.Compound(Map.of("key", NBT.String("value"))));
-@@ -85,26 +85,26 @@ public class TagRecordTest {
+@@ -85,26 +86,26 @@ public class TagRecordTest {
      }
  
      @Test
@@ -7150,14 +7410,15 @@ index 1dfed907baf20311a82d5d4094500703454893e6..b189f7aa45fb74477dd54abbbeac7b1c
          // the item record components
          assertThrows(Throwable.class, () -> Tag.Structure("item", Class.class.cast(ItemStack.class)));
 diff --git a/src/test/java/net/minestom/server/tag/TagSerializerTest.java b/src/test/java/net/minestom/server/tag/TagSerializerTest.java
-index 2f7c6e91e46910f8536218f9d85b9ee3f1468802..e3ca53d336f58f78ba359cce392e9ff3dffdff81 100644
+index 2f7c6e91e46910f8536218f9d85b9ee3f1468802..aacdef1cd32ddca4789bfeb2668609dbf1e8db13 100644
 --- a/src/test/java/net/minestom/server/tag/TagSerializerTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagSerializerTest.java
-@@ -7,9 +7,9 @@ import org.junit.jupiter.api.Test;
+@@ -7,9 +7,10 @@ import org.junit.jupiter.api.Test;
  
  import java.util.List;
  
 -public class TagSerializerTest {
++//Microtus - update java keyword usage
 +class TagSerializerTest {
      @Test
 -    public void fromCompound(){
@@ -7166,19 +7427,20 @@ index 2f7c6e91e46910f8536218f9d85b9ee3f1468802..e3ca53d336f58f78ba359cce392e9ff3
          var effect = new FireworkEffect(false, false, FireworkEffectType.BURST, List.of(), List.of());
          TagHandler handler = TagHandler.newHandler();
 diff --git a/src/test/java/net/minestom/server/tag/TagStructureTest.java b/src/test/java/net/minestom/server/tag/TagStructureTest.java
-index d4f271c89568f90bd6eae7078602ba48cf4f0941..1c4f4e128624ecf265986d186341f8dd5fb85d07 100644
+index d4f271c89568f90bd6eae7078602ba48cf4f0941..35009dff4eb6a5ea0247b87dedee2d2a8d24eed1 100644
 --- a/src/test/java/net/minestom/server/tag/TagStructureTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagStructureTest.java
-@@ -10,7 +10,7 @@ import java.util.UUID;
+@@ -10,7 +10,8 @@ import java.util.UUID;
  import static net.minestom.testing.TestUtils.assertEqualsSNBT;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class TagStructureTest {
++//Microtus - update java keyword usage
 +class TagStructureTest {
  
      private static final Tag<Entry> STRUCTURE_TAG = Tag.Structure("entry", new TagSerializer<>() {
          private static final Tag<String> VALUE_TAG = Tag.String("value");
-@@ -46,7 +46,7 @@ public class TagStructureTest {
+@@ -46,7 +47,7 @@ public class TagStructureTest {
      }
  
      @Test
@@ -7187,7 +7449,7 @@ index d4f271c89568f90bd6eae7078602ba48cf4f0941..1c4f4e128624ecf265986d186341f8dd
          var handler = TagHandler.newHandler();
          assertNull(handler.getTag(STRUCTURE_TAG));
          assertFalse(handler.hasTag(STRUCTURE_TAG));
-@@ -62,7 +62,7 @@ public class TagStructureTest {
+@@ -62,7 +63,7 @@ public class TagStructureTest {
      }
  
      @Test
@@ -7196,7 +7458,7 @@ index d4f271c89568f90bd6eae7078602ba48cf4f0941..1c4f4e128624ecf265986d186341f8dd
          var handler = TagHandler.newHandler();
          var entry = new Entry("hello");
          handler.setTag(STRUCTURE_TAG, entry);
-@@ -79,7 +79,7 @@ public class TagStructureTest {
+@@ -79,7 +80,7 @@ public class TagStructureTest {
      }
  
      @Test
@@ -7205,7 +7467,7 @@ index d4f271c89568f90bd6eae7078602ba48cf4f0941..1c4f4e128624ecf265986d186341f8dd
          var handler = TagHandler.newHandler();
          assertNull(handler.getTag(STRUCTURE_TAG));
          assertFalse(handler.hasTag(STRUCTURE_TAG));
-@@ -105,7 +105,7 @@ public class TagStructureTest {
+@@ -105,7 +106,7 @@ public class TagStructureTest {
      }
  
      @Test
@@ -7214,7 +7476,7 @@ index d4f271c89568f90bd6eae7078602ba48cf4f0941..1c4f4e128624ecf265986d186341f8dd
          var handler = TagHandler.newHandler();
          var entry1 = new Entry("hello");
          var entry2 = new Entry("hello2");
-@@ -134,7 +134,7 @@ public class TagStructureTest {
+@@ -134,7 +135,7 @@ public class TagStructureTest {
      }
  
      @Test
@@ -7224,14 +7486,15 @@ index d4f271c89568f90bd6eae7078602ba48cf4f0941..1c4f4e128624ecf265986d186341f8dd
          Tag<UUID> uuidTag = Tag.UUID("Id").path("SkullOwner");
          Tag<PlayerSkin> skinTag = Tag.Structure("Properties", new TagSerializer<PlayerSkin>() {
 diff --git a/src/test/java/net/minestom/server/tag/TagTest.java b/src/test/java/net/minestom/server/tag/TagTest.java
-index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..ba4ff92e14b8c3dfb486d47ab53ab38f2b905d00 100644
+index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..0a19bfd4d716e9ccc3e4b0f2789955fd878c6076 100644
 --- a/src/test/java/net/minestom/server/tag/TagTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagTest.java
-@@ -11,10 +11,10 @@ import java.util.Map;
+@@ -11,10 +11,11 @@ import java.util.Map;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class TagTest {
++//Microtus - update java keyword usage
 +class TagTest {
  
      @Test
@@ -7240,7 +7503,7 @@ index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..ba4ff92e14b8c3dfb486d47ab53ab38f
          var mutable = new MutableNBTCompound().setInt("key", 5);
          var tag = Tag.Integer("key");
          var handler = TagHandler.fromCompound(new MutableNBTCompound());
-@@ -28,7 +28,7 @@ public class TagTest {
+@@ -28,7 +29,7 @@ public class TagTest {
      }
  
      @Test
@@ -7249,7 +7512,7 @@ index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..ba4ff92e14b8c3dfb486d47ab53ab38f
          var handler = TagHandler.fromCompound(new MutableNBTCompound().set("key", NBT.Int(5)));
          // Removal
          var tag = Tag.Integer("key");
-@@ -38,7 +38,7 @@ public class TagTest {
+@@ -38,7 +39,7 @@ public class TagTest {
      }
  
      @Test
@@ -7258,7 +7521,7 @@ index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..ba4ff92e14b8c3dfb486d47ab53ab38f
          var handler = TagHandler.fromCompound(new MutableNBTCompound().set("key", NBT.Int(5)));
          // Removal
          var tag = Tag.Integer("key");
-@@ -48,14 +48,14 @@ public class TagTest {
+@@ -48,14 +49,14 @@ public class TagTest {
      }
  
      @Test
@@ -7275,7 +7538,7 @@ index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..ba4ff92e14b8c3dfb486d47ab53ab38f
          var mutable = new MutableNBTCompound().setInt("key", 5);
          var handler = TagHandler.fromCompound(mutable);
          assertEquals(5, handler.getTag(Tag.Integer("key")));
-@@ -63,7 +63,7 @@ public class TagTest {
+@@ -63,7 +64,7 @@ public class TagTest {
      }
  
      @Test
@@ -7284,7 +7547,7 @@ index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..ba4ff92e14b8c3dfb486d47ab53ab38f
          // Ensure that TagHandler#asCompound reuse the same compound used for construction
          var compound = NBT.Compound(Map.of("key", NBT.Int(5)));
          var handler = TagHandler.fromCompound(compound);
-@@ -71,7 +71,7 @@ public class TagTest {
+@@ -71,7 +72,7 @@ public class TagTest {
      }
  
      @Test
@@ -7293,7 +7556,7 @@ index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..ba4ff92e14b8c3dfb486d47ab53ab38f
          var nullable = Tag.String("key");
          var notNull = nullable.defaultValue("Hey");
          assertNotSame(nullable, notNull);
-@@ -86,7 +86,7 @@ public class TagTest {
+@@ -86,7 +87,7 @@ public class TagTest {
      }
  
      @Test
@@ -7302,7 +7565,7 @@ index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..ba4ff92e14b8c3dfb486d47ab53ab38f
          var tag1 = Tag.Integer("key");
          var tag2 = Tag.String("key");
  
-@@ -99,7 +99,7 @@ public class TagTest {
+@@ -99,7 +100,7 @@ public class TagTest {
      }
  
      @Test
@@ -7311,7 +7574,7 @@ index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..ba4ff92e14b8c3dfb486d47ab53ab38f
          var item = ItemStack.of(Material.DIAMOND);
          var tag = Tag.ItemStack("item");
          var handler = TagHandler.newHandler();
-@@ -108,7 +108,7 @@ public class TagTest {
+@@ -108,7 +109,7 @@ public class TagTest {
      }
  
      @Test
@@ -7320,7 +7583,7 @@ index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..ba4ff92e14b8c3dfb486d47ab53ab38f
          var tag1 = Tag.Integer("tag1");
          var tag2 = Tag.Integer("tag2");
          var handler = TagHandler.newHandler();
-@@ -121,7 +121,7 @@ public class TagTest {
+@@ -121,7 +122,7 @@ public class TagTest {
      }
  
      @Test
@@ -7329,7 +7592,7 @@ index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..ba4ff92e14b8c3dfb486d47ab53ab38f
          var handler = TagHandler.fromCompound(NBT.Compound(Map.of(
                  "tag1", NBT.Int(5),
                  "tag2", NBT.Int(1))));
-@@ -131,7 +131,7 @@ public class TagTest {
+@@ -131,7 +132,7 @@ public class TagTest {
      }
  
      @Test
@@ -7339,14 +7602,15 @@ index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..ba4ff92e14b8c3dfb486d47ab53ab38f
          for (int i = 0; i < 1000; i++) {
              handler.setTag(Tag.Integer("rehashing" + i), i);
 diff --git a/src/test/java/net/minestom/server/tag/TagUpdateTest.java b/src/test/java/net/minestom/server/tag/TagUpdateTest.java
-index 222b875de2388871adbf7c0f84affa60481f992a..59a64d77c7cc4a5a40b569897cf6131060bc4902 100644
+index 222b875de2388871adbf7c0f84affa60481f992a..38f77120d931fff7c3965ff3d50aa865e6b01f0d 100644
 --- a/src/test/java/net/minestom/server/tag/TagUpdateTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagUpdateTest.java
-@@ -6,10 +6,10 @@ import org.junit.jupiter.api.Test;
+@@ -6,10 +6,11 @@ import org.junit.jupiter.api.Test;
  import static net.minestom.testing.TestUtils.assertEqualsSNBT;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class TagUpdateTest {
++//Microtus - update java keyword usage
 +class TagUpdateTest {
  
      @Test
@@ -7355,7 +7619,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..59a64d77c7cc4a5a40b569897cf61310
          var tag = Tag.Integer("coin");
          var handler = TagHandler.newHandler();
          handler.updateTag(tag, integer -> {
-@@ -25,7 +25,7 @@ public class TagUpdateTest {
+@@ -25,7 +26,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7364,7 +7628,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..59a64d77c7cc4a5a40b569897cf61310
          var tag = Tag.Integer("coin").defaultValue(25);
          var handler = TagHandler.newHandler();
          handler.updateTag(tag, integer -> {
-@@ -41,7 +41,7 @@ public class TagUpdateTest {
+@@ -41,7 +42,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7373,7 +7637,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..59a64d77c7cc4a5a40b569897cf61310
          var tag = Tag.Integer("coin");
          var handler = TagHandler.newHandler();
          handler.setTag(tag, 5);
-@@ -54,7 +54,7 @@ public class TagUpdateTest {
+@@ -54,7 +55,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7382,7 +7646,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..59a64d77c7cc4a5a40b569897cf61310
          var tag = Tag.Integer("coin").path("path");
          var handler = TagHandler.newHandler();
          handler.setTag(tag, 5);
-@@ -67,7 +67,7 @@ public class TagUpdateTest {
+@@ -67,7 +68,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7391,7 +7655,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..59a64d77c7cc4a5a40b569897cf61310
          var tag = Tag.Integer("coin");
          var handler = TagHandler.newHandler();
          var result = handler.updateAndGetTag(tag, integer -> {
-@@ -83,7 +83,7 @@ public class TagUpdateTest {
+@@ -83,7 +84,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7400,7 +7664,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..59a64d77c7cc4a5a40b569897cf61310
          var tag = Tag.Integer("coin");
          var handler = TagHandler.newHandler();
          var result = handler.getAndUpdateTag(tag, integer -> {
-@@ -99,7 +99,7 @@ public class TagUpdateTest {
+@@ -99,7 +100,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7409,7 +7673,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..59a64d77c7cc4a5a40b569897cf61310
          var tag1 = Tag.Integer("coin");
          var tag2 = Tag.Integer("coin").map(i -> i + 1, i -> i - 1);
          var handler = TagHandler.newHandler();
-@@ -110,7 +110,7 @@ public class TagUpdateTest {
+@@ -110,7 +111,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7418,7 +7682,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..59a64d77c7cc4a5a40b569897cf61310
          record Test(int coin) {
          }
  
-@@ -131,7 +131,7 @@ public class TagUpdateTest {
+@@ -131,7 +132,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7427,7 +7691,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..59a64d77c7cc4a5a40b569897cf61310
          record Test(int coin) {
          }
  
-@@ -152,7 +152,7 @@ public class TagUpdateTest {
+@@ -152,7 +153,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7436,7 +7700,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..59a64d77c7cc4a5a40b569897cf61310
          record Test(int coin) {
          }
          record Structure(Test test) {
-@@ -176,7 +176,7 @@ public class TagUpdateTest {
+@@ -176,7 +177,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7445,7 +7709,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..59a64d77c7cc4a5a40b569897cf61310
          record Test(int coin) {
          }
  
-@@ -194,7 +194,7 @@ public class TagUpdateTest {
+@@ -194,7 +195,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7454,7 +7718,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..59a64d77c7cc4a5a40b569897cf61310
          var tagI = Tag.Integer("coin");
          var tagD = Tag.Double("coin");
          var handler = TagHandler.newHandler();
-@@ -203,7 +203,7 @@ public class TagUpdateTest {
+@@ -203,7 +204,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7464,14 +7728,15 @@ index 222b875de2388871adbf7c0f84affa60481f992a..59a64d77c7cc4a5a40b569897cf61310
          var tagX = Tag.Double("x").path("vec");
          var handler = TagHandler.newHandler();
 diff --git a/src/test/java/net/minestom/server/tag/TagUuidTest.java b/src/test/java/net/minestom/server/tag/TagUuidTest.java
-index 7867639d8e7566b15ca176627dcafa69cd1be41f..2cdcbe1aa884b444fbe45a8cebb593bc34ecd2de 100644
+index 7867639d8e7566b15ca176627dcafa69cd1be41f..b26fa5495ee98357b377ca5c620dc4032f3e345d 100644
 --- a/src/test/java/net/minestom/server/tag/TagUuidTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagUuidTest.java
-@@ -8,10 +8,10 @@ import java.util.UUID;
+@@ -8,10 +8,11 @@ import java.util.UUID;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class TagUuidTest {
++//Microtus - update java keyword usage
 +class TagUuidTest {
  
      @Test
@@ -7480,7 +7745,7 @@ index 7867639d8e7566b15ca176627dcafa69cd1be41f..2cdcbe1aa884b444fbe45a8cebb593bc
          var uuid = UUID.randomUUID();
          var tag = Tag.UUID("uuid");
          var handler = TagHandler.newHandler();
-@@ -20,14 +20,14 @@ public class TagUuidTest {
+@@ -20,14 +21,14 @@ public class TagUuidTest {
      }
  
      @Test
@@ -7497,7 +7762,7 @@ index 7867639d8e7566b15ca176627dcafa69cd1be41f..2cdcbe1aa884b444fbe45a8cebb593bc
          var tag = Tag.UUID("entry");
          var handler = TagHandler.newHandler();
          handler.setTag(Tag.Integer("entry"), 1);
-@@ -35,7 +35,7 @@ public class TagUuidTest {
+@@ -35,7 +36,7 @@ public class TagUuidTest {
      }
  
      @Test
@@ -7506,7 +7771,7 @@ index 7867639d8e7566b15ca176627dcafa69cd1be41f..2cdcbe1aa884b444fbe45a8cebb593bc
          var tag = Tag.UUID("uuid");
          var handler = TagHandler.newHandler();
          handler.setTag(tag, UUID.fromString("9ab8ca63-3d7b-43ba-b805-a20a352dae9c"));
-@@ -46,7 +46,7 @@ public class TagUuidTest {
+@@ -46,7 +47,7 @@ public class TagUuidTest {
      }
  
      @Test
@@ -7516,14 +7781,15 @@ index 7867639d8e7566b15ca176627dcafa69cd1be41f..2cdcbe1aa884b444fbe45a8cebb593bc
          var handler = TagHandler.newHandler();
          handler.setTag(Tag.NBT("uuid"), NBT.IntArray(-1699165597, 1031488442, -1207590390, 892186268));
 diff --git a/src/test/java/net/minestom/server/tag/TagValueShareTest.java b/src/test/java/net/minestom/server/tag/TagValueShareTest.java
-index bbed3b075d006d8c6cc92545337e428d14422c72..b375a45d41a8b04d2b7f4a9046db10841547187c 100644
+index bbed3b075d006d8c6cc92545337e428d14422c72..f2b62c543143582a7f63e6aaf6f05eab3bb0f027 100644
 --- a/src/test/java/net/minestom/server/tag/TagValueShareTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagValueShareTest.java
-@@ -11,40 +11,40 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
+@@ -11,40 +11,41 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  /**
   * Test tags that can share cached values.
   */
 -public class TagValueShareTest {
++//Microtus - update java keyword usage
 +class TagValueShareTest {
  
      record Entry(int value) {
@@ -7566,7 +7832,7 @@ index bbed3b075d006d8c6cc92545337e428d14422c72..b375a45d41a8b04d2b7f4a9046db1084
          // Force identical functions
          Function<Integer, Entry> t1 = Entry::new;
          Function<Entry, Integer> t2 = Entry::value;
-@@ -56,26 +56,26 @@ public class TagValueShareTest {
+@@ -56,26 +57,26 @@ public class TagValueShareTest {
      }
  
      @Test
@@ -7597,7 +7863,7 @@ index bbed3b075d006d8c6cc92545337e428d14422c72..b375a45d41a8b04d2b7f4a9046db1084
          var tag = Tag.String("test").list();
          var tag2 = Tag.String("test").list();
          assertTrue(tag.shareValue(tag2));
-@@ -83,7 +83,7 @@ public class TagValueShareTest {
+@@ -83,7 +84,7 @@ public class TagValueShareTest {
      }
  
      @Test
@@ -7606,7 +7872,7 @@ index bbed3b075d006d8c6cc92545337e428d14422c72..b375a45d41a8b04d2b7f4a9046db1084
          var tag = Tag.String("test").list();
          var tag2 = Tag.String("test").list();
          assertFalse(tag.shareValue(tag2.list()));
-@@ -91,7 +91,7 @@ public class TagValueShareTest {
+@@ -91,7 +92,7 @@ public class TagValueShareTest {
      }
  
      @Test
@@ -7615,7 +7881,7 @@ index bbed3b075d006d8c6cc92545337e428d14422c72..b375a45d41a8b04d2b7f4a9046db1084
          var tag = Tag.String("test").list();
          var tag2 = Tag.Integer("test").list();
          assertFalse(tag.shareValue(tag2));
-@@ -99,14 +99,14 @@ public class TagValueShareTest {
+@@ -99,14 +100,14 @@ public class TagValueShareTest {
      }
  
      @Test
@@ -7633,19 +7899,20 @@ index bbed3b075d006d8c6cc92545337e428d14422c72..b375a45d41a8b04d2b7f4a9046db1084
          var tag2 = Tag.Structure("test", Vec.class).list();
          assertTrue(tag.shareValue(tag2));
 diff --git a/src/test/java/net/minestom/server/tag/TagViewTest.java b/src/test/java/net/minestom/server/tag/TagViewTest.java
-index 718d84a6bb77d1ccb9cf5a00358c9df20e141ddd..8ab88efa4bcf663f11ac9392adb425ac86cb9fbd 100644
+index 718d84a6bb77d1ccb9cf5a00358c9df20e141ddd..fde49e58b400a346905314ff85a4492abc951adf 100644
 --- a/src/test/java/net/minestom/server/tag/TagViewTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagViewTest.java
-@@ -11,7 +11,7 @@ import java.util.Map;
+@@ -11,7 +11,8 @@ import java.util.Map;
  import static net.minestom.testing.TestUtils.assertEqualsSNBT;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class TagViewTest {
++//Microtus - update java keyword usage
 +class TagViewTest {
  
      private static final Tag<Entry> VIEW_TAG = Tag.View(new TagSerializer<>() {
          private static final Tag<String> VALUE_TAG = Tag.String("value");
-@@ -32,7 +32,7 @@ public class TagViewTest {
+@@ -32,7 +33,7 @@ public class TagViewTest {
      }
  
      @Test
@@ -7654,7 +7921,7 @@ index 718d84a6bb77d1ccb9cf5a00358c9df20e141ddd..8ab88efa4bcf663f11ac9392adb425ac
          var handler = TagHandler.newHandler();
          assertNull(handler.getTag(VIEW_TAG));
          assertFalse(handler.hasTag(VIEW_TAG));
-@@ -48,7 +48,7 @@ public class TagViewTest {
+@@ -48,7 +49,7 @@ public class TagViewTest {
      }
  
      @Test
@@ -7663,7 +7930,7 @@ index 718d84a6bb77d1ccb9cf5a00358c9df20e141ddd..8ab88efa4bcf663f11ac9392adb425ac
          var handler = TagHandler.newHandler();
          var entry = new Entry("hello");
          handler.setTag(VIEW_TAG, entry);
-@@ -63,7 +63,7 @@ public class TagViewTest {
+@@ -63,7 +64,7 @@ public class TagViewTest {
      }
  
      @Test
@@ -7672,7 +7939,7 @@ index 718d84a6bb77d1ccb9cf5a00358c9df20e141ddd..8ab88efa4bcf663f11ac9392adb425ac
          var handler = TagHandler.newHandler();
          var entry = new Entry("hello");
          handler.setTag(VIEW_TAG, entry);
-@@ -82,7 +82,7 @@ public class TagViewTest {
+@@ -82,7 +83,7 @@ public class TagViewTest {
      }
  
      @Test
@@ -7681,7 +7948,7 @@ index 718d84a6bb77d1ccb9cf5a00358c9df20e141ddd..8ab88efa4bcf663f11ac9392adb425ac
          var handler = TagHandler.newHandler();
          var tag = Tag.View(new TagSerializer<Entry>() {
              @Override
-@@ -112,7 +112,7 @@ public class TagViewTest {
+@@ -112,7 +113,7 @@ public class TagViewTest {
      }
  
      @Test
@@ -7690,7 +7957,7 @@ index 718d84a6bb77d1ccb9cf5a00358c9df20e141ddd..8ab88efa4bcf663f11ac9392adb425ac
          var handler = TagHandler.newHandler();
          var tag = VIEW_TAG.path("path");
          assertNull(handler.getTag(tag));
-@@ -129,7 +129,7 @@ public class TagViewTest {
+@@ -129,7 +130,7 @@ public class TagViewTest {
      }
  
      @Test
@@ -7699,7 +7966,7 @@ index 718d84a6bb77d1ccb9cf5a00358c9df20e141ddd..8ab88efa4bcf663f11ac9392adb425ac
          var handler = TagHandler.newHandler();
          var tag = VIEW_TAG.path("path");
          var entry = new Entry("hello");
-@@ -147,7 +147,7 @@ public class TagViewTest {
+@@ -147,7 +148,7 @@ public class TagViewTest {
      }
  
      @Test
@@ -7708,15 +7975,28 @@ index 718d84a6bb77d1ccb9cf5a00358c9df20e141ddd..8ab88efa4bcf663f11ac9392adb425ac
          var tag = Tag.View(TagSerializer.COMPOUND);
          var handler = TagHandler.newHandler();
          handler.setTag(tag, NBT.Compound(Map.of("value", NBT.String("hello"))));
+diff --git a/src/test/java/net/minestom/server/terminal/TerminalColorConverterTest.java b/src/test/java/net/minestom/server/terminal/TerminalColorConverterTest.java
+index a4e527d1561e748fe0add6e589ba97600feb7b3e..7c68370dbcd97cdd7dddba6aaed8978873da72eb 100644
+--- a/src/test/java/net/minestom/server/terminal/TerminalColorConverterTest.java
++++ b/src/test/java/net/minestom/server/terminal/TerminalColorConverterTest.java
+@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
+ 
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ 
++//Microtus - update java keyword usage
+ class TerminalColorConverterTest {
+     @Test
+     void testFormat() {
 diff --git a/src/test/java/net/minestom/server/thread/AcquirableTest.java b/src/test/java/net/minestom/server/thread/AcquirableTest.java
-index 43753f558743fb6d8cdc7a15211e23b57e033e66..af6812e4251131fe3750600aae6ee1143f09375f 100644
+index 43753f558743fb6d8cdc7a15211e23b57e033e66..247585e7060c4049114b22c9b9245707a9bb5060 100644
 --- a/src/test/java/net/minestom/server/thread/AcquirableTest.java
 +++ b/src/test/java/net/minestom/server/thread/AcquirableTest.java
-@@ -9,10 +9,10 @@ import java.util.concurrent.atomic.AtomicReference;
+@@ -9,10 +9,11 @@ import java.util.concurrent.atomic.AtomicReference;
  import static org.junit.jupiter.api.Assertions.assertNotEquals;
  import static org.junit.jupiter.api.Assertions.assertNotNull;
  
 -public class AcquirableTest {
++//Microtus - update java keyword usage
 +class AcquirableTest {
  
      @Test
@@ -7726,14 +8006,15 @@ index 43753f558743fb6d8cdc7a15211e23b57e033e66..af6812e4251131fe3750600aae6ee114
          Entity entity = new Entity(EntityType.ZOMBIE) {
              @Override
 diff --git a/src/test/java/net/minestom/server/thread/ThreadDispatcherTest.java b/src/test/java/net/minestom/server/thread/ThreadDispatcherTest.java
-index 00f7b48addb0e4ba2ff77f2ea2b49faa374fa4b8..d9de83b15b836ca618f7b9e170062569e8d6e2f3 100644
+index 00f7b48addb0e4ba2ff77f2ea2b49faa374fa4b8..dc4fac5cf5ecc2dcfdc1f6e6fd4e59b90e0be53e 100644
 --- a/src/test/java/net/minestom/server/thread/ThreadDispatcherTest.java
 +++ b/src/test/java/net/minestom/server/thread/ThreadDispatcherTest.java
-@@ -14,10 +14,10 @@ import java.util.stream.IntStream;
+@@ -14,10 +14,11 @@ import java.util.stream.IntStream;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class ThreadDispatcherTest {
++//Microtus - update java keyword usage
 +class ThreadDispatcherTest {
  
      @Test
@@ -7742,7 +8023,7 @@ index 00f7b48addb0e4ba2ff77f2ea2b49faa374fa4b8..d9de83b15b836ca618f7b9e170062569
          final AtomicInteger counter = new AtomicInteger();
          ThreadDispatcher<Object> dispatcher = ThreadDispatcher.singleThread();
          assertEquals(1, dispatcher.threads().size());
-@@ -45,7 +45,7 @@ public class ThreadDispatcherTest {
+@@ -45,7 +46,7 @@ public class ThreadDispatcherTest {
      }
  
      @Test
@@ -7751,7 +8032,7 @@ index 00f7b48addb0e4ba2ff77f2ea2b49faa374fa4b8..d9de83b15b836ca618f7b9e170062569
          // Partitions implementing Tickable should be ticked same as elements
          final AtomicInteger counter1 = new AtomicInteger();
          final AtomicInteger counter2 = new AtomicInteger();
-@@ -74,7 +74,7 @@ public class ThreadDispatcherTest {
+@@ -74,7 +75,7 @@ public class ThreadDispatcherTest {
      }
  
      @Test
@@ -7760,7 +8041,7 @@ index 00f7b48addb0e4ba2ff77f2ea2b49faa374fa4b8..d9de83b15b836ca618f7b9e170062569
          // Ensure that partitions are properly dispatched across threads
          final int threadCount = 10;
          ThreadDispatcher<Tickable> dispatcher = ThreadDispatcher.of(ThreadProvider.counter(), threadCount);
-@@ -103,7 +103,7 @@ public class ThreadDispatcherTest {
+@@ -103,7 +104,7 @@ public class ThreadDispatcherTest {
      }
  
      @Test
@@ -7770,14 +8051,15 @@ index 00f7b48addb0e4ba2ff77f2ea2b49faa374fa4b8..d9de83b15b836ca618f7b9e170062569
          // when RefreshType.ALWAYS is used
          interface Updater extends Tickable {
 diff --git a/src/test/java/net/minestom/server/timer/TestScheduler.java b/src/test/java/net/minestom/server/timer/TestScheduler.java
-index fdbb080822e6110b4dfbe8dcb2b51c0f868170af..3ebcb5bfc47cbb6de2579938560c224cda81b8d8 100644
+index fdbb080822e6110b4dfbe8dcb2b51c0f868170af..da04b40abba2c4ecc745b30ea81778ca6af4d9d7 100644
 --- a/src/test/java/net/minestom/server/timer/TestScheduler.java
 +++ b/src/test/java/net/minestom/server/timer/TestScheduler.java
-@@ -8,10 +8,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
+@@ -8,10 +8,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class TestScheduler {
++//Microtus - update java keyword usage
 +class TestScheduler {
  
      @Test
@@ -7786,7 +8068,7 @@ index fdbb080822e6110b4dfbe8dcb2b51c0f868170af..3ebcb5bfc47cbb6de2579938560c224c
          Scheduler scheduler = Scheduler.newScheduler();
          AtomicBoolean result = new AtomicBoolean(false);
          Task task = scheduler.scheduleNextTick(() -> result.set(true));
-@@ -26,7 +26,7 @@ public class TestScheduler {
+@@ -26,7 +27,7 @@ public class TestScheduler {
      }
  
      @Test
@@ -7795,7 +8077,7 @@ index fdbb080822e6110b4dfbe8dcb2b51c0f868170af..3ebcb5bfc47cbb6de2579938560c224c
          Scheduler scheduler = Scheduler.newScheduler();
          AtomicBoolean result = new AtomicBoolean(false);
          scheduler.buildTask(() -> result.set(true))
-@@ -41,7 +41,7 @@ public class TestScheduler {
+@@ -41,7 +42,7 @@ public class TestScheduler {
      }
  
      @Test
@@ -7804,7 +8086,7 @@ index fdbb080822e6110b4dfbe8dcb2b51c0f868170af..3ebcb5bfc47cbb6de2579938560c224c
          Scheduler scheduler = Scheduler.newScheduler();
          AtomicBoolean result = new AtomicBoolean(false);
          scheduler.scheduleNextProcess(() -> result.set(true));
-@@ -55,7 +55,7 @@ public class TestScheduler {
+@@ -55,7 +56,7 @@ public class TestScheduler {
      }
  
      @Test
@@ -7813,7 +8095,7 @@ index fdbb080822e6110b4dfbe8dcb2b51c0f868170af..3ebcb5bfc47cbb6de2579938560c224c
          Scheduler scheduler = Scheduler.newScheduler();
          AtomicBoolean result = new AtomicBoolean(false);
          var task = scheduler.buildTask(() -> result.set(true))
-@@ -68,7 +68,7 @@ public class TestScheduler {
+@@ -68,7 +69,7 @@ public class TestScheduler {
      }
  
      @Test
@@ -7822,7 +8104,7 @@ index fdbb080822e6110b4dfbe8dcb2b51c0f868170af..3ebcb5bfc47cbb6de2579938560c224c
          Scheduler scheduler = Scheduler.newScheduler();
          AtomicBoolean result = new AtomicBoolean(false);
          var task = scheduler.buildTask(() -> result.set(true))
-@@ -84,7 +84,7 @@ public class TestScheduler {
+@@ -84,7 +85,7 @@ public class TestScheduler {
      }
  
      @Test
@@ -7831,7 +8113,7 @@ index fdbb080822e6110b4dfbe8dcb2b51c0f868170af..3ebcb5bfc47cbb6de2579938560c224c
          Scheduler scheduler = Scheduler.newScheduler();
          // Ignored parked task
          scheduler.buildTask(() -> fail("This parked task should never be executed"))
-@@ -108,7 +108,7 @@ public class TestScheduler {
+@@ -108,7 +109,7 @@ public class TestScheduler {
      }
  
      @Test
@@ -7840,7 +8122,7 @@ index fdbb080822e6110b4dfbe8dcb2b51c0f868170af..3ebcb5bfc47cbb6de2579938560c224c
          Scheduler scheduler = Scheduler.newScheduler();
          CompletableFuture<Void> future = new CompletableFuture<>();
          AtomicBoolean result = new AtomicBoolean(false);
-@@ -123,7 +123,7 @@ public class TestScheduler {
+@@ -123,7 +124,7 @@ public class TestScheduler {
      }
  
      @Test
@@ -7850,14 +8132,15 @@ index fdbb080822e6110b4dfbe8dcb2b51c0f868170af..3ebcb5bfc47cbb6de2579938560c224c
          Scheduler scheduler = Scheduler.newScheduler();
          AtomicBoolean result = new AtomicBoolean(false);
 diff --git a/src/test/java/net/minestom/server/utils/ChunkUtilsTest.java b/src/test/java/net/minestom/server/utils/ChunkUtilsTest.java
-index 5327ad0533a6262b55575da0e7851d3fe4e77f2b..c6d314ab4f1c99aed9d662432844a0edb28e014d 100644
+index 5327ad0533a6262b55575da0e7851d3fe4e77f2b..7b0e91f720a5b3f34e5207d6e5554b07ca5c231e 100644
 --- a/src/test/java/net/minestom/server/utils/ChunkUtilsTest.java
 +++ b/src/test/java/net/minestom/server/utils/ChunkUtilsTest.java
-@@ -9,11 +9,11 @@ import org.junit.jupiter.api.Assertions;
+@@ -9,11 +9,12 @@ import org.junit.jupiter.api.Assertions;
  import java.util.*;
  import java.util.stream.Stream;
  
 -public class ChunkUtilsTest {
++//Microtus - update java keyword usage
 +class ChunkUtilsTest {
  
      @ParameterizedTest
@@ -7868,14 +8151,15 @@ index 5327ad0533a6262b55575da0e7851d3fe4e77f2b..c6d314ab4f1c99aed9d662432844a0ed
          final Set<ChunkCoordinate> o = new HashSet<>();
          ChunkUtils.forChunksInRange(nx, nz, r, (x, z) -> n.add(new ChunkCoordinate(x, z)));
 diff --git a/src/test/java/net/minestom/server/utils/NamespaceIDTest.java b/src/test/java/net/minestom/server/utils/NamespaceIDTest.java
-index 5bae45cd92299a01210869345899018fa4c646af..07ce514e9d8268495d2e4ee632f6760a81a120e8 100644
+index 5bae45cd92299a01210869345899018fa4c646af..3f6016ba4d2eae35daceb3898af01b6a2d286c91 100644
 --- a/src/test/java/net/minestom/server/utils/NamespaceIDTest.java
 +++ b/src/test/java/net/minestom/server/utils/NamespaceIDTest.java
-@@ -5,10 +5,10 @@ import org.junit.jupiter.api.Test;
+@@ -5,10 +5,11 @@ import org.junit.jupiter.api.Test;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class NamespaceIDTest {
++//Microtus - update java keyword usage
 +class NamespaceIDTest {
  
      @Test
@@ -7884,7 +8168,7 @@ index 5bae45cd92299a01210869345899018fa4c646af..07ce514e9d8268495d2e4ee632f6760a
          var namespace = NamespaceID.from("minecraft:any");
          assertEquals("minecraft", namespace.domain());
          assertEquals("any", namespace.path());
-@@ -21,7 +21,7 @@ public class NamespaceIDTest {
+@@ -21,7 +22,7 @@ public class NamespaceIDTest {
      }
  
      @Test
@@ -7893,7 +8177,7 @@ index 5bae45cd92299a01210869345899018fa4c646af..07ce514e9d8268495d2e4ee632f6760a
          var namespace = NamespaceID.from("minecraft:any");
          assertEquals(namespace, NamespaceID.from("minecraft:any"));
          assertNotEquals(namespace, NamespaceID.from("minecraft:any2"));
-@@ -29,7 +29,7 @@ public class NamespaceIDTest {
+@@ -29,7 +30,7 @@ public class NamespaceIDTest {
      }
      // Microtus start - Fix namespace hashcode and equals
      @Test
@@ -7902,7 +8186,7 @@ index 5bae45cd92299a01210869345899018fa4c646af..07ce514e9d8268495d2e4ee632f6760a
          var namespace = NamespaceID.from("minecraft:any");
          var key = Key.key("minecraft:any");
  
-@@ -39,50 +39,50 @@ public class NamespaceIDTest {
+@@ -39,50 +40,50 @@ public class NamespaceIDTest {
      // Microtus end - Fix namespace hashcode and equals
  
      @Test
@@ -7963,14 +8247,15 @@ index 5bae45cd92299a01210869345899018fa4c646af..07ce514e9d8268495d2e4ee632f6760a
      }
  }
 diff --git a/src/test/java/net/minestom/server/utils/ObjectPoolTest.java b/src/test/java/net/minestom/server/utils/ObjectPoolTest.java
-index 42c8557addf779784d57fc5eac5147fd533e4025..d3dc473514df009b1df3957ae5bdfde0e46cd05f 100644
+index 42c8557addf779784d57fc5eac5147fd533e4025..1eb8403d2d2f26727556020108a0e96971f21659 100644
 --- a/src/test/java/net/minestom/server/utils/ObjectPoolTest.java
 +++ b/src/test/java/net/minestom/server/utils/ObjectPoolTest.java
-@@ -8,10 +8,10 @@ import java.util.Set;
+@@ -8,10 +8,11 @@ import java.util.Set;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class ObjectPoolTest {
++//Microtus - update java keyword usage
 +class ObjectPoolTest {
  
      @Test
@@ -7979,7 +8264,7 @@ index 42c8557addf779784d57fc5eac5147fd533e4025..d3dc473514df009b1df3957ae5bdfde0
          var pool = ObjectPool.BUFFER_POOL;
          Set<BinaryBuffer> pooledBuffers = new HashSet<>();
          pool.clear();
-@@ -31,7 +31,7 @@ public class ObjectPoolTest {
+@@ -31,7 +32,7 @@ public class ObjectPoolTest {
      }
  
      @Test
@@ -7989,14 +8274,15 @@ index 42c8557addf779784d57fc5eac5147fd533e4025..d3dc473514df009b1df3957ae5bdfde0
          assertEquals(0, pool.count());
          try (var ignored = pool.hold()) {
 diff --git a/src/test/java/net/minestom/server/utils/PositionUtilsTest.java b/src/test/java/net/minestom/server/utils/PositionUtilsTest.java
-index 888bee67eda2820ebb9944e04073dcb020c162dd..aeba8005db97d16d04b385b388ff469f533ac6a6 100644
+index 888bee67eda2820ebb9944e04073dcb020c162dd..15fb4494aac4122ba54b0c2c6d3549761b680c2b 100644
 --- a/src/test/java/net/minestom/server/utils/PositionUtilsTest.java
 +++ b/src/test/java/net/minestom/server/utils/PositionUtilsTest.java
-@@ -5,10 +5,10 @@ import org.junit.jupiter.api.Test;
+@@ -5,10 +5,11 @@ import org.junit.jupiter.api.Test;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class PositionUtilsTest {
++//Microtus - update java keyword usage
 +class PositionUtilsTest {
  
      @Test
@@ -8005,7 +8291,7 @@ index 888bee67eda2820ebb9944e04073dcb020c162dd..aeba8005db97d16d04b385b388ff469f
          float plusX = PositionUtils.getLookYaw(10, 0);
          assertEquals(-90, plusX, 1E-5);
  
-@@ -34,7 +34,7 @@ public class PositionUtilsTest {
+@@ -34,7 +35,7 @@ public class PositionUtilsTest {
      }
  
      @Test
@@ -8015,14 +8301,15 @@ index 888bee67eda2820ebb9944e04073dcb020c162dd..aeba8005db97d16d04b385b388ff469f
          assertEquals(-90, high, 1E-5);
  
 diff --git a/src/test/java/net/minestom/server/utils/TestMojangUtils.java b/src/test/java/net/minestom/server/utils/TestMojangUtils.java
-index eee508bc380ebb9a8668b80acacfedf342bde903..4eb0a8407815dc946a268d5eeb6c09658e4c85c6 100644
+index eee508bc380ebb9a8668b80acacfedf342bde903..61abc8efbe2e94b279b0226241aa6201d35be914 100644
 --- a/src/test/java/net/minestom/server/utils/TestMojangUtils.java
 +++ b/src/test/java/net/minestom/server/utils/TestMojangUtils.java
-@@ -5,22 +5,22 @@ import org.junit.jupiter.api.Test;
+@@ -5,22 +5,23 @@ import org.junit.jupiter.api.Test;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class TestMojangUtils {
++//Microtus - update java keyword usage
 +class TestMojangUtils {
      @Test
 -    public void testValidNameWorks() {
@@ -8045,7 +8332,7 @@ index eee508bc380ebb9a8668b80acacfedf342bde903..4eb0a8407815dc946a268d5eeb6c0965
          var result = MojangUtils.fromUuid("853c80ef3c3749fdaa49938b674adae6");
          assertNotNull(result);
          assertEquals("jeb_", result.get("name").getAsString());
-@@ -28,13 +28,13 @@ public class TestMojangUtils {
+@@ -28,13 +29,13 @@ public class TestMojangUtils {
      }
  
      @Test
@@ -8062,19 +8349,21 @@ index eee508bc380ebb9a8668b80acacfedf342bde903..4eb0a8407815dc946a268d5eeb6c0965
          assertNull(result);
      }
 diff --git a/src/test/java/net/minestom/server/utils/TranslationIntegrationTest.java b/src/test/java/net/minestom/server/utils/TranslationIntegrationTest.java
-index fe070a1d1754c08e9143bd357bf63695c738c2a1..feb26612e86ad2d576a2d2f28600b01b340e4566 100644
+index fe070a1d1754c08e9143bd357bf63695c738c2a1..91ee91f5589b2243d26d41d43148832c68704220 100644
 --- a/src/test/java/net/minestom/server/utils/TranslationIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/utils/TranslationIntegrationTest.java
-@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -18,8 +18,9 @@ import java.util.List;
+ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNotEquals;
  
++//Microtus - update java keyword usage
  @EnvTest
 -public class TranslationIntegrationTest {
 +class TranslationIntegrationTest {
  
      @BeforeAll
      static void translator() {
-@@ -30,7 +30,7 @@ public class TranslationIntegrationTest {
+@@ -30,7 +31,7 @@ public class TranslationIntegrationTest {
      }
  
      @Test
@@ -8083,7 +8372,7 @@ index fe070a1d1754c08e9143bd357bf63695c738c2a1..feb26612e86ad2d576a2d2f28600b01b
          final var instance = env.createFlatInstance();
          final var connection = env.createConnection();
          final var player = connection.connect(instance, new Pos(0, 40, 0)).join();
-@@ -49,7 +49,7 @@ public class TranslationIntegrationTest {
+@@ -49,7 +50,7 @@ public class TranslationIntegrationTest {
      }
  
      @Test
@@ -8092,15 +8381,29 @@ index fe070a1d1754c08e9143bd357bf63695c738c2a1..feb26612e86ad2d576a2d2f28600b01b
          final var instance = env.createFlatInstance();
          final var connection = env.createConnection();
          final var player = connection.connect(instance, new Pos(0, 40, 0)).join();
+diff --git a/src/test/java/net/minestom/server/utils/UniqueIdUtilsTest.java b/src/test/java/net/minestom/server/utils/UniqueIdUtilsTest.java
+index f7bc989b8f89f37798e2645a54d71127fa5a767d..02cadd1d6d9a90910d45ac5cc6d11482ab6d1357 100644
+--- a/src/test/java/net/minestom/server/utils/UniqueIdUtilsTest.java
++++ b/src/test/java/net/minestom/server/utils/UniqueIdUtilsTest.java
+@@ -7,7 +7,7 @@ import java.util.UUID;
+ import static net.minestom.server.utils.UniqueIdUtils.*;
+ import static org.junit.jupiter.api.Assertions.*;
+ 
+-// Microtus - improve string pattern usage + test
++//Microtus - update java keyword usage
+ class UniqueIdUtilsTest {
+ 
+     @Test
 diff --git a/src/test/java/net/minestom/server/utils/block/BlockIteratorTest.java b/src/test/java/net/minestom/server/utils/block/BlockIteratorTest.java
-index 12ba498890d53c76c1847fb0df1367943a33b4fe..a944e04ef851f120970e6e12a76a7dd670997c89 100644
+index 12ba498890d53c76c1847fb0df1367943a33b4fe..16403be2ca015673e5cadd693aa7126363158de0 100644
 --- a/src/test/java/net/minestom/server/utils/block/BlockIteratorTest.java
 +++ b/src/test/java/net/minestom/server/utils/block/BlockIteratorTest.java
-@@ -9,13 +9,13 @@ import java.util.List;
+@@ -9,13 +9,14 @@ import java.util.List;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class BlockIteratorTest {
++//Microtus - update java keyword usage
 +class BlockIteratorTest {
      private void assertContains(List<Point> points, Point point) {
          assertTrue(points.contains(point), "Expected " + points + " to contain " + point);
@@ -8112,7 +8415,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..a944e04ef851f120970e6e12a76a7dd6
          Vec s = new Vec(0,  0.1, 0);
          Vec e = new Vec(2, 1, 0);
          BlockIterator iterator = new BlockIterator(s, e, 0, 4);
-@@ -29,7 +29,7 @@ public class BlockIteratorTest {
+@@ -29,7 +30,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8121,7 +8424,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..a944e04ef851f120970e6e12a76a7dd6
          Vec s = new Vec(0,  0.1, 0);
          Vec e = new Vec(-2, 1, 0);
          BlockIterator iterator = new BlockIterator(s, e, 0, 4);
-@@ -44,7 +44,7 @@ public class BlockIteratorTest {
+@@ -44,7 +45,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8130,7 +8433,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..a944e04ef851f120970e6e12a76a7dd6
          Vec s = new Vec(0,  -0.1, 0);
          Vec e = new Vec(2, 1, 0);
          BlockIterator iterator = new BlockIterator(s, e, 0, 4);
-@@ -59,7 +59,7 @@ public class BlockIteratorTest {
+@@ -59,7 +60,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8139,7 +8442,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..a944e04ef851f120970e6e12a76a7dd6
          Vec s = new Vec(0,  -0.1, 0);
          Vec e = new Vec(-2, 1, 0);
          BlockIterator iterator = new BlockIterator(s, e, 0, 4);
-@@ -75,7 +75,7 @@ public class BlockIteratorTest {
+@@ -75,7 +76,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8148,7 +8451,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..a944e04ef851f120970e6e12a76a7dd6
          Vec s = new Vec(0,  0, 0);
          Vec e = new Vec(0, 0, 0);
          BlockIterator iterator = new BlockIterator(s, e, 0, 4);
-@@ -83,7 +83,7 @@ public class BlockIteratorTest {
+@@ -83,7 +84,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8157,7 +8460,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..a944e04ef851f120970e6e12a76a7dd6
          Vec s = new Vec(42.5, 0, 51.5);
          Vec e = new Vec(-12, 0, -36);
          BlockIterator iterator = new BlockIterator(s, e, 0, 37);
-@@ -163,7 +163,7 @@ public class BlockIteratorTest {
+@@ -163,7 +164,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8166,7 +8469,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..a944e04ef851f120970e6e12a76a7dd6
          Vec s = new Vec(0.5, 40, 0.5);
          Vec e = new Vec(27, 0, 21);
          BlockIterator iterator = new BlockIterator(s, e, 0, 34);
-@@ -235,7 +235,7 @@ public class BlockIteratorTest {
+@@ -235,7 +236,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8175,7 +8478,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..a944e04ef851f120970e6e12a76a7dd6
          Vec s = new Vec(0.5,  0, 0.5);
          Vec e = new Vec(0, 1, 0);
          BlockIterator iterator = new BlockIterator(s, e, 0, 1);
-@@ -245,7 +245,7 @@ public class BlockIteratorTest {
+@@ -245,7 +246,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8184,7 +8487,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..a944e04ef851f120970e6e12a76a7dd6
          Vec s = new Vec(0.5,  0, 0.5);
          Vec e = new Vec(0, 1, 0);
          BlockIterator iterator = new BlockIterator(s, e, 0, 0.5);
-@@ -254,7 +254,7 @@ public class BlockIteratorTest {
+@@ -254,7 +255,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8193,7 +8496,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..a944e04ef851f120970e6e12a76a7dd6
          Vec s = new Vec(0.1,  0.1, 0.1);
          Vec e = new Vec(1, 1, 1);
          BlockIterator iterator = new BlockIterator(s, e, 0, 4);
-@@ -283,7 +283,7 @@ public class BlockIteratorTest {
+@@ -283,7 +284,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8202,7 +8505,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..a944e04ef851f120970e6e12a76a7dd6
          Vec s = new Vec(0,  0, 0);
          Vec e = new Vec(2, 1, 0);
          BlockIterator iterator = new BlockIterator(s, e, 0, 4);
-@@ -309,7 +309,7 @@ public class BlockIteratorTest {
+@@ -309,7 +310,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8211,7 +8514,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..a944e04ef851f120970e6e12a76a7dd6
          Vec s = new Vec(0,  0, 0);
          Vec e = new Vec(-2, 1, 0);
          BlockIterator iterator = new BlockIterator(s, e, 0, 4);
-@@ -336,7 +336,7 @@ public class BlockIteratorTest {
+@@ -336,7 +337,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8220,7 +8523,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..a944e04ef851f120970e6e12a76a7dd6
          Vec s = new Vec(0,  0, 0);
          Vec e = new Vec(-2, -1, 0);
          BlockIterator iterator = new BlockIterator(s, e, 0, 4);
-@@ -365,7 +365,7 @@ public class BlockIteratorTest {
+@@ -365,7 +366,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8230,14 +8533,15 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..a944e04ef851f120970e6e12a76a7dd6
          Vec e = new Vec(0, -10, 0);
          BlockIterator iterator = new BlockIterator(s, e, 0, 14.142135623730951);
 diff --git a/src/test/java/net/minestom/server/utils/collection/AutoIncrementMapTest.java b/src/test/java/net/minestom/server/utils/collection/AutoIncrementMapTest.java
-index b19454170b525977d6a59353a8da6bc70896bad1..04946c4ab86fe6aad9cebcd510f64251af5c8a55 100644
+index b19454170b525977d6a59353a8da6bc70896bad1..6e968e39c3178a1f7cc7ec2edfe8656b275879e7 100644
 --- a/src/test/java/net/minestom/server/utils/collection/AutoIncrementMapTest.java
 +++ b/src/test/java/net/minestom/server/utils/collection/AutoIncrementMapTest.java
-@@ -4,9 +4,9 @@ import org.junit.jupiter.api.Test;
+@@ -4,9 +4,10 @@ import org.junit.jupiter.api.Test;
  
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
 -public class AutoIncrementMapTest {
++//Microtus - update java keyword usage
 +class AutoIncrementMapTest {
      @Test
 -    public void test() {
@@ -8246,14 +8550,15 @@ index b19454170b525977d6a59353a8da6bc70896bad1..04946c4ab86fe6aad9cebcd510f64251
          for (int i = 0; i < 1000; i++) {
              assertEquals(i, map.get("test" + i));
 diff --git a/src/test/java/net/minestom/server/utils/collection/ObjectArrayTest.java b/src/test/java/net/minestom/server/utils/collection/ObjectArrayTest.java
-index ee2f9544050ed61ad3467949cbdc80004d0739e4..cece245e05262a23325a48f8bd7194d7e87462e1 100644
+index ee2f9544050ed61ad3467949cbdc80004d0739e4..fe49b7e40d2eca3479d8a81daca8300b09e9ee56 100644
 --- a/src/test/java/net/minestom/server/utils/collection/ObjectArrayTest.java
 +++ b/src/test/java/net/minestom/server/utils/collection/ObjectArrayTest.java
-@@ -5,11 +5,11 @@ import org.junit.jupiter.params.provider.ValueSource;
+@@ -5,11 +5,12 @@ import org.junit.jupiter.params.provider.ValueSource;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class ObjectArrayTest {
++//Microtus - update java keyword usage
 +class ObjectArrayTest {
  
      @ParameterizedTest
@@ -8263,7 +8568,7 @@ index ee2f9544050ed61ad3467949cbdc80004d0739e4..cece245e05262a23325a48f8bd7194d7
          ObjectArray<String> array = concurrent ? ObjectArray.concurrent() : ObjectArray.singleThread();
  
          array.set(50, "Hey");
-@@ -37,7 +37,7 @@ public class ObjectArrayTest {
+@@ -37,7 +38,7 @@ public class ObjectArrayTest {
  
      @ParameterizedTest
      @ValueSource(booleans = {false, true})

--- a/minestom-patches/0015-Update-java-keyword-usage.patch
+++ b/minestom-patches/0015-Update-java-keyword-usage.patch
@@ -697,15 +697,14 @@ index 4730006416bd9c4a7f1ff291feddb83c9ffedd6d..00764c03932ecef0e5ac7f68762e4d12
          return Stream.empty();
      }
 diff --git a/src/test/java/net/minestom/server/InsideTest.java b/src/test/java/net/minestom/server/InsideTest.java
-index 4fd8bc46ba32abc852398872bf8b63a30617408e..36d872b6e4e9a8db1fb7e75c808e912a3f52d12c 100644
+index 4fd8bc46ba32abc852398872bf8b63a30617408e..33c65cc23c0982d2e37eb12e40d844562bf85380 100644
 --- a/src/test/java/net/minestom/server/InsideTest.java
 +++ b/src/test/java/net/minestom/server/InsideTest.java
-@@ -5,9 +5,10 @@ import org.junit.jupiter.api.Test;
+@@ -5,9 +5,9 @@ import org.junit.jupiter.api.Test;
  
  import static org.junit.jupiter.api.Assertions.assertTrue;
  
 -public class InsideTest {
-+//Microtus - update java keyword usage
 +class InsideTest {
      @Test
 -    public void inside() {
@@ -714,15 +713,14 @@ index 4fd8bc46ba32abc852398872bf8b63a30617408e..36d872b6e4e9a8db1fb7e75c808e912a
      }
  }
 diff --git a/src/test/java/net/minestom/server/ServerProcessTest.java b/src/test/java/net/minestom/server/ServerProcessTest.java
-index 96d1264f5efefc33cf125747b591a94dc0f5da57..98a05295c822c1cebbcb23e7dcddbeac6834709c 100644
+index 96d1264f5efefc33cf125747b591a94dc0f5da57..c0c90d3e6fa722ca5e79d71955965b3f42fea33b 100644
 --- a/src/test/java/net/minestom/server/ServerProcessTest.java
 +++ b/src/test/java/net/minestom/server/ServerProcessTest.java
-@@ -8,10 +8,11 @@ import java.util.concurrent.atomic.AtomicReference;
+@@ -8,10 +8,10 @@ import java.util.concurrent.atomic.AtomicReference;
  import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
  import static org.junit.jupiter.api.Assertions.assertThrows;
  
 -public class ServerProcessTest {
-+//Microtus - update java keyword usage
 +class ServerProcessTest {
  
      @Test
@@ -731,7 +729,7 @@ index 96d1264f5efefc33cf125747b591a94dc0f5da57..98a05295c822c1cebbcb23e7dcddbeac
          AtomicReference<ServerProcess> process = new AtomicReference<>();
          assertDoesNotThrow(() -> process.set(MinecraftServer.updateProcess()));
          assertDoesNotThrow(() -> process.get().start(new InetSocketAddress("localhost", 25565)));
-@@ -20,7 +21,7 @@ public class ServerProcessTest {
+@@ -20,7 +20,7 @@ public class ServerProcessTest {
      }
  
      @Test
@@ -741,14 +739,12 @@ index 96d1264f5efefc33cf125747b591a94dc0f5da57..98a05295c822c1cebbcb23e7dcddbeac
          process.start(new InetSocketAddress("localhost", 25565));
          var ticker = process.ticker();
 diff --git a/src/test/java/net/minestom/server/advancements/AdvancementIntegrationTest.java b/src/test/java/net/minestom/server/advancements/AdvancementIntegrationTest.java
-index d74d97e8b826dbca100f31d830bba83b91ced040..e8c664e3ecf6ba0483d2c78292c7e9df45463094 100644
+index d74d97e8b826dbca100f31d830bba83b91ced040..2d317516f9e63cd732019b22b39d7c76d5861ec8 100644
 --- a/src/test/java/net/minestom/server/advancements/AdvancementIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/advancements/AdvancementIntegrationTest.java
-@@ -9,11 +9,12 @@ import org.junit.jupiter.api.Test;
- 
+@@ -10,10 +10,10 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.*;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class AdvancementIntegrationTest {
 +class AdvancementIntegrationTest {
@@ -759,7 +755,7 @@ index d74d97e8b826dbca100f31d830bba83b91ced040..e8c664e3ecf6ba0483d2c78292c7e9df
          var instance = env.createFlatInstance();
          var player = env.createPlayer(instance, new Pos(0, 42, 0));
  
-@@ -46,7 +47,7 @@ public class AdvancementIntegrationTest {
+@@ -46,7 +46,7 @@ public class AdvancementIntegrationTest {
      }
  
      @Test
@@ -769,15 +765,14 @@ index d74d97e8b826dbca100f31d830bba83b91ced040..e8c664e3ecf6ba0483d2c78292c7e9df
          var player = env.createPlayer(instance, new Pos(0, 42, 0));
  
 diff --git a/src/test/java/net/minestom/server/adventure/provider/TranslationTest.java b/src/test/java/net/minestom/server/adventure/provider/TranslationTest.java
-index 6754317b80025d68e92e526ba8a4eab9fefbfe6a..a3a72f90485a8736130008e0af937c37913db8fe 100644
+index 6754317b80025d68e92e526ba8a4eab9fefbfe6a..fa2ea6380affb15c5e5e4cb94ccb478277a16a50 100644
 --- a/src/test/java/net/minestom/server/adventure/provider/TranslationTest.java
 +++ b/src/test/java/net/minestom/server/adventure/provider/TranslationTest.java
-@@ -4,10 +4,11 @@ import net.kyori.adventure.text.Component;
+@@ -4,10 +4,10 @@ import net.kyori.adventure.text.Component;
  import net.minestom.server.adventure.MinestomAdventure;
  import org.junit.jupiter.api.Test;
  
 -public class TranslationTest {
-+//Microtus - update java keyword usage
 +class TranslationTest {
  
      @Test
@@ -787,21 +782,19 @@ index 6754317b80025d68e92e526ba8a4eab9fefbfe6a..a3a72f90485a8736130008e0af937c37
          try {
              MinestomFlattenerProvider.INSTANCE.flatten(Component.translatable("key.unregistered"), text -> {
 diff --git a/src/test/java/net/minestom/server/collision/EntityBlockPhysicsIntegrationTest.java b/src/test/java/net/minestom/server/collision/EntityBlockPhysicsIntegrationTest.java
-index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab33ae56a3c 100644
+index 78e6632635d5c40941cf5e160beb8600a788deec..81e1f37d17e3628837854a86b4d0ae4a3b690598 100644
 --- a/src/test/java/net/minestom/server/collision/EntityBlockPhysicsIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/collision/EntityBlockPhysicsIntegrationTest.java
-@@ -16,8 +16,9 @@ import java.util.Map;
- 
+@@ -17,7 +17,7 @@ import java.util.Map;
  import static org.junit.jupiter.api.Assertions.*;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class EntityBlockPhysicsIntegrationTest {
 +class EntityBlockPhysicsIntegrationTest {
      private static final Point PRECISION = new Pos(0.01, 0.01, 0.01);
  
      private static boolean checkPoints(Point expected, Point actual) {
-@@ -45,7 +46,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -45,7 +45,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -810,7 +803,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(0, 43, 1, Block.STONE);
  
-@@ -58,7 +59,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -58,7 +58,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -819,7 +812,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
  
          for (int i = -2; i <= 2; ++i)
-@@ -76,7 +77,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -76,7 +76,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -828,7 +821,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(13, 99, 16, Block.STONE);
  
-@@ -91,7 +92,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -91,7 +91,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -837,7 +830,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(0, 42, 0, Block.OAK_FENCE);
  
-@@ -104,7 +105,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -104,7 +104,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -846,7 +839,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
  
          for (int i = -2; i <= 2; ++i)
-@@ -123,7 +124,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -123,7 +123,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -855,7 +848,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(0, 42, 0, Block.OAK_FENCE);
          instance.setBlock(0, 43, 0, Block.BROWN_CARPET);
-@@ -137,7 +138,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -137,7 +137,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -864,7 +857,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(1, 42, 0, Block.OAK_FENCE);
  
-@@ -150,7 +151,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -150,7 +150,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -873,7 +866,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(4, 40, -1, Block.SANDSTONE_STAIRS);
          instance.setBlock(16, 40, 0, Block.STONE);
-@@ -164,7 +165,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -164,7 +164,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -882,7 +875,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(4, 40, 0, Block.GRASS_BLOCK);
          instance.setBlock(16, 40, 0, Block.STONE);
-@@ -181,7 +182,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -181,7 +181,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -891,7 +884,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(1, 42, 0, Block.OAK_FENCE);
          instance.setBlock(1, 43, 0, Block.BROWN_CARPET);
-@@ -195,7 +196,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -195,7 +195,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -900,7 +893,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
  
          for (int i = -2; i <= 2; ++i)
-@@ -214,7 +215,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -214,7 +214,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -909,7 +902,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
  
          for (int i = -2; i <= 2; ++i)
-@@ -233,7 +234,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -233,7 +233,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -918,7 +911,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
  
          for (int i = -2; i <= 2; ++i)
-@@ -264,7 +265,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -264,7 +264,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -927,7 +920,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(0, 42, 0, Block.OAK_FENCE);
          instance.setBlock(0, 43, 0, Block.BROWN_CARPET);
-@@ -278,7 +279,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -278,7 +278,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -936,7 +929,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
  
          instance.setBlock(0, 45, 0, Block.OAK_FENCE);
-@@ -292,7 +293,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -292,7 +292,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -945,7 +938,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(1, 43, 1, Block.STONE);
          instance.setBlock(1, 43, 2, Block.STONE);
-@@ -308,7 +309,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -308,7 +308,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -954,7 +947,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(1, 43, 1, Block.STONE);
          instance.setBlock(1, 43, 2, Block.STONE);
-@@ -322,7 +323,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -322,7 +322,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -963,7 +956,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          for (int i = -2; i <= 2; ++i)
              for (int j = -2; j <= 2; ++j)
-@@ -341,7 +342,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -341,7 +341,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -972,7 +965,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          for (int i = -2; i <= 2; ++i)
              for (int j = -2; j <= 2; ++j)
-@@ -363,7 +364,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -363,7 +363,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -981,7 +974,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          for (int i = -2; i <= 2; ++i)
              for (int j = -2; j <= 2; ++j)
-@@ -385,7 +386,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -385,7 +385,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -990,7 +983,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(11, 43, 11, Block.STONE);
  
-@@ -402,7 +403,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -402,7 +402,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -999,7 +992,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          Point z1 = new Pos(0, 0, 0);
          Point z2 = new Pos(15, 0, 0);
          Point z3 = new Pos(11, 0, 0);
-@@ -420,7 +421,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -420,7 +420,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1008,7 +1001,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(1, 43, 1, Block.STONE);
  
-@@ -433,7 +434,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -433,7 +433,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1017,7 +1010,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(1, 42, 1, Block.STONE);
  
-@@ -447,7 +448,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -447,7 +447,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1026,7 +1019,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          Block b = Block.ACACIA_TRAPDOOR.withProperties(Map.of("facing", "north", "open", "true"));
  
-@@ -462,7 +463,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -462,7 +462,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1035,7 +1028,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          Block b = Block.ACACIA_TRAPDOOR.withProperties(Map.of("facing", "south", "open", "true"));
  
-@@ -477,7 +478,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -477,7 +477,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1044,7 +1037,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          Block b = Block.ACACIA_TRAPDOOR.withProperties(Map.of("facing", "west", "open", "true"));
  
-@@ -492,7 +493,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -492,7 +492,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1053,7 +1046,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          Block b = Block.ACACIA_TRAPDOOR.withProperties(Map.of("facing", "east", "open", "true"));
  
-@@ -507,7 +508,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -507,7 +507,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1062,7 +1055,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          Block b = Block.ACACIA_TRAPDOOR.withProperties(Map.of("half", "top"));
  
-@@ -522,7 +523,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -522,7 +522,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1071,7 +1064,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          Block b = Block.ACACIA_TRAPDOOR;
  
-@@ -537,7 +538,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -537,7 +537,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1080,7 +1073,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(0, 40, 0, Block.STONE);
  
-@@ -550,7 +551,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -550,7 +550,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1089,7 +1082,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(0, 42, 0, Block.ACACIA_STAIRS);
  
-@@ -563,7 +564,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -563,7 +563,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1098,7 +1091,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(0, 42, 0, Block.ACACIA_STAIRS);
  
-@@ -576,7 +577,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -576,7 +576,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1107,7 +1100,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
  
          for (int i = -2; i <= 2; ++i)
-@@ -592,7 +593,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -592,7 +592,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1116,7 +1109,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(0, 60, 0, Block.STONE);
  
-@@ -605,7 +606,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -605,7 +605,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1125,7 +1118,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(1, 43, 1, Block.STONE);
          instance.setBlock(1, 43, 2, Block.STONE);
-@@ -620,7 +621,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -620,7 +620,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1134,7 +1127,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(1, 43, 0, Block.STONE);
  
-@@ -634,7 +635,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -634,7 +634,7 @@ public class EntityBlockPhysicsIntegrationTest {
  
      // Checks C include all checks for crossing one intermediate block (3 block checks)
      @Test
@@ -1143,7 +1136,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(1, 42, 0, Block.STONE);
  
-@@ -649,7 +650,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -649,7 +649,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1152,7 +1145,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(0, 42, 1, Block.STONE);
  
-@@ -664,7 +665,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -664,7 +664,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1161,7 +1154,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(1, 42, 1, Block.STONE);
  
-@@ -679,7 +680,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -679,7 +679,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1170,7 +1163,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(0, 42, 0, Block.STONE);
  
-@@ -694,7 +695,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -694,7 +694,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1179,7 +1172,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(0, 42, 1, Block.STONE);
  
-@@ -709,7 +710,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -709,7 +709,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1188,7 +1181,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(1, 42, 0, Block.STONE);
  
-@@ -724,7 +725,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -724,7 +724,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1197,7 +1190,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(0, 42, 0, Block.STONE);
  
-@@ -739,7 +740,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -739,7 +739,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1206,7 +1199,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(1, 42, 1, Block.STONE);
  
-@@ -755,7 +756,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -755,7 +755,7 @@ public class EntityBlockPhysicsIntegrationTest {
  
      // Checks CE include checks for crossing two intermediate block (4 block checks)
      @Test
@@ -1215,7 +1208,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(1, 43, 0, Block.STONE);
  
-@@ -770,7 +771,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -770,7 +770,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1224,7 +1217,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(0, 43, 1, Block.STONE);
  
-@@ -785,7 +786,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -785,7 +785,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1233,7 +1226,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(1, 43, 1, Block.STONE);
  
-@@ -801,7 +802,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -801,7 +801,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1242,7 +1235,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
  
          for (int i = -2; i <= 2; ++i)
-@@ -817,7 +818,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -817,7 +817,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1251,7 +1244,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(0, 43, 2, Block.STONE);
          instance.setBlock(2, 43, 0, Block.STONE);
-@@ -831,7 +832,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -831,7 +831,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1260,7 +1253,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
  
          instance.setBlock(0, 43, 1, Block.STONE);
-@@ -865,7 +866,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -865,7 +865,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1269,7 +1262,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityType.ZOMBIE);
  
-@@ -880,7 +881,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -880,7 +880,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1278,7 +1271,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityType.ZOMBIE);
  
-@@ -897,7 +898,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -897,7 +897,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1287,7 +1280,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityType.ZOMBIE);
  
-@@ -909,7 +910,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -909,7 +909,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1296,7 +1289,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          PhysicsResult previousResult = null;
  
-@@ -941,7 +942,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -941,7 +941,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1305,7 +1298,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityType.ZOMBIE);
  
-@@ -955,7 +956,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -955,7 +955,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1314,7 +1307,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityType.ZOMBIE);
  
-@@ -974,7 +975,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -974,7 +974,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1323,7 +1316,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityType.ZOMBIE);
  
-@@ -993,7 +994,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -993,7 +993,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1332,7 +1325,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          Block b = Block.ACACIA_TRAPDOOR.withProperties(Map.of("facing", "south", "open", "true"));
  
-@@ -1011,7 +1012,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -1011,7 +1011,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1341,7 +1334,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(0, 43, 1, Block.STONE);
  
-@@ -1031,7 +1032,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -1031,7 +1031,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1350,7 +1343,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(0, 43, 1, Block.STONE);
  
-@@ -1062,7 +1063,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -1062,7 +1062,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1359,7 +1352,7 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          var instance = env.createFlatInstance();
          instance.setBlock(0, 42, 0, Block.STONE);
  
-@@ -1077,7 +1078,7 @@ public class EntityBlockPhysicsIntegrationTest {
+@@ -1077,7 +1077,7 @@ public class EntityBlockPhysicsIntegrationTest {
      }
  
      @Test
@@ -1369,14 +1362,12 @@ index 78e6632635d5c40941cf5e160beb8600a788deec..7ef3ad22f5bc66cbb64d280992609ab3
          instance.setBlock(0, 42, 0, Block.STONE);
  
 diff --git a/src/test/java/net/minestom/server/collision/EntityBlockTouchTickIntegrationTest.java b/src/test/java/net/minestom/server/collision/EntityBlockTouchTickIntegrationTest.java
-index f5fbb8a9b99720d4a5594e683e9fb3729aaaaf89..04b7b5bc1bb96e4d565bcb1348d433ff6ae55548 100644
+index f5fbb8a9b99720d4a5594e683e9fb3729aaaaf89..2160a817501fc61bb6273767012c9e7179e7b25e 100644
 --- a/src/test/java/net/minestom/server/collision/EntityBlockTouchTickIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/collision/EntityBlockTouchTickIntegrationTest.java
-@@ -19,10 +19,11 @@ import java.util.Set;
- import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -20,9 +20,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertTrue;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class EntityBlockTouchTickIntegrationTest {
 +class EntityBlockTouchTickIntegrationTest {
@@ -1386,7 +1377,7 @@ index f5fbb8a9b99720d4a5594e683e9fb3729aaaaf89..04b7b5bc1bb96e4d565bcb1348d433ff
          var instance = env.createFlatInstance();
  
          Set<Point> positions = new HashSet<>();
-@@ -60,7 +61,7 @@ public class EntityBlockTouchTickIntegrationTest {
+@@ -60,7 +60,7 @@ public class EntityBlockTouchTickIntegrationTest {
      }
  
      @Test
@@ -1395,7 +1386,7 @@ index f5fbb8a9b99720d4a5594e683e9fb3729aaaaf89..04b7b5bc1bb96e4d565bcb1348d433ff
          var instance = env.createFlatInstance();
          instance.loadChunk(new Pos(1000, 1000, 1000));
  
-@@ -100,7 +101,7 @@ public class EntityBlockTouchTickIntegrationTest {
+@@ -100,7 +100,7 @@ public class EntityBlockTouchTickIntegrationTest {
      }
  
      @Test
@@ -1404,7 +1395,7 @@ index f5fbb8a9b99720d4a5594e683e9fb3729aaaaf89..04b7b5bc1bb96e4d565bcb1348d433ff
          var instance = env.createFlatInstance();
          instance.loadChunk(new Pos(1000, 1000, 1000));
  
-@@ -148,7 +149,7 @@ public class EntityBlockTouchTickIntegrationTest {
+@@ -148,7 +148,7 @@ public class EntityBlockTouchTickIntegrationTest {
      }
  
      @Test
@@ -1414,14 +1405,12 @@ index f5fbb8a9b99720d4a5594e683e9fb3729aaaaf89..04b7b5bc1bb96e4d565bcb1348d433ff
          instance.loadChunk(new Pos(-1000, 44, -1000));
  
 diff --git a/src/test/java/net/minestom/server/collision/EntityProjectileCollisionIntegrationTest.java b/src/test/java/net/minestom/server/collision/EntityProjectileCollisionIntegrationTest.java
-index ee893bba4cc28ae29138eec0900dd89962d9fbfc..f821c225bc8216c41092e5495942578350051878 100644
+index ee893bba4cc28ae29138eec0900dd89962d9fbfc..658ad566b1925008c5b2bf0ed26ea930f3dd899c 100644
 --- a/src/test/java/net/minestom/server/collision/EntityProjectileCollisionIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/collision/EntityProjectileCollisionIntegrationTest.java
-@@ -23,11 +23,12 @@ import java.util.concurrent.atomic.AtomicReference;
- 
+@@ -24,10 +24,10 @@ import java.util.concurrent.atomic.AtomicReference;
  import static org.junit.jupiter.api.Assertions.*;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class EntityProjectileCollisionIntegrationTest {
 +class EntityProjectileCollisionIntegrationTest {
@@ -1432,7 +1421,7 @@ index ee893bba4cc28ae29138eec0900dd89962d9fbfc..f821c225bc8216c41092e54959425783
          final Instance instance = env.createFlatInstance();
          instance.getWorldBorder().setDiameter(1000.0);
  
-@@ -71,7 +72,7 @@ public class EntityProjectileCollisionIntegrationTest {
+@@ -71,7 +71,7 @@ public class EntityProjectileCollisionIntegrationTest {
      }
  
      @Test
@@ -1441,7 +1430,7 @@ index ee893bba4cc28ae29138eec0900dd89962d9fbfc..f821c225bc8216c41092e54959425783
          final Instance instance = env.createFlatInstance();
          instance.getWorldBorder().setDiameter(1000.0);
  
-@@ -119,7 +120,7 @@ public class EntityProjectileCollisionIntegrationTest {
+@@ -119,7 +119,7 @@ public class EntityProjectileCollisionIntegrationTest {
      }
  
      @Test
@@ -1451,14 +1440,12 @@ index ee893bba4cc28ae29138eec0900dd89962d9fbfc..f821c225bc8216c41092e54959425783
          instance.getWorldBorder().setDiameter(1000.0);
  
 diff --git a/src/test/java/net/minestom/server/collision/PlacementCollisionIntegrationTest.java b/src/test/java/net/minestom/server/collision/PlacementCollisionIntegrationTest.java
-index 27a2f36c19fd8c2dce75f1bd1ff514dadd027b8a..b41c07c8beb6d9ca9ea0aef138082fe04e462b85 100644
+index 27a2f36c19fd8c2dce75f1bd1ff514dadd027b8a..f3e90e530f4b3487e50d83634b3e0351f5388437 100644
 --- a/src/test/java/net/minestom/server/collision/PlacementCollisionIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/collision/PlacementCollisionIntegrationTest.java
-@@ -11,31 +11,32 @@ import org.junit.jupiter.api.Test;
- 
+@@ -12,30 +12,30 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.*;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class PlacementCollisionIntegrationTest {
 +class PlacementCollisionIntegrationTest {
@@ -1493,15 +1480,14 @@ index 27a2f36c19fd8c2dce75f1bd1ff514dadd027b8a..b41c07c8beb6d9ca9ea0aef138082fe0
          env.createPlayer(instance, new Pos(5.7, -8, 6.389));
          assertNull(BlockCollision.canPlaceBlockAt(instance, new Vec(5, -9, 6), Block.STONE));
 diff --git a/src/test/java/net/minestom/server/command/ArgumentParserTest.java b/src/test/java/net/minestom/server/command/ArgumentParserTest.java
-index 232d55948303a74d35724c2d601ace10a8d98811..66fd64bd2306cd905050893621cdc66fd25890df 100644
+index 232d55948303a74d35724c2d601ace10a8d98811..844f846afe976a4667a2743957d19b155a7d7a3f 100644
 --- a/src/test/java/net/minestom/server/command/ArgumentParserTest.java
 +++ b/src/test/java/net/minestom/server/command/ArgumentParserTest.java
-@@ -11,10 +11,11 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+@@ -11,10 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
  /**
   * Test string version of arguments.
   */
 -public class ArgumentParserTest {
-+//Microtus - update java keyword usage
 +class ArgumentParserTest {
  
      @Test
@@ -1511,15 +1497,14 @@ index 232d55948303a74d35724c2d601ace10a8d98811..66fd64bd2306cd905050893621cdc66f
          assertParserEquals("Literal<example>", ArgumentType.Literal("example"));
          assertParserEquals("Boolean<example>", ArgumentType.Boolean("example"));
 diff --git a/src/test/java/net/minestom/server/command/ArgumentTest.java b/src/test/java/net/minestom/server/command/ArgumentTest.java
-index 6aa58875c186549b658ef5a5277dc4fbd378df80..1f8e528b34f03c217b03948ba1cd1a41d0225570 100644
+index 6aa58875c186549b658ef5a5277dc4fbd378df80..0c438d1230824e25352af1a53534a3b0e97234b3 100644
 --- a/src/test/java/net/minestom/server/command/ArgumentTest.java
 +++ b/src/test/java/net/minestom/server/command/ArgumentTest.java
-@@ -11,16 +11,17 @@ import java.util.List;
+@@ -11,16 +11,16 @@ import java.util.List;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class ArgumentTest {
-+//Microtus - update java keyword usage
 +class ArgumentTest {
  
      @Test
@@ -1535,7 +1520,7 @@ index 6aa58875c186549b658ef5a5277dc4fbd378df80..1f8e528b34f03c217b03948ba1cd1a41
          var arg = ArgumentType.String("id");
  
          assertFalse(arg.hasErrorCallback());
-@@ -30,7 +31,7 @@ public class ArgumentTest {
+@@ -30,7 +30,7 @@ public class ArgumentTest {
      }
  
      @Test
@@ -1544,7 +1529,7 @@ index 6aa58875c186549b658ef5a5277dc4fbd378df80..1f8e528b34f03c217b03948ba1cd1a41
          var arg = ArgumentType.String("id");
  
          assertFalse(arg.isOptional());
-@@ -40,7 +41,7 @@ public class ArgumentTest {
+@@ -40,7 +40,7 @@ public class ArgumentTest {
      }
  
      @Test
@@ -1554,7 +1539,7 @@ index 6aa58875c186549b658ef5a5277dc4fbd378df80..1f8e528b34f03c217b03948ba1cd1a41
  
          assertFalse(arg.hasSuggestion());
 diff --git a/src/test/java/net/minestom/server/command/ArgumentTypeTest.java b/src/test/java/net/minestom/server/command/ArgumentTypeTest.java
-index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedcfbe8ca41 100644
+index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec96243cbb963 100644
 --- a/src/test/java/net/minestom/server/command/ArgumentTypeTest.java
 +++ b/src/test/java/net/minestom/server/command/ArgumentTypeTest.java
 @@ -16,7 +16,6 @@ import net.minestom.server.item.Enchantment;
@@ -1565,12 +1550,11 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
  import net.minestom.server.tag.Tag;
  import net.minestom.server.utils.location.RelativeVec;
  import net.minestom.server.utils.math.FloatRange;
-@@ -31,10 +30,11 @@ import java.util.UUID;
+@@ -31,10 +30,10 @@ import java.util.UUID;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class ArgumentTypeTest {
-+//Microtus - update java keyword usage
 +class ArgumentTypeTest {
  
      @Test
@@ -1579,7 +1563,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.Enchantment("enchantment");
          assertInvalidArg(arg, "minecraft:invalid_enchantment");
          assertArg(arg, Enchantment.SWEEPING, Enchantment.SWEEPING.name());
-@@ -42,7 +42,7 @@ public class ArgumentTypeTest {
+@@ -42,7 +41,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1588,7 +1572,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.EntityType("entity_type");
          assertInvalidArg(arg, "minecraft:invalid_entity_type");
          assertArg(arg, EntityType.ARMOR_STAND, EntityType.ARMOR_STAND.name());
-@@ -50,7 +50,7 @@ public class ArgumentTypeTest {
+@@ -50,7 +49,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1597,7 +1581,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.Particle("particle");
          assertInvalidArg(arg, "minecraft:invalid_particle");
          assertArg(arg, Particle.BLOCK, Particle.BLOCK.name());
-@@ -58,7 +58,7 @@ public class ArgumentTypeTest {
+@@ -58,7 +57,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1606,7 +1590,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.BlockState("block_state");
          assertInvalidArg(arg, "minecraft:invalid_block[invalid_property=invalid_key]");
          assertInvalidArg(arg, "minecraft:stone[invalid_property=invalid_key]");
-@@ -69,7 +69,7 @@ public class ArgumentTypeTest {
+@@ -69,7 +68,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1615,7 +1599,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.Color("color");
          assertInvalidArg(arg, "invalid_color");
          assertArg(arg, Style.style(NamedTextColor.DARK_PURPLE), "dark_purple");
-@@ -77,7 +77,7 @@ public class ArgumentTypeTest {
+@@ -77,7 +76,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1624,7 +1608,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.Component("component");
          var component1 = Component.text("Example text", NamedTextColor.DARK_AQUA);
          var component2 = Component.text("Other example text", Style.style(TextDecoration.OBFUSCATED));
-@@ -90,7 +90,7 @@ public class ArgumentTypeTest {
+@@ -90,7 +89,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1633,7 +1617,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.Entity("entity");
  
          assertValidArg(arg, "@a");
-@@ -127,7 +127,7 @@ public class ArgumentTypeTest {
+@@ -127,7 +126,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1642,7 +1626,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.FloatRange("float_range");
          assertArg(arg, new FloatRange(0f, 50f), "0..50");
          assertArg(arg, new FloatRange(0f, 0f), "0..0");
-@@ -142,7 +142,7 @@ public class ArgumentTypeTest {
+@@ -142,7 +141,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1651,7 +1635,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.IntRange("int_range");
  
          assertArg(arg, new IntRange(0, 50), "0..50");
-@@ -161,14 +161,14 @@ public class ArgumentTypeTest {
+@@ -161,14 +160,14 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1668,7 +1652,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.NbtCompound("nbt_compound");
          assertArg(arg, NBT.Compound(mut -> mut.put("long_array", NBT.LongArray(12, 49, 119))), "{\"long_array\":[L;12L,49L,119L]}");
          assertArg(arg, NBT.Compound(mut -> mut.put("nested", NBT.Compound(mut2 ->
-@@ -183,7 +183,7 @@ public class ArgumentTypeTest {
+@@ -183,7 +182,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1677,7 +1661,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.NBT("nbt");
          assertArg(arg, NBT.String("string"), "string");
          assertArg(arg, NBT.String("string"), "\"string\"");
-@@ -198,14 +198,14 @@ public class ArgumentTypeTest {
+@@ -198,14 +197,14 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1694,7 +1678,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.ResourceLocation("resource_location");
          assertArg(arg, "minecraft:resource_location_example", "minecraft:resource_location_example");
          assertInvalidArg(arg, "minecraft:invalid resource location");
-@@ -213,14 +213,14 @@ public class ArgumentTypeTest {
+@@ -213,14 +212,14 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1711,7 +1695,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.Time("time");
          assertArg(arg, Duration.of(20, TimeUnit.SERVER_TICK), "20");
          assertArg(arg, Duration.of(40, TimeUnit.SERVER_TICK), "40t");
-@@ -232,14 +232,14 @@ public class ArgumentTypeTest {
+@@ -232,14 +231,14 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1728,7 +1712,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.Double("double");
          assertArg(arg, 2564d, "2564");
          assertArg(arg, -591.981d, "-591.981");
-@@ -248,7 +248,7 @@ public class ArgumentTypeTest {
+@@ -248,7 +247,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1737,7 +1721,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.Float("float");
          assertArg(arg, 2564f, "2564");
          assertArg(arg, -591.981f, "-591.981");
-@@ -257,7 +257,7 @@ public class ArgumentTypeTest {
+@@ -257,7 +256,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1746,7 +1730,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.Integer("integer");
          assertArg(arg, 2564, "2564");
          assertInvalidArg(arg, "256.4");
-@@ -265,15 +265,15 @@ public class ArgumentTypeTest {
+@@ -265,15 +264,15 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1765,7 +1749,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.RelativeBlockPosition("relative_block_position");
          var vec = new Vec(-3, 14, 255);
  
-@@ -297,7 +297,7 @@ public class ArgumentTypeTest {
+@@ -297,7 +296,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1774,7 +1758,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.RelativeVec2("relative_vec_2");
          var vec = new Vec(-3, 14.25);
  
-@@ -318,7 +318,7 @@ public class ArgumentTypeTest {
+@@ -318,7 +317,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1783,7 +1767,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.RelativeVec3("relative_vec_3");
          var vec = new Vec(-3, 14.25, 255);
  
-@@ -339,7 +339,7 @@ public class ArgumentTypeTest {
+@@ -339,7 +338,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1792,7 +1776,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.Boolean("boolean");
          assertArg(arg, true, "true");
          assertArg(arg, false, "false");
-@@ -347,7 +347,7 @@ public class ArgumentTypeTest {
+@@ -347,7 +346,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1801,7 +1785,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          enum ExampleEnum {FIRST, SECOND, Third, fourth}
  
          var arg = ArgumentType.Enum("enum", ExampleEnum.class);
-@@ -375,7 +375,7 @@ public class ArgumentTypeTest {
+@@ -375,7 +374,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1810,7 +1794,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.Group("group", ArgumentType.Integer("integer"), ArgumentType.String("string"), ArgumentType.Double("double"));
  
          // Test normal input
-@@ -401,7 +401,7 @@ public class ArgumentTypeTest {
+@@ -401,7 +400,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1819,7 +1803,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.Literal("literal");
          assertArg(arg, "literal", "literal");
          assertInvalidArg(arg, "not_literal");
-@@ -409,7 +409,7 @@ public class ArgumentTypeTest {
+@@ -409,7 +408,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1828,7 +1812,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.Loop("loop", ArgumentType.String("string"), ArgumentType.String("string2").map(s -> {
              throw new IllegalArgumentException("This argument should never be triggered");
          }));
-@@ -419,7 +419,7 @@ public class ArgumentTypeTest {
+@@ -419,7 +418,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1837,7 +1821,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.String("string");
          assertArg(arg, "text", "text");
          assertArg(arg, "more text", "\"more text\"");
-@@ -429,7 +429,7 @@ public class ArgumentTypeTest {
+@@ -429,7 +428,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1846,7 +1830,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
          var arg = ArgumentType.StringArray("string_array");
          assertArrayArg(arg, new String[]{"example", "text"}, "example text");
          assertArrayArg(arg, new String[]{"some", "more", "placeholder", "text"}, "some more placeholder text");
-@@ -439,7 +439,7 @@ public class ArgumentTypeTest {
+@@ -439,7 +438,7 @@ public class ArgumentTypeTest {
      }
  
      @Test
@@ -1856,15 +1840,14 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..406d88e0d1132b1e9f4dce3f86fefedc
  
          assertArg(arg, "word1", "word1");
 diff --git a/src/test/java/net/minestom/server/command/CommandConditionTest.java b/src/test/java/net/minestom/server/command/CommandConditionTest.java
-index f7450b020c91807984e83b004774c916621d152f..0c68f513645f949cf216db6936f809a8e89eedab 100644
+index f7450b020c91807984e83b004774c916621d152f..f76f113a161c315badfdec9ef5932dbf4a461e40 100644
 --- a/src/test/java/net/minestom/server/command/CommandConditionTest.java
 +++ b/src/test/java/net/minestom/server/command/CommandConditionTest.java
-@@ -13,10 +13,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
+@@ -13,10 +13,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class CommandConditionTest {
-+//Microtus - update java keyword usage
 +class CommandConditionTest {
  
      @Test
@@ -1873,7 +1856,7 @@ index f7450b020c91807984e83b004774c916621d152f..0c68f513645f949cf216db6936f809a8
          var dispatcher = new CommandDispatcher();
          assertNull(dispatcher.findCommand("name"));
          var sender = new Sender();
-@@ -39,7 +40,7 @@ public class CommandConditionTest {
+@@ -39,7 +39,7 @@ public class CommandConditionTest {
      }
  
      @Test
@@ -1882,7 +1865,7 @@ index f7450b020c91807984e83b004774c916621d152f..0c68f513645f949cf216db6936f809a8
          var dispatcher = new CommandDispatcher();
          assertNull(dispatcher.findCommand("name"));
          var sender = new Sender();
-@@ -83,7 +84,7 @@ public class CommandConditionTest {
+@@ -83,7 +83,7 @@ public class CommandConditionTest {
      }
  
      @Test
@@ -1892,15 +1875,14 @@ index f7450b020c91807984e83b004774c916621d152f..0c68f513645f949cf216db6936f809a8
          assertNull(dispatcher.findCommand("name"));
          var sender = new Sender();
 diff --git a/src/test/java/net/minestom/server/command/CommandManagerTest.java b/src/test/java/net/minestom/server/command/CommandManagerTest.java
-index 0c69902dc9870ed8de36f90955c184f1cfc2b952..c536e48e85c14c9e94d3621ab00550d3615d9e60 100644
+index 0c69902dc9870ed8de36f90955c184f1cfc2b952..8e9cd85c205e12b8d85ddb3d3f01847cb0fdf115 100644
 --- a/src/test/java/net/minestom/server/command/CommandManagerTest.java
 +++ b/src/test/java/net/minestom/server/command/CommandManagerTest.java
-@@ -8,10 +8,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
+@@ -8,10 +8,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class CommandManagerTest {
-+//Microtus - update java keyword usage
 +class CommandManagerTest {
  
      @Test
@@ -1909,7 +1891,7 @@ index 0c69902dc9870ed8de36f90955c184f1cfc2b952..c536e48e85c14c9e94d3621ab00550d3
          var manager = new CommandManager();
  
          var command = new Command("name1", "name2");
-@@ -30,7 +31,7 @@ public class CommandManagerTest {
+@@ -30,7 +30,7 @@ public class CommandManagerTest {
      }
  
      @Test
@@ -1919,14 +1901,12 @@ index 0c69902dc9870ed8de36f90955c184f1cfc2b952..c536e48e85c14c9e94d3621ab00550d3
  
          AtomicBoolean check = new AtomicBoolean(false);
 diff --git a/src/test/java/net/minestom/server/command/CommandPacketFilteringTest.java b/src/test/java/net/minestom/server/command/CommandPacketFilteringTest.java
-index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..20a4553faacf73384fd9774601b04cbb979b3b14 100644
+index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..f1723d9525bbb6f7af06fe948efde4edeffc17aa 100644
 --- a/src/test/java/net/minestom/server/command/CommandPacketFilteringTest.java
 +++ b/src/test/java/net/minestom/server/command/CommandPacketFilteringTest.java
-@@ -9,19 +9,20 @@ import org.junit.jupiter.api.Test;
- import java.util.Set;
+@@ -10,18 +10,18 @@ import java.util.Set;
  import java.util.UUID;
  
-+//Microtus - update java keyword usage
  @SuppressWarnings("ConstantConditions")
 -public class CommandPacketFilteringTest {
 +class CommandPacketFilteringTest {
@@ -1946,7 +1926,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..20a4553faacf73384fd9774601b04cbb
          final Command foo = new Command("foo");
          foo.setCondition(((sender, commandString) -> true));
          assertFiltering(foo, """
-@@ -31,7 +32,7 @@ public class CommandPacketFilteringTest {
+@@ -31,7 +31,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -1955,7 +1935,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..20a4553faacf73384fd9774601b04cbb
          final Command foo = new Command("foo");
          assertFiltering(foo, """
                  foo=%
-@@ -40,7 +41,7 @@ public class CommandPacketFilteringTest {
+@@ -40,7 +40,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -1964,7 +1944,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..20a4553faacf73384fd9774601b04cbb
          final Command foo = new Command("foo");
          foo.setCondition((sender, commandString) -> true);
          final Command bar = new Command("bar");
-@@ -55,7 +56,7 @@ public class CommandPacketFilteringTest {
+@@ -55,7 +55,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -1973,7 +1953,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..20a4553faacf73384fd9774601b04cbb
          final Command foo = new Command("foo");
          foo.setCondition((sender, commandString) -> true);
          final Command bar = new Command("bar");
-@@ -68,7 +69,7 @@ public class CommandPacketFilteringTest {
+@@ -68,7 +68,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -1982,7 +1962,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..20a4553faacf73384fd9774601b04cbb
          final Command foo = new Command("foo");
          foo.setCondition((sender, commandString) -> true);
          final Command bar = new Command("bar");
-@@ -82,7 +83,7 @@ public class CommandPacketFilteringTest {
+@@ -82,7 +82,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -1991,7 +1971,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..20a4553faacf73384fd9774601b04cbb
          final Command foo = new Command("foo");
          foo.setCondition((sender, commandString) -> true);
          final Command bar = new Command("bar");
-@@ -99,7 +100,7 @@ public class CommandPacketFilteringTest {
+@@ -99,7 +99,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -2000,7 +1980,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..20a4553faacf73384fd9774601b04cbb
          final Command foo = new Command("foo");
          foo.addConditionalSyntax((sender, commandString) -> true, null, ArgumentType.Group("test", ArgumentType.Literal("bar")));
          assertFiltering(foo, """
-@@ -110,7 +111,7 @@ public class CommandPacketFilteringTest {
+@@ -110,7 +110,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -2009,7 +1989,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..20a4553faacf73384fd9774601b04cbb
          final Command foo = new Command("foo");
          foo.addConditionalSyntax((sender, commandString) -> false, null, ArgumentType.Group("test", ArgumentType.Literal("foo")));
          assertFiltering(foo, """
-@@ -120,7 +121,7 @@ public class CommandPacketFilteringTest {
+@@ -120,7 +120,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -2018,7 +1998,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..20a4553faacf73384fd9774601b04cbb
          final Command foo = new Command("foo");
          foo.addSyntax(null, ArgumentType.Group("test", ArgumentType.Literal("bar")));
          assertFiltering(foo, """
-@@ -131,7 +132,7 @@ public class CommandPacketFilteringTest {
+@@ -131,7 +131,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -2027,7 +2007,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..20a4553faacf73384fd9774601b04cbb
          final Command foo = new Command("foo");
          foo.addConditionalSyntax((sender, commandString) -> true, null, ArgumentType.Group("test", ArgumentType.Literal("bar"), ArgumentType.Literal("baz")));
          assertFiltering(foo, """
-@@ -143,7 +144,7 @@ public class CommandPacketFilteringTest {
+@@ -143,7 +143,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -2036,7 +2016,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..20a4553faacf73384fd9774601b04cbb
          final Command foo = new Command("foo");
          foo.addConditionalSyntax((sender, commandString) -> false, null, ArgumentType.Group("test", ArgumentType.Literal("foo"), ArgumentType.Literal("baz")));
          assertFiltering(foo, """
-@@ -153,7 +154,7 @@ public class CommandPacketFilteringTest {
+@@ -153,7 +153,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -2045,7 +2025,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..20a4553faacf73384fd9774601b04cbb
          final Command foo = new Command("foo");
          foo.addSyntax(null, ArgumentType.Group("test", ArgumentType.Literal("bar"), ArgumentType.Literal("baz")));
          assertFiltering(foo, """
-@@ -165,7 +166,7 @@ public class CommandPacketFilteringTest {
+@@ -165,7 +165,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -2054,7 +2034,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..20a4553faacf73384fd9774601b04cbb
          final Command foo = new Command("foo");
          foo.addSyntax(null, ArgumentType.Loop("test", ArgumentType.Literal("bar"), ArgumentType.Literal("baz")));
          assertFiltering(foo, """
-@@ -177,7 +178,7 @@ public class CommandPacketFilteringTest {
+@@ -177,7 +177,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -2063,7 +2043,7 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..20a4553faacf73384fd9774601b04cbb
          final Command foo = new Command("foo");
          foo.addConditionalSyntax((sender, commandString) -> true, null, ArgumentType.Loop("test", ArgumentType.Literal("bar"), ArgumentType.Literal("baz")));
          assertFiltering(foo, """
-@@ -189,7 +190,7 @@ public class CommandPacketFilteringTest {
+@@ -189,7 +189,7 @@ public class CommandPacketFilteringTest {
      }
  
      @Test
@@ -2073,15 +2053,14 @@ index 0ce8a207fba69c94ddeeb75696eb3c8a23e3eada..20a4553faacf73384fd9774601b04cbb
          foo.addConditionalSyntax((sender, commandString) -> false, null, ArgumentType.Loop("test", ArgumentType.Literal("bar"), ArgumentType.Literal("baz")));
          assertFiltering(foo, """
 diff --git a/src/test/java/net/minestom/server/command/CommandPacketTest.java b/src/test/java/net/minestom/server/command/CommandPacketTest.java
-index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..79c06e6051c032b2e0f2b7fca4d2320c515ea395 100644
+index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..2b51669947330396da684b251e20e096138e1b36 100644
 --- a/src/test/java/net/minestom/server/command/CommandPacketTest.java
 +++ b/src/test/java/net/minestom/server/command/CommandPacketTest.java
-@@ -9,9 +9,10 @@ import org.junit.jupiter.api.Test;
+@@ -9,9 +9,9 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNotNull;
  
 -public class CommandPacketTest {
-+//Microtus - update java keyword usage
 +class CommandPacketTest {
      @Test
 -    public void singleCommandWithOneSyntax() {
@@ -2089,7 +2068,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..79c06e6051c032b2e0f2b7fca4d2320c
          final Command foo = new Command("foo");
          foo.addSyntax(CommandPacketTest::dummyExecutor, ArgumentType.Integer("bar"));
  
-@@ -34,7 +35,7 @@ public class CommandPacketTest {
+@@ -34,7 +34,7 @@ public class CommandPacketTest {
      }
  
      @Test
@@ -2098,7 +2077,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..79c06e6051c032b2e0f2b7fca4d2320c
          enum Dimension {OVERWORLD, THE_NETHER, THE_END}
          final Command execute = new Command("execute");
          execute.addSyntax(CommandPacketTest::dummyExecutor, ArgumentType.Loop("params",
-@@ -62,7 +63,7 @@ public class CommandPacketTest {
+@@ -62,7 +62,7 @@ public class CommandPacketTest {
      }
  
      @Test
@@ -2107,7 +2086,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..79c06e6051c032b2e0f2b7fca4d2320c
          var graph = Graph.builder(ArgumentType.Literal("foo"))
                  .append(ArgumentType.Enum("bar", A.class), b -> b.append(ArgumentType.Enum("baz", B.class)))
                  .build();
-@@ -76,7 +77,7 @@ public class CommandPacketTest {
+@@ -76,7 +76,7 @@ public class CommandPacketTest {
      }
  
      @Test
@@ -2116,7 +2095,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..79c06e6051c032b2e0f2b7fca4d2320c
          var graph = Graph.builder(ArgumentType.Literal("foo"))
                  .append(ArgumentType.Word("bar").from("A", "B", "C"))
                  .build();
-@@ -89,7 +90,7 @@ public class CommandPacketTest {
+@@ -89,7 +89,7 @@ public class CommandPacketTest {
      }
  
      @Test
@@ -2125,7 +2104,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..79c06e6051c032b2e0f2b7fca4d2320c
          var graph = Graph.builder(ArgumentType.Literal("foo"))
                  .append(ArgumentType.Word("bar"))
                  .build();
-@@ -102,7 +103,7 @@ public class CommandPacketTest {
+@@ -102,7 +102,7 @@ public class CommandPacketTest {
      }
  
      @Test
@@ -2134,7 +2113,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..79c06e6051c032b2e0f2b7fca4d2320c
          var graph = Graph.builder(ArgumentType.Literal("foo"))
                  .append(ArgumentType.Enum("bar", A.class), b -> b.append(ArgumentType.Command("baz")))
                  .build();
-@@ -117,7 +118,7 @@ public class CommandPacketTest {
+@@ -117,7 +117,7 @@ public class CommandPacketTest {
      }
  
      @Test
@@ -2143,7 +2122,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..79c06e6051c032b2e0f2b7fca4d2320c
          var graph = Graph.builder(ArgumentType.Literal("foo"))
                  .append(ArgumentType.Integer("int1"), b -> b.append(ArgumentType.Enum("test", A.class), c -> c.append(ArgumentType.Integer("int2"))))
                  .build();
-@@ -139,7 +140,7 @@ public class CommandPacketTest {
+@@ -139,7 +139,7 @@ public class CommandPacketTest {
      }
  
      @Test
@@ -2152,7 +2131,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..79c06e6051c032b2e0f2b7fca4d2320c
          var graph = Graph.builder(ArgumentType.Literal("foo"))
                  .append(ArgumentType.Group("1", ArgumentType.Integer("int1"), ArgumentType.Integer("int2")),
                          b -> b.append(ArgumentType.Group("2", ArgumentType.Integer("int3"), ArgumentType.Integer("int4"))))
-@@ -155,7 +156,7 @@ public class CommandPacketTest {
+@@ -155,7 +155,7 @@ public class CommandPacketTest {
                  """, graph);
      }
      @Test
@@ -2161,7 +2140,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..79c06e6051c032b2e0f2b7fca4d2320c
          var graph = Graph.builder(ArgumentType.Literal("foo"))
                  .append(ArgumentType.Enum("a", A.class))
                  .append(ArgumentType.Literal("l"))
-@@ -170,7 +171,7 @@ public class CommandPacketTest {
+@@ -170,7 +170,7 @@ public class CommandPacketTest {
      }
  
      @Test
@@ -2170,7 +2149,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..79c06e6051c032b2e0f2b7fca4d2320c
          var graph = Graph.builder(ArgumentType.Word("foo").from("foo", "bar"))
                  .build();
          assertPacketGraph("""
-@@ -180,7 +181,7 @@ public class CommandPacketTest {
+@@ -180,7 +180,7 @@ public class CommandPacketTest {
      }
  
      @Test
@@ -2179,7 +2158,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..79c06e6051c032b2e0f2b7fca4d2320c
          var graph = Graph.builder(ArgumentType.Word("foo").from("foo", "bar"))
                  .append(ArgumentType.Literal("l"))
                  .build();
-@@ -192,7 +193,7 @@ public class CommandPacketTest {
+@@ -192,7 +192,7 @@ public class CommandPacketTest {
      }
  
      @Test
@@ -2188,7 +2167,7 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..79c06e6051c032b2e0f2b7fca4d2320c
          var foo = Graph.builder(ArgumentType.Literal("foo"))
                  .append(ArgumentType.String("msg"))
                  .build();
-@@ -210,7 +211,7 @@ public class CommandPacketTest {
+@@ -210,7 +210,7 @@ public class CommandPacketTest {
      }
  
      @Test
@@ -2198,15 +2177,14 @@ index 512aadd1123ef9db3a5a6f4cd0bcce25ece5fdcd..79c06e6051c032b2e0f2b7fca4d2320c
                  .append(ArgumentType.String("msg"))
                  .build();
 diff --git a/src/test/java/net/minestom/server/command/CommandParseTest.java b/src/test/java/net/minestom/server/command/CommandParseTest.java
-index d2751fcfd67ca910f59f33e5dcf4bcd9a23f429a..17ed355caedb5f10204de4a01bf5920866fc38b3 100644
+index d2751fcfd67ca910f59f33e5dcf4bcd9a23f429a..0c5062a628f072d0dc1608d0df533404e79d92cc 100644
 --- a/src/test/java/net/minestom/server/command/CommandParseTest.java
 +++ b/src/test/java/net/minestom/server/command/CommandParseTest.java
-@@ -11,16 +11,17 @@ import static net.minestom.server.command.builder.arguments.ArgumentType.Literal
+@@ -11,16 +11,16 @@ import static net.minestom.server.command.builder.arguments.ArgumentType.Literal
  import static net.minestom.server.command.builder.arguments.ArgumentType.Word;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class CommandParseTest {
-+//Microtus - update java keyword usage
 +class CommandParseTest {
  
      @Test
@@ -2222,7 +2200,7 @@ index d2751fcfd67ca910f59f33e5dcf4bcd9a23f429a..17ed355caedb5f10204de4a01bf59208
          final AtomicBoolean b = new AtomicBoolean();
          var foo = Graph.merge(Graph.builder(Literal("foo"), createExecutor(b)).build());
          assertValid(foo, "foo", b);
-@@ -29,7 +30,7 @@ public class CommandParseTest {
+@@ -29,7 +29,7 @@ public class CommandParseTest {
      }
  
      @Test
@@ -2231,7 +2209,7 @@ index d2751fcfd67ca910f59f33e5dcf4bcd9a23f429a..17ed355caedb5f10204de4a01bf59208
          final AtomicBoolean b = new AtomicBoolean();
          final AtomicBoolean b1 = new AtomicBoolean();
          var graph = Graph.merge(
-@@ -44,7 +45,7 @@ public class CommandParseTest {
+@@ -44,7 +44,7 @@ public class CommandParseTest {
      }
  
      @Test
@@ -2240,7 +2218,7 @@ index d2751fcfd67ca910f59f33e5dcf4bcd9a23f429a..17ed355caedb5f10204de4a01bf59208
          final AtomicBoolean add = new AtomicBoolean();
          final AtomicBoolean action = new AtomicBoolean();
          var foo = Graph.merge(Graph.builder(Literal("foo"))
-@@ -69,7 +70,7 @@ public class CommandParseTest {
+@@ -69,7 +69,7 @@ public class CommandParseTest {
      }
  
      @Test
@@ -2249,7 +2227,7 @@ index d2751fcfd67ca910f59f33e5dcf4bcd9a23f429a..17ed355caedb5f10204de4a01bf59208
          final AtomicBoolean b = new AtomicBoolean();
          final AtomicReference<String> expectedFirstArg = new AtomicReference<>("T");
          var foo = Graph.merge(Graph.builder(Literal("foo"))
-@@ -92,7 +93,7 @@ public class CommandParseTest {
+@@ -92,7 +92,7 @@ public class CommandParseTest {
      }
  
      @Test
@@ -2258,7 +2236,7 @@ index d2751fcfd67ca910f59f33e5dcf4bcd9a23f429a..17ed355caedb5f10204de4a01bf59208
          enum A {a, b}
          final AtomicBoolean b = new AtomicBoolean();
          var foo = Graph.merge(Graph.builder(Literal("foo"))
-@@ -105,7 +106,7 @@ public class CommandParseTest {
+@@ -105,7 +105,7 @@ public class CommandParseTest {
      }
  
      @Test
@@ -2267,7 +2245,7 @@ index d2751fcfd67ca910f59f33e5dcf4bcd9a23f429a..17ed355caedb5f10204de4a01bf59208
          final AtomicBoolean b = new AtomicBoolean();
          var foo = Graph.merge(Graph.builder(Word("").from("foo", "bar"), createExecutor(b))
                  .build());
-@@ -115,7 +116,7 @@ public class CommandParseTest {
+@@ -115,7 +115,7 @@ public class CommandParseTest {
      }
  
      @Test
@@ -2277,15 +2255,14 @@ index d2751fcfd67ca910f59f33e5dcf4bcd9a23f429a..17ed355caedb5f10204de4a01bf59208
          var foo = Graph.merge(Graph.builder(Word("").from("foo", "bar"))
                  .append(ArgumentType.Integer("test"), createExecutor(b))
 diff --git a/src/test/java/net/minestom/server/command/CommandSenderTest.java b/src/test/java/net/minestom/server/command/CommandSenderTest.java
-index fe2b5186f3b90d46b465c0ca7fb319020f0b0286..fe864c687498c507dfda082f1740c5f810ec895a 100644
+index fe2b5186f3b90d46b465c0ca7fb319020f0b0286..a4ff2e54c1650dae3831c07072c0f54b803c5f20 100644
 --- a/src/test/java/net/minestom/server/command/CommandSenderTest.java
 +++ b/src/test/java/net/minestom/server/command/CommandSenderTest.java
-@@ -16,10 +16,11 @@ import java.util.Set;
+@@ -16,10 +16,10 @@ import java.util.Set;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class CommandSenderTest {
-+//Microtus - update java keyword usage
 +class CommandSenderTest {
  
      @Test
@@ -2294,7 +2271,7 @@ index fe2b5186f3b90d46b465c0ca7fb319020f0b0286..fe864c687498c507dfda082f1740c5f8
  
          CommandSender sender = new SenderTest();
  
-@@ -36,7 +37,7 @@ public class CommandSenderTest {
+@@ -36,7 +36,7 @@ public class CommandSenderTest {
      }
  
      @Test
@@ -2304,14 +2281,12 @@ index fe2b5186f3b90d46b465c0ca7fb319020f0b0286..fe864c687498c507dfda082f1740c5f8
  
          assertNull(sender.getMostRecentMessage());
 diff --git a/src/test/java/net/minestom/server/command/CommandSuggestionIntegrationTest.java b/src/test/java/net/minestom/server/command/CommandSuggestionIntegrationTest.java
-index fff2a33d02b9ed1cfe2e320fb1c758e0839da047..130bb03196e54e3c8b7485ee287a7287ea417525 100644
+index fff2a33d02b9ed1cfe2e320fb1c758e0839da047..c54b9ba92b8576f625a421df8a8073474aec8bea 100644
 --- a/src/test/java/net/minestom/server/command/CommandSuggestionIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/command/CommandSuggestionIntegrationTest.java
-@@ -17,11 +17,12 @@ import static net.minestom.server.command.builder.arguments.ArgumentType.Integer
- import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -18,10 +18,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class CommandSuggestionIntegrationTest {
 +class CommandSuggestionIntegrationTest {
@@ -2322,7 +2297,7 @@ index fff2a33d02b9ed1cfe2e320fb1c758e0839da047..130bb03196e54e3c8b7485ee287a7287
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -52,7 +53,7 @@ public class CommandSuggestionIntegrationTest {
+@@ -52,7 +52,7 @@ public class CommandSuggestionIntegrationTest {
      }
  
      @Test
@@ -2331,7 +2306,7 @@ index fff2a33d02b9ed1cfe2e320fb1c758e0839da047..130bb03196e54e3c8b7485ee287a7287
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -64,20 +65,20 @@ public class CommandSuggestionIntegrationTest {
+@@ -64,20 +64,20 @@ public class CommandSuggestionIntegrationTest {
  
          var command = new Command("foo");
  
@@ -2357,7 +2332,7 @@ index fff2a33d02b9ed1cfe2e320fb1c758e0839da047..130bb03196e54e3c8b7485ee287a7287
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -86,16 +87,16 @@ public class CommandSuggestionIntegrationTest {
+@@ -86,16 +86,16 @@ public class CommandSuggestionIntegrationTest {
  
          var subCommand = new Command("bar");
  
@@ -2382,7 +2357,7 @@ index fff2a33d02b9ed1cfe2e320fb1c758e0839da047..130bb03196e54e3c8b7485ee287a7287
  
          command.addSubcommand(subCommand);
  
-@@ -105,29 +106,28 @@ public class CommandSuggestionIntegrationTest {
+@@ -105,29 +105,28 @@ public class CommandSuggestionIntegrationTest {
          player.addPacketToQueue(new ClientTabCompletePacket(1, "foo bar "));
          player.interpretPacketQueue();
  
@@ -2423,7 +2398,7 @@ index fff2a33d02b9ed1cfe2e320fb1c758e0839da047..130bb03196e54e3c8b7485ee287a7287
  
          env.process().command().register(command);
  
-@@ -135,9 +135,8 @@ public class CommandSuggestionIntegrationTest {
+@@ -135,9 +134,8 @@ public class CommandSuggestionIntegrationTest {
          player.addPacketToQueue(new ClientTabCompletePacket(1, "foo literal2 "));
          player.interpretPacketQueue();
  
@@ -2436,7 +2411,7 @@ index fff2a33d02b9ed1cfe2e320fb1c758e0839da047..130bb03196e54e3c8b7485ee287a7287
  
  }
 diff --git a/src/test/java/net/minestom/server/command/CommandSyntaxMultiTest.java b/src/test/java/net/minestom/server/command/CommandSyntaxMultiTest.java
-index ca0fec6265f2373a96d63a7b4c402ab35aa0395e..77106a978f2cb086528d717f6c879274a59478e7 100644
+index ca0fec6265f2373a96d63a7b4c402ab35aa0395e..063ad7f76714778b6e459db03e13066bb02bd13c 100644
 --- a/src/test/java/net/minestom/server/command/CommandSyntaxMultiTest.java
 +++ b/src/test/java/net/minestom/server/command/CommandSyntaxMultiTest.java
 @@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
@@ -2447,12 +2422,11 @@ index ca0fec6265f2373a96d63a7b4c402ab35aa0395e..77106a978f2cb086528d717f6c879274
  import java.util.concurrent.atomic.AtomicReference;
  
  import static net.minestom.server.command.builder.arguments.ArgumentType.Float;
-@@ -16,10 +15,11 @@ import static net.minestom.server.command.builder.arguments.ArgumentType.*;
+@@ -16,10 +15,10 @@ import static net.minestom.server.command.builder.arguments.ArgumentType.*;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.fail;
  
 -public class CommandSyntaxMultiTest {
-+//Microtus - update java keyword usage
 +class CommandSyntaxMultiTest {
  
      @Test
@@ -2461,7 +2435,7 @@ index ca0fec6265f2373a96d63a7b4c402ab35aa0395e..77106a978f2cb086528d717f6c879274
          List<List<Argument<?>>> args = List.of(
                  List.of(Literal("integer"), Integer("number")),
                  List.of(Literal("float"), Float("number"))
-@@ -29,7 +29,7 @@ public class CommandSyntaxMultiTest {
+@@ -29,7 +28,7 @@ public class CommandSyntaxMultiTest {
      }
  
      @Test
@@ -2470,7 +2444,7 @@ index ca0fec6265f2373a96d63a7b4c402ab35aa0395e..77106a978f2cb086528d717f6c879274
          List<List<Argument<?>>> args = List.of(
                  List.of(Word("word")),
                  List.of(Literal("literal"))
-@@ -38,7 +38,7 @@ public class CommandSyntaxMultiTest {
+@@ -38,7 +37,7 @@ public class CommandSyntaxMultiTest {
      }
  
      @Test
@@ -2480,15 +2454,14 @@ index ca0fec6265f2373a96d63a7b4c402ab35aa0395e..77106a978f2cb086528d717f6c879274
                  List.of(Word("a")),
                  List.of(Word("b"), Word("a"))
 diff --git a/src/test/java/net/minestom/server/command/CommandSyntaxSingleTest.java b/src/test/java/net/minestom/server/command/CommandSyntaxSingleTest.java
-index 42cfa09255a0fb576f5db0edde46233252916f11..247fd5ede85f7fbe5d1b3eb32f033089f8a5b21b 100644
+index 42cfa09255a0fb576f5db0edde46233252916f11..1a56d96f878ba6cab7234a7cfbb08f9e11927cf1 100644
 --- a/src/test/java/net/minestom/server/command/CommandSyntaxSingleTest.java
 +++ b/src/test/java/net/minestom/server/command/CommandSyntaxSingleTest.java
-@@ -18,9 +18,10 @@ import static net.minestom.server.command.builder.arguments.ArgumentType.*;
+@@ -18,9 +18,9 @@ import static net.minestom.server.command.builder.arguments.ArgumentType.*;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.fail;
  
 -public class CommandSyntaxSingleTest {
-+//Microtus - update java keyword usage
 +class CommandSyntaxSingleTest {
      @Test
 -    public void singleInteger() {
@@ -2496,7 +2469,7 @@ index 42cfa09255a0fb576f5db0edde46233252916f11..247fd5ede85f7fbe5d1b3eb32f033089
          List<Argument<?>> args = List.of(Integer("number"));
          assertSyntax(args, "5", ExpectedExecution.SYNTAX, Map.of("number", 5));
          assertSyntax(args, "5 5", ExpectedExecution.DEFAULT);
-@@ -28,7 +29,7 @@ public class CommandSyntaxSingleTest {
+@@ -28,7 +28,7 @@ public class CommandSyntaxSingleTest {
      }
  
      @Test
@@ -2505,7 +2478,7 @@ index 42cfa09255a0fb576f5db0edde46233252916f11..247fd5ede85f7fbe5d1b3eb32f033089
          List<Argument<?>> args = List.of(Integer("number"), Integer("number2"));
          assertSyntax(args, "5", ExpectedExecution.DEFAULT);
          assertSyntax(args, "5 6", ExpectedExecution.SYNTAX, Map.of("number", 5, "number2", 6));
-@@ -36,7 +37,7 @@ public class CommandSyntaxSingleTest {
+@@ -36,7 +36,7 @@ public class CommandSyntaxSingleTest {
      }
  
      @Test
@@ -2514,7 +2487,7 @@ index 42cfa09255a0fb576f5db0edde46233252916f11..247fd5ede85f7fbe5d1b3eb32f033089
          List<Argument<?>> args = List.of(String("string"));
          assertSyntax(args, """
                  "value"
-@@ -46,7 +47,7 @@ public class CommandSyntaxSingleTest {
+@@ -46,7 +46,7 @@ public class CommandSyntaxSingleTest {
      }
  
      @Test
@@ -2523,7 +2496,7 @@ index 42cfa09255a0fb576f5db0edde46233252916f11..247fd5ede85f7fbe5d1b3eb32f033089
          List<Argument<?>> args = List.of(String("string"), String("string2"));
          assertSyntax(args, "test", ExpectedExecution.DEFAULT);
          assertSyntax(args, """
-@@ -60,7 +61,7 @@ public class CommandSyntaxSingleTest {
+@@ -60,7 +60,7 @@ public class CommandSyntaxSingleTest {
      }
  
      @Test
@@ -2532,7 +2505,7 @@ index 42cfa09255a0fb576f5db0edde46233252916f11..247fd5ede85f7fbe5d1b3eb32f033089
          List<Argument<?>> args = List.of(Group("loop", Integer("first"), Integer("second")));
          // 1 2
          {
-@@ -74,7 +75,7 @@ public class CommandSyntaxSingleTest {
+@@ -74,7 +74,7 @@ public class CommandSyntaxSingleTest {
      }
  
      @Test
@@ -2541,7 +2514,7 @@ index 42cfa09255a0fb576f5db0edde46233252916f11..247fd5ede85f7fbe5d1b3eb32f033089
          List<Argument<?>> stringLoop = List.of(Loop("loop", String("value")));
          assertSyntax(stringLoop, "one two three", ExpectedExecution.SYNTAX, Map.of("loop", List.of("one", "two", "three")));
  
-@@ -83,7 +84,7 @@ public class CommandSyntaxSingleTest {
+@@ -83,7 +83,7 @@ public class CommandSyntaxSingleTest {
      }
  
      @Test
@@ -2550,7 +2523,7 @@ index 42cfa09255a0fb576f5db0edde46233252916f11..247fd5ede85f7fbe5d1b3eb32f033089
          List<Argument<?>> groupLoop = List.of(Loop("loop", Group("group", Integer("first"), Integer("second"))));
          // 1 2
          {
-@@ -112,7 +113,7 @@ public class CommandSyntaxSingleTest {
+@@ -112,7 +112,7 @@ public class CommandSyntaxSingleTest {
      }
  
      @Test
@@ -2560,15 +2533,14 @@ index 42cfa09255a0fb576f5db0edde46233252916f11..247fd5ede85f7fbe5d1b3eb32f033089
                  Loop("loop",
                          Group("group", BlockState("block"), Enchantment("enchant")),
 diff --git a/src/test/java/net/minestom/server/command/CommandTest.java b/src/test/java/net/minestom/server/command/CommandTest.java
-index 420530aa47c0de56de27e1aa55d1a29395ae1c5c..68b6f164e0a69b54ffeded34b0528c235de08d53 100644
+index 420530aa47c0de56de27e1aa55d1a29395ae1c5c..d56c151d1d296776b690790573b49690cb34875e 100644
 --- a/src/test/java/net/minestom/server/command/CommandTest.java
 +++ b/src/test/java/net/minestom/server/command/CommandTest.java
-@@ -10,10 +10,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
+@@ -10,10 +10,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class CommandTest {
-+//Microtus - update java keyword usage
 +class CommandTest {
  
      @Test
@@ -2577,7 +2549,7 @@ index 420530aa47c0de56de27e1aa55d1a29395ae1c5c..68b6f164e0a69b54ffeded34b0528c23
          Command command = new Command("name1", "name2", "name3");
  
          assertEquals("name1", command.getName());
-@@ -27,7 +28,7 @@ public class CommandTest {
+@@ -27,7 +27,7 @@ public class CommandTest {
      }
  
      @Test
@@ -2586,28 +2558,15 @@ index 420530aa47c0de56de27e1aa55d1a29395ae1c5c..68b6f164e0a69b54ffeded34b0528c23
          var manager = new CommandManager();
  
          AtomicBoolean hasRun = new AtomicBoolean(false);
-diff --git a/src/test/java/net/minestom/server/command/CommandTestUtils.java b/src/test/java/net/minestom/server/command/CommandTestUtils.java
-index ea0d9fc24acca8a2fd56a8e17c021de829bd0ff2..20e8c7db054737919f20e55c10e6dee76b77ac2d 100644
---- a/src/test/java/net/minestom/server/command/CommandTestUtils.java
-+++ b/src/test/java/net/minestom/server/command/CommandTestUtils.java
-@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
- import static org.junit.jupiter.api.Assertions.assertEquals;
- import static org.junit.jupiter.api.Assertions.fail;
- 
-+//Microtus - update java keyword usage
- public class CommandTestUtils {
- 
-     public static void assertPacket(DeclareCommandsPacket packet, String expectedStructure) {
 diff --git a/src/test/java/net/minestom/server/command/GraphConversionExecutorTest.java b/src/test/java/net/minestom/server/command/GraphConversionExecutorTest.java
-index 55e5612f3e41096c6904dba1a5002af4ea2a0131..7a20eb0a36807f0c6c2391b51db47b969ab663a3 100644
+index 55e5612f3e41096c6904dba1a5002af4ea2a0131..0bb5c4470c0093a8511f6e3c1d2862189eec662e 100644
 --- a/src/test/java/net/minestom/server/command/GraphConversionExecutorTest.java
 +++ b/src/test/java/net/minestom/server/command/GraphConversionExecutorTest.java
-@@ -8,9 +8,10 @@ import org.junit.jupiter.api.Test;
+@@ -8,9 +8,9 @@ import org.junit.jupiter.api.Test;
  import static net.minestom.server.command.builder.arguments.ArgumentType.Literal;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class GraphConversionExecutorTest {
-+//Microtus - update java keyword usage
 +class GraphConversionExecutorTest {
      @Test
 -    public void defaultCondition() {
@@ -2615,7 +2574,7 @@ index 55e5612f3e41096c6904dba1a5002af4ea2a0131..7a20eb0a36807f0c6c2391b51db47b96
          final Command foo = new Command("foo");
          // Constant true
          {
-@@ -31,7 +32,7 @@ public class GraphConversionExecutorTest {
+@@ -31,7 +31,7 @@ public class GraphConversionExecutorTest {
      }
  
      @Test
@@ -2624,7 +2583,7 @@ index 55e5612f3e41096c6904dba1a5002af4ea2a0131..7a20eb0a36807f0c6c2391b51db47b96
          final Command foo = new Command("foo");
          foo.addSyntax(GraphConversionExecutorTest::dummyExecutor, Literal("first"));
  
-@@ -44,7 +45,7 @@ public class GraphConversionExecutorTest {
+@@ -44,7 +44,7 @@ public class GraphConversionExecutorTest {
      }
  
      @Test
@@ -2633,7 +2592,7 @@ index 55e5612f3e41096c6904dba1a5002af4ea2a0131..7a20eb0a36807f0c6c2391b51db47b96
          final Command foo = new Command("foo");
          foo.addConditionalSyntax((sender, context) -> true,
                  GraphConversionExecutorTest::dummyExecutor, Literal("first"));
-@@ -57,7 +58,7 @@ public class GraphConversionExecutorTest {
+@@ -57,7 +57,7 @@ public class GraphConversionExecutorTest {
      }
  
      @Test
@@ -2642,7 +2601,7 @@ index 55e5612f3e41096c6904dba1a5002af4ea2a0131..7a20eb0a36807f0c6c2391b51db47b96
          final Command foo = new Command("foo");
          foo.addConditionalSyntax((sender, context) -> false,
                  GraphConversionExecutorTest::dummyExecutor, Literal("first"));
-@@ -70,7 +71,7 @@ public class GraphConversionExecutorTest {
+@@ -70,7 +70,7 @@ public class GraphConversionExecutorTest {
      }
  
      @Test
@@ -2652,15 +2611,14 @@ index 55e5612f3e41096c6904dba1a5002af4ea2a0131..7a20eb0a36807f0c6c2391b51db47b96
          foo.setCondition((sender, commandString) -> false);
          final Graph graph = Graph.fromCommand(foo);
 diff --git a/src/test/java/net/minestom/server/command/GraphConversionTest.java b/src/test/java/net/minestom/server/command/GraphConversionTest.java
-index 7c294232ed4e25e457ab95ecfcc757c7b312b184..21cfa14bfadcfdf1df6d8d2db0f9630780155b1a 100644
+index 7c294232ed4e25e457ab95ecfcc757c7b312b184..a429406c4713708ea76b82d576f990c88b8067db 100644
 --- a/src/test/java/net/minestom/server/command/GraphConversionTest.java
 +++ b/src/test/java/net/minestom/server/command/GraphConversionTest.java
-@@ -9,16 +9,17 @@ import static net.minestom.server.command.builder.arguments.ArgumentType.Integer
+@@ -9,16 +9,16 @@ import static net.minestom.server.command.builder.arguments.ArgumentType.Integer
  import static net.minestom.server.command.builder.arguments.ArgumentType.*;
  import static org.junit.jupiter.api.Assertions.assertTrue;
  
 -public class GraphConversionTest {
-+//Microtus - update java keyword usage
 +class GraphConversionTest {
      @Test
 -    public void empty() {
@@ -2676,7 +2634,7 @@ index 7c294232ed4e25e457ab95ecfcc757c7b312b184..21cfa14bfadcfdf1df6d8d2db0f96307
          final Command foo = new Command("foo");
          var first = Literal("first");
          foo.addSyntax(GraphConversionTest::dummyExecutor, first);
-@@ -28,7 +29,7 @@ public class GraphConversionTest {
+@@ -28,7 +28,7 @@ public class GraphConversionTest {
      }
  
      @Test
@@ -2685,7 +2643,7 @@ index 7c294232ed4e25e457ab95ecfcc757c7b312b184..21cfa14bfadcfdf1df6d8d2db0f96307
          final Command foo = new Command("foo");
          var first = Literal("first");
          var second = Literal("second");
-@@ -43,7 +44,7 @@ public class GraphConversionTest {
+@@ -43,7 +43,7 @@ public class GraphConversionTest {
      }
  
      @Test
@@ -2694,7 +2652,7 @@ index 7c294232ed4e25e457ab95ecfcc757c7b312b184..21cfa14bfadcfdf1df6d8d2db0f96307
          enum A {A, B, C, D, E}
          final Command foo = new Command("foo");
  
-@@ -64,7 +65,7 @@ public class GraphConversionTest {
+@@ -64,7 +64,7 @@ public class GraphConversionTest {
      }
  
      @Test
@@ -2703,7 +2661,7 @@ index 7c294232ed4e25e457ab95ecfcc757c7b312b184..21cfa14bfadcfdf1df6d8d2db0f96307
          final Command foo = new Command("foo");
  
          var bar = Literal("bar");
-@@ -81,7 +82,7 @@ public class GraphConversionTest {
+@@ -81,7 +81,7 @@ public class GraphConversionTest {
      }
  
      @Test
@@ -2712,7 +2670,7 @@ index 7c294232ed4e25e457ab95ecfcc757c7b312b184..21cfa14bfadcfdf1df6d8d2db0f96307
          final Command main = new Command("main");
          final Command sub = new Command("sub");
  
-@@ -107,14 +108,14 @@ public class GraphConversionTest {
+@@ -107,14 +107,14 @@ public class GraphConversionTest {
      }
  
      @Test
@@ -2730,15 +2688,14 @@ index 7c294232ed4e25e457ab95ecfcc757c7b312b184..21cfa14bfadcfdf1df6d8d2db0f96307
          var graph = Graph.builder(Word("main").from("main", "first", "second")).build();
          assertEqualsGraph(graph, main);
 diff --git a/src/test/java/net/minestom/server/command/GraphMergeTest.java b/src/test/java/net/minestom/server/command/GraphMergeTest.java
-index d257c0bd8881037ca13fd805931d94756b268e5b..37b404e9d79207274a10d17b1d091cb5bec56eb6 100644
+index d257c0bd8881037ca13fd805931d94756b268e5b..bed954ced10cc69d96986be1eac7093e7492c395 100644
 --- a/src/test/java/net/minestom/server/command/GraphMergeTest.java
 +++ b/src/test/java/net/minestom/server/command/GraphMergeTest.java
-@@ -8,10 +8,11 @@ import java.util.List;
+@@ -8,10 +8,10 @@ import java.util.List;
  import static net.minestom.server.command.builder.arguments.ArgumentType.Literal;
  import static org.junit.jupiter.api.Assertions.assertTrue;
  
 -public class GraphMergeTest {
-+//Microtus - update java keyword usage
 +class GraphMergeTest {
  
      @Test
@@ -2747,7 +2704,7 @@ index d257c0bd8881037ca13fd805931d94756b268e5b..37b404e9d79207274a10d17b1d091cb5
          var foo = new Command("foo");
          var bar = new Command("bar");
          var result = Graph.builder(Literal(""))
-@@ -22,7 +23,7 @@ public class GraphMergeTest {
+@@ -22,7 +22,7 @@ public class GraphMergeTest {
      }
  
      @Test
@@ -2756,7 +2713,7 @@ index d257c0bd8881037ca13fd805931d94756b268e5b..37b404e9d79207274a10d17b1d091cb5
          var graph1 = Graph.builder(Literal("foo")).build();
          var graph2 = Graph.builder(Literal("bar")).build();
          var result = Graph.builder(Literal(""))
-@@ -33,7 +34,7 @@ public class GraphMergeTest {
+@@ -33,7 +33,7 @@ public class GraphMergeTest {
      }
  
      @Test
@@ -2766,15 +2723,14 @@ index d257c0bd8881037ca13fd805931d94756b268e5b..37b404e9d79207274a10d17b1d091cb5
          var graph2 = Graph.builder(Literal("bar")).append(Literal("2")).build();
          var result = Graph.builder(Literal(""))
 diff --git a/src/test/java/net/minestom/server/command/GraphTest.java b/src/test/java/net/minestom/server/command/GraphTest.java
-index 388768e3bb3eace4665eff42ff06270aa47fbdf3..d9f334d1f5b35c0e31526e04287869b16c500b2d 100644
+index 388768e3bb3eace4665eff42ff06270aa47fbdf3..91dff666e2c11c27b09406243c2b783560de3218 100644
 --- a/src/test/java/net/minestom/server/command/GraphTest.java
 +++ b/src/test/java/net/minestom/server/command/GraphTest.java
-@@ -9,9 +9,10 @@ import java.util.List;
+@@ -9,9 +9,9 @@ import java.util.List;
  import static net.minestom.server.command.builder.arguments.ArgumentType.Literal;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class GraphTest {
-+//Microtus - update java keyword usage
 +class GraphTest {
      @Test
 -    public void empty() {
@@ -2782,7 +2738,7 @@ index 388768e3bb3eace4665eff42ff06270aa47fbdf3..d9f334d1f5b35c0e31526e04287869b1
          var result = Graph.builder(Literal(""))
                  .build();
          var node = result.root();
-@@ -20,7 +21,7 @@ public class GraphTest {
+@@ -20,7 +20,7 @@ public class GraphTest {
      }
  
      @Test
@@ -2791,7 +2747,7 @@ index 388768e3bb3eace4665eff42ff06270aa47fbdf3..d9f334d1f5b35c0e31526e04287869b1
          var result = Graph.builder(Literal(""))
                  .append(Literal("foo"))
                  .build();
-@@ -31,7 +32,7 @@ public class GraphTest {
+@@ -31,7 +31,7 @@ public class GraphTest {
      }
  
      @Test
@@ -2800,7 +2756,7 @@ index 388768e3bb3eace4665eff42ff06270aa47fbdf3..d9f334d1f5b35c0e31526e04287869b1
          var result = Graph.builder(Literal(""))
                  .append(Literal("foo"))
                  .append(Literal("bar"))
-@@ -42,7 +43,7 @@ public class GraphTest {
+@@ -42,7 +42,7 @@ public class GraphTest {
      }
  
      @Test
@@ -2809,7 +2765,7 @@ index 388768e3bb3eace4665eff42ff06270aa47fbdf3..d9f334d1f5b35c0e31526e04287869b1
          final Command foo = new Command("foo");
          var first = Literal("first");
          foo.addSyntax(GraphTest::dummyExecutor, first);
-@@ -54,7 +55,7 @@ public class GraphTest {
+@@ -54,7 +54,7 @@ public class GraphTest {
      }
  
      @Test
@@ -2819,15 +2775,14 @@ index 388768e3bb3eace4665eff42ff06270aa47fbdf3..d9f334d1f5b35c0e31526e04287869b1
  
          {
 diff --git a/src/test/java/net/minestom/server/command/SubcommandTest.java b/src/test/java/net/minestom/server/command/SubcommandTest.java
-index 6ed762fa232c741dbe0be886245e98d1515f9bd4..9b7ee1de34867d3689b37c52326cbf275606ca8a 100644
+index 6ed762fa232c741dbe0be886245e98d1515f9bd4..88968d428de85c144dafe1ed509edd30d808fa85 100644
 --- a/src/test/java/net/minestom/server/command/SubcommandTest.java
 +++ b/src/test/java/net/minestom/server/command/SubcommandTest.java
-@@ -8,10 +8,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
+@@ -8,10 +8,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
  import static org.junit.jupiter.api.Assertions.assertFalse;
  import static org.junit.jupiter.api.Assertions.assertTrue;
  
 -public class SubcommandTest {
-+//Microtus - update java keyword usage
 +class SubcommandTest {
  
      @Test
@@ -2836,7 +2791,7 @@ index 6ed762fa232c741dbe0be886245e98d1515f9bd4..9b7ee1de34867d3689b37c52326cbf27
          var manager = new CommandManager();
  
          var parent = new Command("parent");
-@@ -33,7 +34,7 @@ public class SubcommandTest {
+@@ -33,7 +33,7 @@ public class SubcommandTest {
      }
  
      @Test
@@ -2846,15 +2801,14 @@ index 6ed762fa232c741dbe0be886245e98d1515f9bd4..9b7ee1de34867d3689b37c52326cbf27
  
          var parent = new Command("parent");
 diff --git a/src/test/java/net/minestom/server/coordinate/CoordinateTest.java b/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
-index 560cf470c2ce9b12faf5af245f13b104a3a27a6e..373cc028435570ff4f62a062a98ba5a85598a935 100644
+index 560cf470c2ce9b12faf5af245f13b104a3a27a6e..2ebccae5928b3f66a8e1cb683342b4fc1a3131b1 100644
 --- a/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
 +++ b/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
-@@ -11,10 +11,11 @@ import java.util.List;
+@@ -11,10 +11,10 @@ import java.util.List;
  import static net.minestom.server.utils.chunk.ChunkUtils.*;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class CoordinateTest {
-+//Microtus - update java keyword usage
 +class CoordinateTest {
  
      @Test
@@ -2863,7 +2817,7 @@ index 560cf470c2ce9b12faf5af245f13b104a3a27a6e..373cc028435570ff4f62a062a98ba5a8
          var index = getChunkIndex(2, 5);
          assertEquals(2, getChunkCoordX(index));
          assertEquals(5, getChunkCoordZ(index));
-@@ -29,7 +30,7 @@ public class CoordinateTest {
+@@ -29,7 +29,7 @@ public class CoordinateTest {
      }
  
      @Test
@@ -2872,7 +2826,7 @@ index 560cf470c2ce9b12faf5af245f13b104a3a27a6e..373cc028435570ff4f62a062a98ba5a8
          assertEquals(0, getChunkCoordinate(15));
          assertEquals(1, getChunkCoordinate(16));
          assertEquals(-1, getChunkCoordinate(-16));
-@@ -43,7 +44,7 @@ public class CoordinateTest {
+@@ -43,7 +43,7 @@ public class CoordinateTest {
      }
  
      @Test
@@ -2881,7 +2835,7 @@ index 560cf470c2ce9b12faf5af245f13b104a3a27a6e..373cc028435570ff4f62a062a98ba5a8
          assertEquals(289, getChunkCount(8));
          assertEquals(169, getChunkCount(6));
          assertEquals(121, getChunkCount(5));
-@@ -53,7 +54,7 @@ public class CoordinateTest {
+@@ -53,7 +53,7 @@ public class CoordinateTest {
      }
  
      @Test
@@ -2890,7 +2844,7 @@ index 560cf470c2ce9b12faf5af245f13b104a3a27a6e..373cc028435570ff4f62a062a98ba5a8
          Vec temp = Vec.ZERO;
          assertEquals(0, temp.x());
          assertEquals(0, temp.y());
-@@ -81,7 +82,7 @@ public class CoordinateTest {
+@@ -81,7 +81,7 @@ public class CoordinateTest {
      }
  
      @Test
@@ -2899,7 +2853,7 @@ index 560cf470c2ce9b12faf5af245f13b104a3a27a6e..373cc028435570ff4f62a062a98ba5a8
          Vec temp = Vec.ZERO.withX(1);
          assertEquals(1, temp.x());
          assertEquals(0, temp.y());
-@@ -94,7 +95,7 @@ public class CoordinateTest {
+@@ -94,7 +94,7 @@ public class CoordinateTest {
      }
  
      @Test
@@ -2908,7 +2862,7 @@ index 560cf470c2ce9b12faf5af245f13b104a3a27a6e..373cc028435570ff4f62a062a98ba5a8
          assertEquals(8, ChunkUtils.toSectionRelativeCoordinate(-40));
          assertEquals(12, ChunkUtils.toSectionRelativeCoordinate(-20));
          assertEquals(0, ChunkUtils.toSectionRelativeCoordinate(0));
-@@ -107,7 +108,7 @@ public class CoordinateTest {
+@@ -107,7 +107,7 @@ public class CoordinateTest {
      }
  
      @Test
@@ -2917,7 +2871,7 @@ index 560cf470c2ce9b12faf5af245f13b104a3a27a6e..373cc028435570ff4f62a062a98ba5a8
          // Test if the block index is correctly converted back and forth
  
          List<Vec> tempEquals = List.of(
-@@ -151,7 +152,7 @@ public class CoordinateTest {
+@@ -151,7 +151,7 @@ public class CoordinateTest {
      }
  
      @Test
@@ -2927,15 +2881,14 @@ index 560cf470c2ce9b12faf5af245f13b104a3a27a6e..373cc028435570ff4f62a062a98ba5a8
  
          for (int x = 0; x < Chunk.CHUNK_SIZE_X; x++) {
 diff --git a/src/test/java/net/minestom/server/coordinate/PosViewDirectionTest.java b/src/test/java/net/minestom/server/coordinate/PosViewDirectionTest.java
-index e0ae029f68f7ec614d69836fdc9b84542a5b4bd5..1922b6c9f74916e252f3169c863dc18662176815 100644
+index e0ae029f68f7ec614d69836fdc9b84542a5b4bd5..1072819aa016c8ce3d2c47031caa084fc246186f 100644
 --- a/src/test/java/net/minestom/server/coordinate/PosViewDirectionTest.java
 +++ b/src/test/java/net/minestom/server/coordinate/PosViewDirectionTest.java
-@@ -4,11 +4,12 @@ import org.junit.jupiter.api.Test;
+@@ -4,11 +4,11 @@ import org.junit.jupiter.api.Test;
  
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
 -public class PosViewDirectionTest {
-+//Microtus - update java keyword usage
 +class PosViewDirectionTest {
      private static final float EPSILON = 0.01f;
  
@@ -2946,14 +2899,12 @@ index e0ae029f68f7ec614d69836fdc9b84542a5b4bd5..1922b6c9f74916e252f3169c863dc186
          Pos position;
  
 diff --git a/src/test/java/net/minestom/server/entity/EntityBoundingBoxIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityBoundingBoxIntegrationTest.java
-index dc20cd87d838a6b186180d94d7037c276fc9169c..a870739251b09c5e0dccd9e66501909ce96c8822 100644
+index dc20cd87d838a6b186180d94d7037c276fc9169c..01bbdd9065aa8e5966eaad3d788b13025455e738 100644
 --- a/src/test/java/net/minestom/server/entity/EntityBoundingBoxIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityBoundingBoxIntegrationTest.java
-@@ -12,10 +12,11 @@ import org.junit.jupiter.api.Test;
- 
+@@ -13,9 +13,9 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class EntityBoundingBoxIntegrationTest {
 +class EntityBoundingBoxIntegrationTest {
@@ -2963,7 +2914,7 @@ index dc20cd87d838a6b186180d94d7037c276fc9169c..a870739251b09c5e0dccd9e66501909c
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -36,7 +37,7 @@ public class EntityBoundingBoxIntegrationTest {
+@@ -36,7 +36,7 @@ public class EntityBoundingBoxIntegrationTest {
      }
  
      @Test
@@ -2972,7 +2923,7 @@ index dc20cd87d838a6b186180d94d7037c276fc9169c..a870739251b09c5e0dccd9e66501909c
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -54,7 +55,7 @@ public class EntityBoundingBoxIntegrationTest {
+@@ -54,7 +54,7 @@ public class EntityBoundingBoxIntegrationTest {
      }
  
      @Test
@@ -2981,27 +2932,13 @@ index dc20cd87d838a6b186180d94d7037c276fc9169c..a870739251b09c5e0dccd9e66501909c
          final var instance = env.createFlatInstance();
          final var listener = env.listen(PickupItemEvent.class);
          final var spawnPos = new Pos(0, 42, 0);
-diff --git a/src/test/java/net/minestom/server/entity/EntityEqualsTest.java b/src/test/java/net/minestom/server/entity/EntityEqualsTest.java
-index e11088a617e6da7b058b6c6a8a8ffb311ceebe48..0ad4a671fed6860a008a50f6be48e2bb5c07afcc 100644
---- a/src/test/java/net/minestom/server/entity/EntityEqualsTest.java
-+++ b/src/test/java/net/minestom/server/entity/EntityEqualsTest.java
-@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
- 
- import static org.junit.jupiter.api.Assertions.*;
- 
-+//Microtus - update java keyword usage
- class EntityEqualsTest {
- 
-     @Test
 diff --git a/src/test/java/net/minestom/server/entity/EntityInstanceIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityInstanceIntegrationTest.java
-index 5a9d128ef0d73a1726d6af1ed73ff1fee36a82a7..496a402d1c63d69e8d922e407deab47d9282bb40 100644
+index 5a9d128ef0d73a1726d6af1ed73ff1fee36a82a7..ba578f774f6787183606206ef9a435bbd147e6b3 100644
 --- a/src/test/java/net/minestom/server/entity/EntityInstanceIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityInstanceIntegrationTest.java
-@@ -10,11 +10,12 @@ import java.time.Duration;
- 
+@@ -11,10 +11,10 @@ import java.time.Duration;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class EntityInstanceIntegrationTest {
 +class EntityInstanceIntegrationTest {
@@ -3012,7 +2949,7 @@ index 5a9d128ef0d73a1726d6af1ed73ff1fee36a82a7..496a402d1c63d69e8d922e407deab47d
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityTypes.ZOMBIE);
          entity.setInstance(instance, new Pos(0, 42, 0)).join();
-@@ -23,7 +24,7 @@ public class EntityInstanceIntegrationTest {
+@@ -23,7 +23,7 @@ public class EntityInstanceIntegrationTest {
      }
  
      @Test
@@ -3021,7 +2958,7 @@ index 5a9d128ef0d73a1726d6af1ed73ff1fee36a82a7..496a402d1c63d69e8d922e407deab47d
          var instance = env.createFlatInstance();
          var player = env.createPlayer(instance, new Pos(0, 42, 0));
          assertEquals(instance, player.getInstance());
-@@ -31,7 +32,7 @@ public class EntityInstanceIntegrationTest {
+@@ -31,7 +31,7 @@ public class EntityInstanceIntegrationTest {
      }
  
      @Test
@@ -3031,14 +2968,12 @@ index 5a9d128ef0d73a1726d6af1ed73ff1fee36a82a7..496a402d1c63d69e8d922e407deab47d
          var instance2 = env.createFlatInstance();
          var connection = env.createConnection();
 diff --git a/src/test/java/net/minestom/server/entity/EntityLineOfSightIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityLineOfSightIntegrationTest.java
-index a6bb809294a39af40ab9d89a86299d37c5e15e00..b4877072205311257d16cfb9f610575e817ed186 100644
+index a6bb809294a39af40ab9d89a86299d37c5e15e00..eb4c8083d2517206c90a0c598e20fce700740f1b 100644
 --- a/src/test/java/net/minestom/server/entity/EntityLineOfSightIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityLineOfSightIntegrationTest.java
-@@ -8,10 +8,11 @@ import org.junit.jupiter.api.Test;
- 
+@@ -9,9 +9,9 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.*;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class EntityLineOfSightIntegrationTest {
 +class EntityLineOfSightIntegrationTest {
@@ -3048,7 +2983,7 @@ index a6bb809294a39af40ab9d89a86299d37c5e15e00..b4877072205311257d16cfb9f610575e
          var instance = env.createFlatInstance();
  
          var entity = new Entity(EntityTypes.ZOMBIE);
-@@ -35,7 +36,7 @@ public class EntityLineOfSightIntegrationTest {
+@@ -35,7 +35,7 @@ public class EntityLineOfSightIntegrationTest {
      }
  
      @Test
@@ -3057,7 +2992,7 @@ index a6bb809294a39af40ab9d89a86299d37c5e15e00..b4877072205311257d16cfb9f610575e
          var instance = env.createFlatInstance();
  
          var entity = new Entity(EntityTypes.ZOMBIE);
-@@ -59,7 +60,7 @@ public class EntityLineOfSightIntegrationTest {
+@@ -59,7 +59,7 @@ public class EntityLineOfSightIntegrationTest {
      }
  
      @Test
@@ -3066,7 +3001,7 @@ index a6bb809294a39af40ab9d89a86299d37c5e15e00..b4877072205311257d16cfb9f610575e
          var instance = env.createFlatInstance();
  
          var entity = new Entity(EntityTypes.ZOMBIE);
-@@ -83,7 +84,7 @@ public class EntityLineOfSightIntegrationTest {
+@@ -83,7 +83,7 @@ public class EntityLineOfSightIntegrationTest {
      }
  
      @Test
@@ -3075,7 +3010,7 @@ index a6bb809294a39af40ab9d89a86299d37c5e15e00..b4877072205311257d16cfb9f610575e
          var instance = env.createFlatInstance();
  
          var entity = new Entity(EntityTypes.ZOMBIE);
-@@ -109,7 +110,7 @@ public class EntityLineOfSightIntegrationTest {
+@@ -109,7 +109,7 @@ public class EntityLineOfSightIntegrationTest {
      }
  
      @Test
@@ -3084,7 +3019,7 @@ index a6bb809294a39af40ab9d89a86299d37c5e15e00..b4877072205311257d16cfb9f610575e
          var instance = env.createFlatInstance();
  
          var entity = new Entity(EntityTypes.ZOMBIE);
-@@ -130,7 +131,7 @@ public class EntityLineOfSightIntegrationTest {
+@@ -130,7 +130,7 @@ public class EntityLineOfSightIntegrationTest {
      }
  
      @Test
@@ -3093,7 +3028,7 @@ index a6bb809294a39af40ab9d89a86299d37c5e15e00..b4877072205311257d16cfb9f610575e
          var instance = env.createFlatInstance();
  
          var entity = new Entity(EntityTypes.ZOMBIE);
-@@ -145,7 +146,7 @@ public class EntityLineOfSightIntegrationTest {
+@@ -145,7 +145,7 @@ public class EntityLineOfSightIntegrationTest {
          assertTrue(entity.hasLineOfSight(entity2, false));
      }
      @Test
@@ -3103,14 +3038,12 @@ index a6bb809294a39af40ab9d89a86299d37c5e15e00..b4877072205311257d16cfb9f610575e
  
          var entity = new Entity(EntityTypes.ZOMBIE);
 diff --git a/src/test/java/net/minestom/server/entity/EntityMetaIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityMetaIntegrationTest.java
-index d4bc0029ea907166ea1e42cccc801828ad2829c9..21603a61f8213d530805d8b651a5ac6b724bea32 100644
+index d4bc0029ea907166ea1e42cccc801828ad2829c9..570f9d13fd3795dbd8646d0803b422efa02004cf 100644
 --- a/src/test/java/net/minestom/server/entity/EntityMetaIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityMetaIntegrationTest.java
-@@ -13,11 +13,12 @@ import java.util.function.Consumer;
- 
+@@ -14,10 +14,10 @@ import java.util.function.Consumer;
  import static org.junit.jupiter.api.Assertions.*;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class EntityMetaIntegrationTest {
 +class EntityMetaIntegrationTest {
@@ -3121,7 +3054,7 @@ index d4bc0029ea907166ea1e42cccc801828ad2829c9..21603a61f8213d530805d8b651a5ac6b
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var otherPlayer = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -79,7 +80,7 @@ public class EntityMetaIntegrationTest {
+@@ -79,7 +79,7 @@ public class EntityMetaIntegrationTest {
      }
  
      @Test
@@ -3131,15 +3064,14 @@ index d4bc0029ea907166ea1e42cccc801828ad2829c9..21603a61f8213d530805d8b651a5ac6b
          var connection = env.createConnection();
          var instance = env.createFlatInstance();
 diff --git a/src/test/java/net/minestom/server/entity/EntityMetaTest.java b/src/test/java/net/minestom/server/entity/EntityMetaTest.java
-index fec36086a4cc442ab5b41fa38139011d803d8a60..1cda4f35f16941307c451d7c4e5d8d51eef23096 100644
+index fec36086a4cc442ab5b41fa38139011d803d8a60..3e14287168e35f62756493a12feb6a95aea34857 100644
 --- a/src/test/java/net/minestom/server/entity/EntityMetaTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityMetaTest.java
-@@ -7,10 +7,11 @@ import java.util.List;
+@@ -7,10 +7,10 @@ import java.util.List;
  
  import static org.junit.jupiter.api.Assertions.assertTrue;
  
 -public class EntityMetaTest {
-+//Microtus - update java keyword usage
 +class EntityMetaTest {
  
      @Test
@@ -3149,14 +3081,12 @@ index fec36086a4cc442ab5b41fa38139011d803d8a60..1cda4f35f16941307c451d7c4e5d8d51
          for (var field : EntityTypes.class.getDeclaredFields()) {
              final EntityType entityType = (EntityType) field.get(this);
 diff --git a/src/test/java/net/minestom/server/entity/EntityProjectileIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityProjectileIntegrationTest.java
-index 814257ce83dcf9228df221f877bb521980e83b8a..6db09213abec98a4dbaf7def9b2a0604d1934201 100644
+index 814257ce83dcf9228df221f877bb521980e83b8a..d5f4bf0c9e56569a8b85ec8789f0fcda7240dd53 100644
 --- a/src/test/java/net/minestom/server/entity/EntityProjectileIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityProjectileIntegrationTest.java
-@@ -7,10 +7,11 @@ import org.junit.jupiter.api.Test;
- 
+@@ -8,9 +8,9 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class EntityProjectileIntegrationTest {
 +class EntityProjectileIntegrationTest {
@@ -3166,7 +3096,7 @@ index 814257ce83dcf9228df221f877bb521980e83b8a..6db09213abec98a4dbaf7def9b2a0604
          var instance = env.createFlatInstance();
          var shooter = new EntityCreature(EntityType.SKELETON);
          shooter.setInstance(instance, new Pos(0, 42, 0)).join();
-@@ -42,7 +43,7 @@ public class EntityProjectileIntegrationTest {
+@@ -42,7 +42,7 @@ public class EntityProjectileIntegrationTest {
      }
  
      @Test
@@ -3176,14 +3106,12 @@ index 814257ce83dcf9228df221f877bb521980e83b8a..6db09213abec98a4dbaf7def9b2a0604
          var shooter = new EntityCreature(EntityType.SKELETON);
          shooter.setInstance(instance, new Pos(0, 42, 0)).join();
 diff --git a/src/test/java/net/minestom/server/entity/EntityRemovalIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityRemovalIntegrationTest.java
-index 42d6e2f23777010d59206346d9efa5158ca70dec..fd3c02404358941ef54f0bb27277b312827d0fb0 100644
+index 42d6e2f23777010d59206346d9efa5158ca70dec..35387a6cdcd97079a9e6d896e305f952c15a3a1f 100644
 --- a/src/test/java/net/minestom/server/entity/EntityRemovalIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityRemovalIntegrationTest.java
-@@ -15,11 +15,12 @@ import java.util.List;
- import static net.minestom.testing.TestUtils.waitUntilCleared;
+@@ -16,10 +16,10 @@ import static net.minestom.testing.TestUtils.waitUntilCleared;
  import static org.junit.jupiter.api.Assertions.*;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class EntityRemovalIntegrationTest {
 +class EntityRemovalIntegrationTest {
@@ -3194,7 +3122,7 @@ index 42d6e2f23777010d59206346d9efa5158ca70dec..fd3c02404358941ef54f0bb27277b312
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          connection.connect(instance, new Pos(0, 40, 0)).join();
-@@ -33,7 +34,7 @@ public class EntityRemovalIntegrationTest {
+@@ -33,7 +33,7 @@ public class EntityRemovalIntegrationTest {
      }
  
      @Test
@@ -3203,7 +3131,7 @@ index 42d6e2f23777010d59206346d9efa5158ca70dec..fd3c02404358941ef54f0bb27277b312
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityType.ZOMBIE);
          entity.setInstance(instance, new Pos(0, 40, 0)).join();
-@@ -45,7 +46,7 @@ public class EntityRemovalIntegrationTest {
+@@ -45,7 +45,7 @@ public class EntityRemovalIntegrationTest {
      }
  
      @Test
@@ -3212,7 +3140,7 @@ index 42d6e2f23777010d59206346d9efa5158ca70dec..fd3c02404358941ef54f0bb27277b312
          var instance = env.createFlatInstance();
          var entity = new TestEntity(2, TimeUnit.SERVER_TICK);
          entity.setInstance(instance, new Pos(0, 40, 0)).join();
-@@ -65,7 +66,7 @@ public class EntityRemovalIntegrationTest {
+@@ -65,7 +65,7 @@ public class EntityRemovalIntegrationTest {
      }
  
      @Test
@@ -3221,7 +3149,7 @@ index 42d6e2f23777010d59206346d9efa5158ca70dec..fd3c02404358941ef54f0bb27277b312
          // Ensure that entities do not stay in memory after they are removed
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityType.ZOMBIE);
-@@ -80,7 +81,7 @@ public class EntityRemovalIntegrationTest {
+@@ -80,7 +80,7 @@ public class EntityRemovalIntegrationTest {
      }
  
      @Test
@@ -3230,7 +3158,7 @@ index 42d6e2f23777010d59206346d9efa5158ca70dec..fd3c02404358941ef54f0bb27277b312
          // Ensure that the entities GCed when a local listener is present
          var node = env.process().eventHandler();
          var entity = new Entity(EntityType.ZOMBIE);
-@@ -97,7 +98,7 @@ public class EntityRemovalIntegrationTest {
+@@ -97,7 +97,7 @@ public class EntityRemovalIntegrationTest {
      }
  
      static final class TestEntity extends Entity {
@@ -3240,14 +3168,12 @@ index 42d6e2f23777010d59206346d9efa5158ca70dec..fd3c02404358941ef54f0bb27277b312
              scheduleRemove(delay, unit);
          }
 diff --git a/src/test/java/net/minestom/server/entity/EntityTeleportIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityTeleportIntegrationTest.java
-index 22b32a5d5275ae3aca28bce8b87975aae4bd5f32..8ddb099db0fb0e9e0fed051ecea06d3f5daa2f62 100644
+index 22b32a5d5275ae3aca28bce8b87975aae4bd5f32..8eea5dcf24ebffc832af63308b6d6435913732a2 100644
 --- a/src/test/java/net/minestom/server/entity/EntityTeleportIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityTeleportIntegrationTest.java
-@@ -10,11 +10,12 @@ import org.junit.jupiter.api.Test;
- 
+@@ -11,10 +11,10 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class EntityTeleportIntegrationTest {
 +class EntityTeleportIntegrationTest {
@@ -3258,7 +3184,7 @@ index 22b32a5d5275ae3aca28bce8b87975aae4bd5f32..8ddb099db0fb0e9e0fed051ecea06d3f
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityTypes.ZOMBIE);
          entity.setInstance(instance, new Pos(0, 42, 0)).join();
-@@ -26,7 +27,7 @@ public class EntityTeleportIntegrationTest {
+@@ -26,7 +26,7 @@ public class EntityTeleportIntegrationTest {
      }
  
      @Test
@@ -3267,7 +3193,7 @@ index 22b32a5d5275ae3aca28bce8b87975aae4bd5f32..8ddb099db0fb0e9e0fed051ecea06d3f
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityTypes.ZOMBIE);
          entity.setInstance(instance, new Pos(0, 42, 0)).join();
-@@ -38,7 +39,7 @@ public class EntityTeleportIntegrationTest {
+@@ -38,7 +38,7 @@ public class EntityTeleportIntegrationTest {
      }
  
      @Test
@@ -3276,7 +3202,7 @@ index 22b32a5d5275ae3aca28bce8b87975aae4bd5f32..8ddb099db0fb0e9e0fed051ecea06d3f
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 40, 0)).join();
-@@ -65,7 +66,7 @@ public class EntityTeleportIntegrationTest {
+@@ -65,7 +65,7 @@ public class EntityTeleportIntegrationTest {
      }
  
      @Test
@@ -3286,14 +3212,12 @@ index 22b32a5d5275ae3aca28bce8b87975aae4bd5f32..8ddb099db0fb0e9e0fed051ecea06d3f
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 40, 0)).join();
 diff --git a/src/test/java/net/minestom/server/entity/EntityVelocityIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityVelocityIntegrationTest.java
-index 2ee0bd4296cd18e9a0c243cf5606ab6ced6f81cb..6165e4aa6fd7a744a00375f128acf435224ef901 100644
+index 2ee0bd4296cd18e9a0c243cf5606ab6ced6f81cb..b417ccc6e678d5233e5c2caf8b4c364793f2100d 100644
 --- a/src/test/java/net/minestom/server/entity/EntityVelocityIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityVelocityIntegrationTest.java
-@@ -14,10 +14,11 @@ import java.util.function.BooleanSupplier;
- 
+@@ -15,9 +15,9 @@ import java.util.function.BooleanSupplier;
  import static org.junit.jupiter.api.Assertions.*;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class EntityVelocityIntegrationTest {
 +class EntityVelocityIntegrationTest {
@@ -3303,7 +3227,7 @@ index 2ee0bd4296cd18e9a0c243cf5606ab6ced6f81cb..6165e4aa6fd7a744a00375f128acf435
          var instance = env.createFlatInstance();
          loadChunks(instance);
  
-@@ -36,7 +37,7 @@ public class EntityVelocityIntegrationTest {
+@@ -36,7 +36,7 @@ public class EntityVelocityIntegrationTest {
      }
  
      @Test
@@ -3312,7 +3236,7 @@ index 2ee0bd4296cd18e9a0c243cf5606ab6ced6f81cb..6165e4aa6fd7a744a00375f128acf435
          var instance = env.createFlatInstance();
          loadChunks(instance);
  
-@@ -67,7 +68,7 @@ public class EntityVelocityIntegrationTest {
+@@ -67,7 +67,7 @@ public class EntityVelocityIntegrationTest {
      }
  
      @Test
@@ -3321,7 +3245,7 @@ index 2ee0bd4296cd18e9a0c243cf5606ab6ced6f81cb..6165e4aa6fd7a744a00375f128acf435
          var instance = env.createFlatInstance();
          loadChunks(instance);
  
-@@ -102,7 +103,7 @@ public class EntityVelocityIntegrationTest {
+@@ -102,7 +102,7 @@ public class EntityVelocityIntegrationTest {
      }
  
      @Test
@@ -3330,7 +3254,7 @@ index 2ee0bd4296cd18e9a0c243cf5606ab6ced6f81cb..6165e4aa6fd7a744a00375f128acf435
          var instance = env.createFlatInstance();
          loadChunks(instance);
  
-@@ -127,7 +128,7 @@ public class EntityVelocityIntegrationTest {
+@@ -127,7 +127,7 @@ public class EntityVelocityIntegrationTest {
      }
  
      @Test
@@ -3339,7 +3263,7 @@ index 2ee0bd4296cd18e9a0c243cf5606ab6ced6f81cb..6165e4aa6fd7a744a00375f128acf435
          // Player movement should not send velocity packets as already client predicted
          var instance = env.createFlatInstance();
          var player = env.createPlayer(instance, new Pos(0, 42, 0));
-@@ -141,7 +142,7 @@ public class EntityVelocityIntegrationTest {
+@@ -141,7 +141,7 @@ public class EntityVelocityIntegrationTest {
      }
  
      @Test
@@ -3348,7 +3272,7 @@ index 2ee0bd4296cd18e9a0c243cf5606ab6ced6f81cb..6165e4aa6fd7a744a00375f128acf435
          var instance = env.createFlatInstance();
          loadChunks(instance);
  
-@@ -164,7 +165,7 @@ public class EntityVelocityIntegrationTest {
+@@ -164,7 +164,7 @@ public class EntityVelocityIntegrationTest {
      }
  
      @Test
@@ -3358,14 +3282,12 @@ index 2ee0bd4296cd18e9a0c243cf5606ab6ced6f81cb..6165e4aa6fd7a744a00375f128acf435
  
          var instance = env.createFlatInstance();
 diff --git a/src/test/java/net/minestom/server/entity/EntityViewDirectionIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityViewDirectionIntegrationTest.java
-index 00d15fb47f66a452336339b59833c10bf2c03674..aea8f80657d2df38db6f1a30a5b2aa743716f4bf 100644
+index 00d15fb47f66a452336339b59833c10bf2c03674..5ba3cb257207b4cf630ee3c24fb54f80c85a85d6 100644
 --- a/src/test/java/net/minestom/server/entity/EntityViewDirectionIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityViewDirectionIntegrationTest.java
-@@ -8,12 +8,13 @@ import org.junit.jupiter.api.Test;
- import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -9,11 +9,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertTrue;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class EntityViewDirectionIntegrationTest {
 +class EntityViewDirectionIntegrationTest {
@@ -3377,7 +3299,7 @@ index 00d15fb47f66a452336339b59833c10bf2c03674..aea8f80657d2df38db6f1a30a5b2aa74
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityType.ZOMBIE);
          entity.setInstance(instance, new Pos(0, 40, 0)).join();
-@@ -48,7 +49,7 @@ public class EntityViewDirectionIntegrationTest {
+@@ -48,7 +48,7 @@ public class EntityViewDirectionIntegrationTest {
      }
  
      @Test
@@ -3386,7 +3308,7 @@ index 00d15fb47f66a452336339b59833c10bf2c03674..aea8f80657d2df38db6f1a30a5b2aa74
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityType.ZOMBIE);
          double eyeHeight = entity.getEyeHeight(); // adding this to some position Y coordinates, to look horizontally
-@@ -87,7 +88,7 @@ public class EntityViewDirectionIntegrationTest {
+@@ -87,7 +87,7 @@ public class EntityViewDirectionIntegrationTest {
      }
  
      @Test
@@ -3395,7 +3317,7 @@ index 00d15fb47f66a452336339b59833c10bf2c03674..aea8f80657d2df38db6f1a30a5b2aa74
          var instance = env.createFlatInstance();
          // same type, same eye height
          var e1 = new Entity(EntityType.ZOMBIE);
-@@ -121,7 +122,7 @@ public class EntityViewDirectionIntegrationTest {
+@@ -121,7 +121,7 @@ public class EntityViewDirectionIntegrationTest {
      }
  
      @Test
@@ -3405,14 +3327,12 @@ index 00d15fb47f66a452336339b59833c10bf2c03674..aea8f80657d2df38db6f1a30a5b2aa74
          // same type, same eye height
          var e1 = new Entity(EntityType.ZOMBIE);
 diff --git a/src/test/java/net/minestom/server/entity/EntityViewIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityViewIntegrationTest.java
-index 181b303252adccd24255baaa9a76ca18dc297d9b..09ab9a26753e2e84b3f52cd8e1f4da6ac7c64ed5 100644
+index 181b303252adccd24255baaa9a76ca18dc297d9b..b87d2081c413b2693f65b3d6b93814574ef377e7 100644
 --- a/src/test/java/net/minestom/server/entity/EntityViewIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityViewIntegrationTest.java
-@@ -8,11 +8,12 @@ import org.junit.jupiter.api.Test;
- 
+@@ -9,10 +9,10 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.*;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class EntityViewIntegrationTest {
 +class EntityViewIntegrationTest {
@@ -3423,7 +3343,7 @@ index 181b303252adccd24255baaa9a76ca18dc297d9b..09ab9a26753e2e84b3f52cd8e1f4da6a
          var instance = env.createFlatInstance();
          var entity = new Entity(EntityType.ZOMBIE);
          entity.setInstance(instance, new Pos(0, 40, 42)).join();
-@@ -20,14 +21,14 @@ public class EntityViewIntegrationTest {
+@@ -20,14 +20,14 @@ public class EntityViewIntegrationTest {
      }
  
      @Test
@@ -3440,7 +3360,7 @@ index 181b303252adccd24255baaa9a76ca18dc297d9b..09ab9a26753e2e84b3f52cd8e1f4da6a
          var instance = env.createFlatInstance();
          var p1 = env.createPlayer(instance, new Pos(0, 42, 42));
          var p2 = env.createPlayer(instance, new Pos(0, 42, 42));
-@@ -48,7 +49,7 @@ public class EntityViewIntegrationTest {
+@@ -48,7 +48,7 @@ public class EntityViewIntegrationTest {
      }
  
      @Test
@@ -3449,7 +3369,7 @@ index 181b303252adccd24255baaa9a76ca18dc297d9b..09ab9a26753e2e84b3f52cd8e1f4da6a
          var instance = env.createFlatInstance();
          var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
          var p2 = env.createPlayer(instance, new Pos(0, 42, 5_000));
-@@ -65,7 +66,7 @@ public class EntityViewIntegrationTest {
+@@ -65,7 +65,7 @@ public class EntityViewIntegrationTest {
      }
  
      @Test
@@ -3458,7 +3378,7 @@ index 181b303252adccd24255baaa9a76ca18dc297d9b..09ab9a26753e2e84b3f52cd8e1f4da6a
          var instance = env.createFlatInstance();
          var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
          var p2 = env.createPlayer(instance, new Pos(0, 42, 96));
-@@ -79,7 +80,7 @@ public class EntityViewIntegrationTest {
+@@ -79,7 +79,7 @@ public class EntityViewIntegrationTest {
      }
  
      @Test
@@ -3467,7 +3387,7 @@ index 181b303252adccd24255baaa9a76ca18dc297d9b..09ab9a26753e2e84b3f52cd8e1f4da6a
          var instance = env.createFlatInstance();
          var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
          assertTrue(p1.isAutoViewable());
-@@ -96,7 +97,7 @@ public class EntityViewIntegrationTest {
+@@ -96,7 +96,7 @@ public class EntityViewIntegrationTest {
      }
  
      @Test
@@ -3476,7 +3396,7 @@ index 181b303252adccd24255baaa9a76ca18dc297d9b..09ab9a26753e2e84b3f52cd8e1f4da6a
          var instance = env.createFlatInstance();
          var p = env.createPlayer(instance, new Pos(0, 42, 0));
          assertTrue(p.hasPredictableViewers());
-@@ -123,7 +124,7 @@ public class EntityViewIntegrationTest {
+@@ -123,7 +123,7 @@ public class EntityViewIntegrationTest {
      }
  
      @Test
@@ -3485,7 +3405,7 @@ index 181b303252adccd24255baaa9a76ca18dc297d9b..09ab9a26753e2e84b3f52cd8e1f4da6a
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 40, 0)).join();
-@@ -153,7 +154,7 @@ public class EntityViewIntegrationTest {
+@@ -153,7 +153,7 @@ public class EntityViewIntegrationTest {
      }
  
      @Test
@@ -3495,14 +3415,12 @@ index 181b303252adccd24255baaa9a76ca18dc297d9b..09ab9a26753e2e84b3f52cd8e1f4da6a
          var p1 = env.createPlayer(instance, new Pos(0, 40, 0));
          var p2 = env.createPlayer(instance, new Pos(0, 40, 0));
 diff --git a/src/test/java/net/minestom/server/entity/EntityViewerRuleIntegrationTest.java b/src/test/java/net/minestom/server/entity/EntityViewerRuleIntegrationTest.java
-index 40038cf6f257e058e79ffb8eacdcf96ca1e61685..cb27e3537db1ee1bcc2a8997746727931451be74 100644
+index 40038cf6f257e058e79ffb8eacdcf96ca1e61685..6074de4b7fc26017f615bf08503dd01055ee1e39 100644
 --- a/src/test/java/net/minestom/server/entity/EntityViewerRuleIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/EntityViewerRuleIntegrationTest.java
-@@ -9,11 +9,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
- 
+@@ -10,10 +10,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class EntityViewerRuleIntegrationTest {
 +class EntityViewerRuleIntegrationTest {
@@ -3513,7 +3431,7 @@ index 40038cf6f257e058e79ffb8eacdcf96ca1e61685..cb27e3537db1ee1bcc2a899774672793
          var instance = env.createFlatInstance();
          var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
          p1.updateViewableRule(p -> p.getEntityId() == p1.getEntityId() + 1);
-@@ -30,7 +31,7 @@ public class EntityViewerRuleIntegrationTest {
+@@ -30,7 +30,7 @@ public class EntityViewerRuleIntegrationTest {
      }
  
      @Test
@@ -3522,7 +3440,7 @@ index 40038cf6f257e058e79ffb8eacdcf96ca1e61685..cb27e3537db1ee1bcc2a899774672793
          var instance = env.createFlatInstance();
          var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
  
-@@ -48,7 +49,7 @@ public class EntityViewerRuleIntegrationTest {
+@@ -48,7 +48,7 @@ public class EntityViewerRuleIntegrationTest {
      }
  
      @Test
@@ -3531,7 +3449,7 @@ index 40038cf6f257e058e79ffb8eacdcf96ca1e61685..cb27e3537db1ee1bcc2a899774672793
          var instance = env.createFlatInstance();
          var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
          var p2 = env.createPlayer(instance, new Pos(0, 42, 0));
-@@ -80,7 +81,7 @@ public class EntityViewerRuleIntegrationTest {
+@@ -80,7 +80,7 @@ public class EntityViewerRuleIntegrationTest {
      }
  
      @Test
@@ -3540,7 +3458,7 @@ index 40038cf6f257e058e79ffb8eacdcf96ca1e61685..cb27e3537db1ee1bcc2a899774672793
          var instance = env.createFlatInstance();
          var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
          p1.updateViewerRule(e -> e.getEntityId() == p1.getEntityId() + 1);
-@@ -97,7 +98,7 @@ public class EntityViewerRuleIntegrationTest {
+@@ -97,7 +97,7 @@ public class EntityViewerRuleIntegrationTest {
      }
  
      @Test
@@ -3549,7 +3467,7 @@ index 40038cf6f257e058e79ffb8eacdcf96ca1e61685..cb27e3537db1ee1bcc2a899774672793
          var instance = env.createFlatInstance();
          var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
          AtomicBoolean enabled = new AtomicBoolean(false);
-@@ -114,7 +115,7 @@ public class EntityViewerRuleIntegrationTest {
+@@ -114,7 +114,7 @@ public class EntityViewerRuleIntegrationTest {
      }
  
      @Test
@@ -3559,15 +3477,14 @@ index 40038cf6f257e058e79ffb8eacdcf96ca1e61685..cb27e3537db1ee1bcc2a899774672793
          var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
          var p2 = env.createPlayer(instance, new Pos(0, 42, 0));
 diff --git a/src/test/java/net/minestom/server/entity/GameModeTest.java b/src/test/java/net/minestom/server/entity/GameModeTest.java
-index 2d7ea85dd0764cf052efa3ced47bab698c6c3aa4..1a24ecb4bb56306581cdccfb8c3107db9c3da247 100644
+index 2d7ea85dd0764cf052efa3ced47bab698c6c3aa4..f249cac8065fe61c163c03573b1ad2430bd4c262 100644
 --- a/src/test/java/net/minestom/server/entity/GameModeTest.java
 +++ b/src/test/java/net/minestom/server/entity/GameModeTest.java
-@@ -4,18 +4,19 @@ import org.junit.jupiter.api.Test;
+@@ -4,18 +4,18 @@ import org.junit.jupiter.api.Test;
  
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
 -public class GameModeTest {
-+//Microtus - update java keyword usage
 +class GameModeTest {
  
      @Test
@@ -3590,14 +3507,12 @@ index 2d7ea85dd0764cf052efa3ced47bab698c6c3aa4..1a24ecb4bb56306581cdccfb8c3107db
          assertEquals(GameMode.CREATIVE, GameMode.fromId(1));
          assertEquals(GameMode.ADVENTURE, GameMode.fromId(2));
 diff --git a/src/test/java/net/minestom/server/entity/PassengerIntegrationTest.java b/src/test/java/net/minestom/server/entity/PassengerIntegrationTest.java
-index 2b9402f1cbf337d38d1cc0d6ae5a68d91050b173..6c2c2346ba3dba836cafb28b699b3b9898dbeaa2 100644
+index 2b9402f1cbf337d38d1cc0d6ae5a68d91050b173..012ac45c68a090b8ca18b7181490313ead8d99f3 100644
 --- a/src/test/java/net/minestom/server/entity/PassengerIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/PassengerIntegrationTest.java
-@@ -7,11 +7,12 @@ import org.junit.jupiter.api.Test;
- 
+@@ -8,10 +8,10 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.*;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class PassengerIntegrationTest {
 +class PassengerIntegrationTest {
@@ -3608,7 +3523,7 @@ index 2b9402f1cbf337d38d1cc0d6ae5a68d91050b173..6c2c2346ba3dba836cafb28b699b3b98
          var instance = env.createFlatInstance();
          var vehicle = new Entity(EntityType.ZOMBIE);
          var passenger = new Entity(EntityType.ZOMBIE);
-@@ -28,7 +29,7 @@ public class PassengerIntegrationTest {
+@@ -28,7 +28,7 @@ public class PassengerIntegrationTest {
      }
  
      @Test
@@ -3618,14 +3533,12 @@ index 2b9402f1cbf337d38d1cc0d6ae5a68d91050b173..6c2c2346ba3dba836cafb28b699b3b98
          var vehicle = new Entity(EntityType.ZOMBIE);
          var passenger = new Entity(EntityType.ZOMBIE);
 diff --git a/src/test/java/net/minestom/server/entity/PlayerHeldIntegrationTest.java b/src/test/java/net/minestom/server/entity/PlayerHeldIntegrationTest.java
-index efd06b005614c0bc67ed985fa56988139e714f93..dd2e87aa63831d46913518a1b5695ab8175396ee 100644
+index efd06b005614c0bc67ed985fa56988139e714f93..feccdb951f27d6e46fe8aa4f18ded7a0d3949d21 100644
 --- a/src/test/java/net/minestom/server/entity/PlayerHeldIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/PlayerHeldIntegrationTest.java
-@@ -11,11 +11,12 @@ import org.junit.jupiter.api.Test;
- 
+@@ -12,10 +12,10 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class PlayerHeldIntegrationTest {
 +class PlayerHeldIntegrationTest {
@@ -3636,7 +3549,7 @@ index efd06b005614c0bc67ed985fa56988139e714f93..dd2e87aa63831d46913518a1b5695ab8
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 40, 0)).join();
-@@ -32,7 +33,7 @@ public class PlayerHeldIntegrationTest {
+@@ -32,7 +32,7 @@ public class PlayerHeldIntegrationTest {
      }
  
      @Test
@@ -3646,15 +3559,14 @@ index efd06b005614c0bc67ed985fa56988139e714f93..dd2e87aa63831d46913518a1b5695ab8
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 40, 0)).join();
 diff --git a/src/test/java/net/minestom/server/entity/PlayerSkinTest.java b/src/test/java/net/minestom/server/entity/PlayerSkinTest.java
-index 771bdca2a59bc50d53578fe7a5abe4169f2dae07..119351b2d61a4c8f3201d8e9a377afeb3b95ee45 100644
+index 771bdca2a59bc50d53578fe7a5abe4169f2dae07..4f8e547d6a00099f8e6b5fe03dd6aee6b79a8ce3 100644
 --- a/src/test/java/net/minestom/server/entity/PlayerSkinTest.java
 +++ b/src/test/java/net/minestom/server/entity/PlayerSkinTest.java
-@@ -5,16 +5,17 @@ import org.junit.jupiter.api.Test;
+@@ -5,16 +5,16 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.assertNotNull;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
 -public class PlayerSkinTest {
-+//Microtus - update java keyword usage
 +class PlayerSkinTest {
  
      @Test
@@ -3671,14 +3583,12 @@ index 771bdca2a59bc50d53578fe7a5abe4169f2dae07..119351b2d61a4c8f3201d8e9a377afeb
          assertNull(skin);
      }
 diff --git a/src/test/java/net/minestom/server/entity/ai/ClosestEntityTargetTest.java b/src/test/java/net/minestom/server/entity/ai/ClosestEntityTargetTest.java
-index 5c34c621e1bf3d9a9ec07b927ca8473f05278846..20472444bcc6381f2ab24a21d85b5356c2db694d 100644
+index 5c34c621e1bf3d9a9ec07b927ca8473f05278846..25d78311447f9236c78ae319899c295f9b7e2225 100644
 --- a/src/test/java/net/minestom/server/entity/ai/ClosestEntityTargetTest.java
 +++ b/src/test/java/net/minestom/server/entity/ai/ClosestEntityTargetTest.java
-@@ -11,11 +11,12 @@ import org.junit.jupiter.api.Test;
- import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -12,10 +12,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class ClosestEntityTargetTest {
 +class ClosestEntityTargetTest {
@@ -3690,14 +3600,12 @@ index 5c34c621e1bf3d9a9ec07b927ca8473f05278846..20472444bcc6381f2ab24a21d85b5356
  
          var self = new EntityCreature(EntityType.ZOMBIE);
 diff --git a/src/test/java/net/minestom/server/entity/player/PlayerBlockPlacementIntegrationTest.java b/src/test/java/net/minestom/server/entity/player/PlayerBlockPlacementIntegrationTest.java
-index c2bf3603d30cfc95e5d4aa5a9669cb08dca218c6..8163cc3553bfced069142fae010fba20abf58936 100644
+index c2bf3603d30cfc95e5d4aa5a9669cb08dca218c6..0566d0edc971797d11df73af3772b504072545da 100644
 --- a/src/test/java/net/minestom/server/entity/player/PlayerBlockPlacementIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/player/PlayerBlockPlacementIntegrationTest.java
-@@ -18,12 +18,13 @@ import java.util.stream.Stream;
- 
+@@ -19,11 +19,11 @@ import java.util.stream.Stream;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class PlayerBlockPlacementIntegrationTest {
 +class PlayerBlockPlacementIntegrationTest {
@@ -3710,14 +3618,12 @@ index c2bf3603d30cfc95e5d4aa5a9669cb08dca218c6..8163cc3553bfced069142fae010fba20
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
 diff --git a/src/test/java/net/minestom/server/entity/player/PlayerIntegrationTest.java b/src/test/java/net/minestom/server/entity/player/PlayerIntegrationTest.java
-index b36bec3de3026ca3e1b8f7217c05407da073dfe7..95e615078525cfa66e7bbde9f9a9397ea80b913c 100644
+index b36bec3de3026ca3e1b8f7217c05407da073dfe7..8d7be19dd4d72044a99a01af4190fd2c1b5d7937 100644
 --- a/src/test/java/net/minestom/server/entity/player/PlayerIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/player/PlayerIntegrationTest.java
-@@ -22,14 +22,15 @@ import java.util.List;
- 
+@@ -23,13 +23,13 @@ import java.util.List;
  import static org.junit.jupiter.api.Assertions.*;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class PlayerIntegrationTest {
 +class PlayerIntegrationTest {
@@ -3731,7 +3637,7 @@ index b36bec3de3026ca3e1b8f7217c05407da073dfe7..95e615078525cfa66e7bbde9f9a9397e
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -72,7 +73,7 @@ public class PlayerIntegrationTest {
+@@ -72,7 +72,7 @@ public class PlayerIntegrationTest {
      }
  
      @Test
@@ -3740,7 +3646,7 @@ index b36bec3de3026ca3e1b8f7217c05407da073dfe7..95e615078525cfa66e7bbde9f9a9397e
          ClientSettingsPacket packet = new ClientSettingsPacket("en_us", (byte) 16, ChatMessageType.FULL,
                  true, (byte) 127, Player.MainHand.LEFT, true, true);
  
-@@ -110,7 +111,7 @@ public class PlayerIntegrationTest {
+@@ -110,7 +110,7 @@ public class PlayerIntegrationTest {
      }
  
      @Test
@@ -3749,7 +3655,7 @@ index b36bec3de3026ca3e1b8f7217c05407da073dfe7..95e615078525cfa66e7bbde9f9a9397e
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
  
-@@ -141,7 +142,7 @@ public class PlayerIntegrationTest {
+@@ -141,7 +141,7 @@ public class PlayerIntegrationTest {
       * when changing dimensions
       */
      @Test
@@ -3758,7 +3664,7 @@ index b36bec3de3026ca3e1b8f7217c05407da073dfe7..95e615078525cfa66e7bbde9f9a9397e
          final int TEST_PERMISSION_LEVEL = 2;
          final var testDimension = DimensionType.builder(NamespaceID.from("minestom:test_dimension")).build();
          env.process().dimension().addDimension(testDimension);
-@@ -177,7 +178,7 @@ public class PlayerIntegrationTest {
+@@ -177,7 +177,7 @@ public class PlayerIntegrationTest {
      }
  
      @Test
@@ -3767,7 +3673,7 @@ index b36bec3de3026ca3e1b8f7217c05407da073dfe7..95e615078525cfa66e7bbde9f9a9397e
          String dimensionNamespace = "minestom:test_dimension";
          final var testDimension = DimensionType.builder(NamespaceID.from(dimensionNamespace)).build();
          env.process().dimension().addDimension(testDimension);
-@@ -195,7 +196,7 @@ public class PlayerIntegrationTest {
+@@ -195,7 +195,7 @@ public class PlayerIntegrationTest {
      }
      // Microtus start - Fix team spam
      @Test
@@ -3776,7 +3682,7 @@ index b36bec3de3026ca3e1b8f7217c05407da073dfe7..95e615078525cfa66e7bbde9f9a9397e
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var tracker = connection.trackIncoming(PlayerInfoUpdatePacket.class);
-@@ -228,7 +229,7 @@ public class PlayerIntegrationTest {
+@@ -228,7 +228,7 @@ public class PlayerIntegrationTest {
      }
  
      @Test
@@ -3786,14 +3692,12 @@ index b36bec3de3026ca3e1b8f7217c05407da073dfe7..95e615078525cfa66e7bbde9f9a9397e
  
          var instance = env.createFlatInstance();
 diff --git a/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java b/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
-index 30e9977964d9d0e9732f3b6216cf1c839f7bc63c..ea7683856f2008e979e7f06107a81e2d7eb12782 100644
+index 30e9977964d9d0e9732f3b6216cf1c839f7bc63c..1bd8b09c6c8f5c8ae02d398b6d44f88b6f491418 100644
 --- a/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
-@@ -25,11 +25,12 @@ import java.util.concurrent.CompletableFuture;
- 
+@@ -26,10 +26,10 @@ import java.util.concurrent.CompletableFuture;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class PlayerMovementIntegrationTest {
 +class PlayerMovementIntegrationTest {
@@ -3804,7 +3708,7 @@ index 30e9977964d9d0e9732f3b6216cf1c839f7bc63c..ea7683856f2008e979e7f06107a81e2d
          var instance = env.createFlatInstance();
          var p1 = env.createPlayer(instance, new Pos(0, 40, 0));
          // No confirmation
-@@ -45,7 +46,7 @@ public class PlayerMovementIntegrationTest {
+@@ -45,7 +45,7 @@ public class PlayerMovementIntegrationTest {
  
      // FIXME
      //@Test
@@ -3813,7 +3717,7 @@ index 30e9977964d9d0e9732f3b6216cf1c839f7bc63c..ea7683856f2008e979e7f06107a81e2d
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var p1 = env.createPlayer(instance, new Pos(0, 40, 0));
-@@ -62,7 +63,7 @@ public class PlayerMovementIntegrationTest {
+@@ -62,7 +62,7 @@ public class PlayerMovementIntegrationTest {
      }
  
      @Test
@@ -3823,15 +3727,14 @@ index 30e9977964d9d0e9732f3b6216cf1c839f7bc63c..ea7683856f2008e979e7f06107a81e2d
          final int viewDiameter = MinecraftServer.getChunkViewDistance() * 2 + 1;
          // Preload all possible chunks to avoid issues due to async loading
 diff --git a/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkIntegrationTest.java b/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkIntegrationTest.java
-index 1dac5752d654cf22dc83d02c396dcb2c9be904e7..9015a9c37934faeeae0f42f13b910fc4773f83f7 100644
+index 1dac5752d654cf22dc83d02c396dcb2c9be904e7..760f92b1f25da06ef91c08cb91b31b387d8e9edf 100644
 --- a/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkIntegrationTest.java
-@@ -17,12 +17,12 @@ import java.util.Set;
+@@ -17,12 +17,11 @@ import java.util.Set;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -
-+//Microtus - update java keyword usage
  @EnvTest
 -public class PlayerRespawnChunkIntegrationTest {
 +class PlayerRespawnChunkIntegrationTest {
@@ -3842,7 +3745,7 @@ index 1dac5752d654cf22dc83d02c396dcb2c9be904e7..9015a9c37934faeeae0f42f13b910fc4
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          Player player = connection.connect(instance, new Pos(0, 40, 0)).join();
-@@ -36,7 +36,7 @@ public class PlayerRespawnChunkIntegrationTest {
+@@ -36,7 +35,7 @@ public class PlayerRespawnChunkIntegrationTest {
      }
  
      @Test
@@ -3851,7 +3754,7 @@ index 1dac5752d654cf22dc83d02c396dcb2c9be904e7..9015a9c37934faeeae0f42f13b910fc4
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          Player player = connection.connect(instance, new Pos(0, 40, 0)).join();
-@@ -50,7 +50,7 @@ public class PlayerRespawnChunkIntegrationTest {
+@@ -50,7 +49,7 @@ public class PlayerRespawnChunkIntegrationTest {
      }
  
      @Test
@@ -3861,15 +3764,14 @@ index 1dac5752d654cf22dc83d02c396dcb2c9be904e7..9015a9c37934faeeae0f42f13b910fc4
          var connection = env.createConnection();
          Player player = connection.connect(instance, new Pos(0, 40, 0)).join();
 diff --git a/src/test/java/net/minestom/server/event/EventNodeGraphTest.java b/src/test/java/net/minestom/server/event/EventNodeGraphTest.java
-index c9f650b9eca9c9ad35ccc15d61e9e4e67cd48fb4..90c5b5e8554116354d4d388d1c7c3d0d2451ec75 100644
+index c9f650b9eca9c9ad35ccc15d61e9e4e67cd48fb4..37d8007440767e211697478d2b0cba92cf038772 100644
 --- a/src/test/java/net/minestom/server/event/EventNodeGraphTest.java
 +++ b/src/test/java/net/minestom/server/event/EventNodeGraphTest.java
-@@ -6,16 +6,17 @@ import java.util.List;
+@@ -6,16 +6,16 @@ import java.util.List;
  
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
 -public class EventNodeGraphTest {
-+//Microtus - update java keyword usage
 +class EventNodeGraphTest {
  
      @Test
@@ -3885,7 +3787,7 @@ index c9f650b9eca9c9ad35ccc15d61e9e4e67cd48fb4..90c5b5e8554116354d4d388d1c7c3d0d
          EventNode<Event> node = EventNode.all("main");
          node.addChild(EventNode.all("child"));
          verifyGraph(node, new EventNodeImpl.Graph("main", "Event", 0,
-@@ -24,7 +25,7 @@ public class EventNodeGraphTest {
+@@ -24,7 +24,7 @@ public class EventNodeGraphTest {
      }
  
      @Test
@@ -3895,15 +3797,14 @@ index c9f650b9eca9c9ad35ccc15d61e9e4e67cd48fb4..90c5b5e8554116354d4d388d1c7c3d0d
              EventNode<Event> node = EventNode.all("main");
              node.addChild(EventNode.all("child1").setPriority(5));
 diff --git a/src/test/java/net/minestom/server/event/EventNodeMapTest.java b/src/test/java/net/minestom/server/event/EventNodeMapTest.java
-index e803aa3e5319ba2abadd916b8e96781fc9734ed8..fa625e3d6f5426f5c29338ee00e6cc5da1ceaabe 100644
+index e803aa3e5319ba2abadd916b8e96781fc9734ed8..28c019a1c67ed99a7d1e216daf7fbe0f05ca3989 100644
 --- a/src/test/java/net/minestom/server/event/EventNodeMapTest.java
 +++ b/src/test/java/net/minestom/server/event/EventNodeMapTest.java
-@@ -13,10 +13,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
+@@ -13,10 +13,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
  import static net.minestom.testing.TestUtils.waitUntilCleared;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class EventNodeMapTest {
-+//Microtus - update java keyword usage
 +class EventNodeMapTest {
  
      @Test
@@ -3912,7 +3813,7 @@ index e803aa3e5319ba2abadd916b8e96781fc9734ed8..fa625e3d6f5426f5c29338ee00e6cc5d
          var item = ItemStack.of(Material.DIAMOND);
          var node = EventNode.all("main");
          var itemNode1 = node.map(item, EventFilter.ITEM);
-@@ -31,7 +32,7 @@ public class EventNodeMapTest {
+@@ -31,7 +31,7 @@ public class EventNodeMapTest {
      }
  
      @Test
@@ -3921,7 +3822,7 @@ index e803aa3e5319ba2abadd916b8e96781fc9734ed8..fa625e3d6f5426f5c29338ee00e6cc5d
          var item = ItemStack.of(Material.DIAMOND);
          var node = (EventNodeImpl<Event>) EventNode.all("main");
          var itemNode = node.map(item, EventFilter.ITEM);
-@@ -42,7 +43,7 @@ public class EventNodeMapTest {
+@@ -42,7 +42,7 @@ public class EventNodeMapTest {
      }
  
      @Test
@@ -3930,7 +3831,7 @@ index e803aa3e5319ba2abadd916b8e96781fc9734ed8..fa625e3d6f5426f5c29338ee00e6cc5d
          var item = ItemStack.of(Material.DIAMOND);
          var node = (EventNodeImpl<Event>) EventNode.all("main");
          var itemNode = node.map(item, EventFilter.ITEM);
-@@ -51,7 +52,7 @@ public class EventNodeMapTest {
+@@ -51,7 +51,7 @@ public class EventNodeMapTest {
      }
  
      @Test
@@ -3939,7 +3840,7 @@ index e803aa3e5319ba2abadd916b8e96781fc9734ed8..fa625e3d6f5426f5c29338ee00e6cc5d
          var item = ItemStack.of(Material.DIAMOND);
          var node = EventNode.all("main");
  
-@@ -76,7 +77,7 @@ public class EventNodeMapTest {
+@@ -76,7 +76,7 @@ public class EventNodeMapTest {
      }
  
      @Test
@@ -3948,7 +3849,7 @@ index e803aa3e5319ba2abadd916b8e96781fc9734ed8..fa625e3d6f5426f5c29338ee00e6cc5d
          var process = MinecraftServer.updateProcess();
          var node = process.eventHandler();
          var entity = new Entity(EntityType.ZOMBIE);
-@@ -102,7 +103,7 @@ public class EventNodeMapTest {
+@@ -102,7 +102,7 @@ public class EventNodeMapTest {
      }
  
      @Test
@@ -3958,15 +3859,14 @@ index e803aa3e5319ba2abadd916b8e96781fc9734ed8..fa625e3d6f5426f5c29338ee00e6cc5d
          var item = ItemStack.of(Material.DIAMOND);
          var node = EventNode.all("main");
 diff --git a/src/test/java/net/minestom/server/event/EventNodeQueryTest.java b/src/test/java/net/minestom/server/event/EventNodeQueryTest.java
-index 9e035b0f764ee8e90cf8769edda1e87fc69af81d..ddb1d863679bd1de990e6135c2339f5d9656d6d1 100644
+index 9e035b0f764ee8e90cf8769edda1e87fc69af81d..fd481a2b8ff53cb174c788ac95dc071fa87ae6af 100644
 --- a/src/test/java/net/minestom/server/event/EventNodeQueryTest.java
 +++ b/src/test/java/net/minestom/server/event/EventNodeQueryTest.java
-@@ -9,10 +9,11 @@ import java.util.List;
+@@ -9,10 +9,10 @@ import java.util.List;
  import static net.minestom.testing.TestUtils.assertEqualsIgnoreOrder;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
 -public class EventNodeQueryTest {
-+//Microtus - update java keyword usage
 +class EventNodeQueryTest {
  
      @Test
@@ -3975,7 +3875,7 @@ index 9e035b0f764ee8e90cf8769edda1e87fc69af81d..ddb1d863679bd1de990e6135c2339f5d
          var node = EventNode.all("main");
          assertEquals(List.of(), node.findChildren("test"));
  
-@@ -33,7 +34,7 @@ public class EventNodeQueryTest {
+@@ -33,7 +33,7 @@ public class EventNodeQueryTest {
      }
  
      @Test
@@ -3984,7 +3884,7 @@ index 9e035b0f764ee8e90cf8769edda1e87fc69af81d..ddb1d863679bd1de990e6135c2339f5d
          var node = EventNode.all("main");
          assertEquals(List.of(), node.findChildren("test", Event.class));
  
-@@ -58,7 +59,7 @@ public class EventNodeQueryTest {
+@@ -58,7 +58,7 @@ public class EventNodeQueryTest {
      }
  
      @Test
@@ -3994,20 +3894,19 @@ index 9e035b0f764ee8e90cf8769edda1e87fc69af81d..ddb1d863679bd1de990e6135c2339f5d
  
          var child1 = EventNode.all("test");
 diff --git a/src/test/java/net/minestom/server/event/EventNodeTest.java b/src/test/java/net/minestom/server/event/EventNodeTest.java
-index 114033a08a7d9acebfd67ce535afe9e39a08262a..00f9328ff288af41c0841805b760b3856eef2239 100644
+index 114033a08a7d9acebfd67ce535afe9e39a08262a..b1e46999c543fce8efabf4f38e3e655c5a153ef5 100644
 --- a/src/test/java/net/minestom/server/event/EventNodeTest.java
 +++ b/src/test/java/net/minestom/server/event/EventNodeTest.java
-@@ -17,7 +17,8 @@ import java.util.concurrent.atomic.AtomicInteger;
+@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  import static net.minestom.testing.TestUtils.waitUntilCleared;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class EventNodeTest {
-+//Microtus - update java keyword usage
 +class EventNodeTest {
  
      static class EventTest implements Event {
      }
-@@ -57,7 +58,7 @@ public class EventNodeTest {
+@@ -57,7 +57,7 @@ public class EventNodeTest {
      }
  
      @Test
@@ -4016,7 +3915,7 @@ index 114033a08a7d9acebfd67ce535afe9e39a08262a..00f9328ff288af41c0841805b760b385
          var node = EventNode.all("main");
          AtomicBoolean result = new AtomicBoolean(false);
          var listener = EventListener.of(EventTest.class, eventTest -> result.set(true));
-@@ -74,7 +75,7 @@ public class EventNodeTest {
+@@ -74,7 +74,7 @@ public class EventNodeTest {
      }
  
      @Test
@@ -4025,7 +3924,7 @@ index 114033a08a7d9acebfd67ce535afe9e39a08262a..00f9328ff288af41c0841805b760b385
          var node = EventNode.all("main");
          var handle = node.getHandle(EventTest.class);
          assertSame(handle, node.getHandle(EventTest.class));
-@@ -84,7 +85,7 @@ public class EventNodeTest {
+@@ -84,7 +84,7 @@ public class EventNodeTest {
      }
  
      @Test
@@ -4034,7 +3933,7 @@ index 114033a08a7d9acebfd67ce535afe9e39a08262a..00f9328ff288af41c0841805b760b385
          var node = EventNode.all("main");
          AtomicBoolean result = new AtomicBoolean(false);
          var listener = EventListener.builder(CancellableTest.class)
-@@ -103,7 +104,7 @@ public class EventNodeTest {
+@@ -103,7 +103,7 @@ public class EventNodeTest {
      }
  
      @Test
@@ -4043,7 +3942,7 @@ index 114033a08a7d9acebfd67ce535afe9e39a08262a..00f9328ff288af41c0841805b760b385
          var node = EventNode.all("main");
          AtomicBoolean result1 = new AtomicBoolean(false);
          AtomicBoolean result2 = new AtomicBoolean(false);
-@@ -144,7 +145,7 @@ public class EventNodeTest {
+@@ -144,7 +144,7 @@ public class EventNodeTest {
      //}
  
      @Test
@@ -4052,7 +3951,7 @@ index 114033a08a7d9acebfd67ce535afe9e39a08262a..00f9328ff288af41c0841805b760b385
          var node = EventNode.all("main");
          AtomicInteger result = new AtomicInteger(0);
          var child1 = EventNode.all("child1").setPriority(1)
-@@ -159,14 +160,14 @@ public class EventNodeTest {
+@@ -159,14 +159,14 @@ public class EventNodeTest {
                  });
          node.addChild(child1);
          node.addChild(child2);
@@ -4069,7 +3968,7 @@ index 114033a08a7d9acebfd67ce535afe9e39a08262a..00f9328ff288af41c0841805b760b385
          node.call(new EventTest());
          assertEquals(1, result.get(), "child2 should has been removed");
  
-@@ -178,7 +179,7 @@ public class EventNodeTest {
+@@ -178,7 +178,7 @@ public class EventNodeTest {
      }
  
      @Test
@@ -4078,7 +3977,7 @@ index 114033a08a7d9acebfd67ce535afe9e39a08262a..00f9328ff288af41c0841805b760b385
          AtomicBoolean result = new AtomicBoolean(false);
          AtomicBoolean childResult = new AtomicBoolean(false);
  
-@@ -202,7 +203,7 @@ public class EventNodeTest {
+@@ -202,7 +202,7 @@ public class EventNodeTest {
      }
  
      @Test
@@ -4087,7 +3986,7 @@ index 114033a08a7d9acebfd67ce535afe9e39a08262a..00f9328ff288af41c0841805b760b385
          var node = EventNode.all("main");
  
          AtomicBoolean result = new AtomicBoolean(false);
-@@ -224,7 +225,7 @@ public class EventNodeTest {
+@@ -224,7 +224,7 @@ public class EventNodeTest {
      }
  
      @Test
@@ -4096,7 +3995,7 @@ index 114033a08a7d9acebfd67ce535afe9e39a08262a..00f9328ff288af41c0841805b760b385
          var node = EventNode.all("main");
          var ref = new WeakReference<>(node);
  
-@@ -234,7 +235,7 @@ public class EventNodeTest {
+@@ -234,7 +234,7 @@ public class EventNodeTest {
      }
  
      @Test
@@ -4105,7 +4004,7 @@ index 114033a08a7d9acebfd67ce535afe9e39a08262a..00f9328ff288af41c0841805b760b385
          var node = EventNode.all("main");
          var ref = new WeakReference<>(node);
          node.addListener(EventTest.class, event -> {
-@@ -261,7 +262,7 @@ public class EventNodeTest {
+@@ -261,7 +261,7 @@ public class EventNodeTest {
  //    }
  
      @Test
@@ -4115,14 +4014,12 @@ index 114033a08a7d9acebfd67ce535afe9e39a08262a..00f9328ff288af41c0841805b760b385
  
          var handler = ItemStack.AIR;
 diff --git a/src/test/java/net/minestom/server/instance/AnvilLoaderIntegrationTest.java b/src/test/java/net/minestom/server/instance/AnvilLoaderIntegrationTest.java
-index 1e8f352c6dea803bbe9cea8998fb4d03535f6177..6425f798ea972201d94a05ae92dfce930003dcf2 100644
+index 1e8f352c6dea803bbe9cea8998fb4d03535f6177..7fcb6ffa93f15baf5dc1d77f21a01068461f8115 100644
 --- a/src/test/java/net/minestom/server/instance/AnvilLoaderIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/instance/AnvilLoaderIntegrationTest.java
-@@ -18,15 +18,16 @@ import java.util.function.Consumer;
- 
+@@ -19,14 +19,14 @@ import java.util.function.Consumer;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class AnvilLoaderIntegrationTest {
 +class AnvilLoaderIntegrationTest {
@@ -4137,7 +4034,7 @@ index 1e8f352c6dea803bbe9cea8998fb4d03535f6177..6425f798ea972201d94a05ae92dfce93
          // https://stackoverflow.com/a/60621544
          Files.walkFileTree(testRoot, new SimpleFileVisitor<>() {
  
-@@ -48,7 +49,7 @@ public class AnvilLoaderIntegrationTest {
+@@ -48,7 +48,7 @@ public class AnvilLoaderIntegrationTest {
  
  
      @Test
@@ -4146,7 +4043,7 @@ index 1e8f352c6dea803bbe9cea8998fb4d03535f6177..6425f798ea972201d94a05ae92dfce93
          // load a world that contains only a basic house and make sure it is loaded properly
  
          AnvilLoader chunkLoader = new AnvilLoader(worldFolder) {
-@@ -145,7 +146,7 @@ public class AnvilLoaderIntegrationTest {
+@@ -145,7 +145,7 @@ public class AnvilLoaderIntegrationTest {
      }
  
      @Test
@@ -4155,7 +4052,7 @@ index 1e8f352c6dea803bbe9cea8998fb4d03535f6177..6425f798ea972201d94a05ae92dfce93
          Instance instance = env.createFlatInstance(new AnvilLoader(worldFolder) {
              // Force loads inside current thread
              @Override
-@@ -183,7 +184,7 @@ public class AnvilLoaderIntegrationTest {
+@@ -183,7 +183,7 @@ public class AnvilLoaderIntegrationTest {
      }
  
      @AfterAll
@@ -4165,15 +4062,14 @@ index 1e8f352c6dea803bbe9cea8998fb4d03535f6177..6425f798ea972201d94a05ae92dfce93
  
              @Override
 diff --git a/src/test/java/net/minestom/server/instance/BlockClientNbtTest.java b/src/test/java/net/minestom/server/instance/BlockClientNbtTest.java
-index 837eda9fe513972169ed8d0e528cbcdc387e5401..3ffd0f28b520199e8130640d14f8a9cf4dcb98e5 100644
+index 837eda9fe513972169ed8d0e528cbcdc387e5401..96522d656031c43dce30959e90a20f6ee82905e3 100644
 --- a/src/test/java/net/minestom/server/instance/BlockClientNbtTest.java
 +++ b/src/test/java/net/minestom/server/instance/BlockClientNbtTest.java
-@@ -17,10 +17,11 @@ import java.util.Map;
+@@ -17,10 +17,10 @@ import java.util.Map;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
 -public class BlockClientNbtTest {
-+//Microtus - update java keyword usage
 +class BlockClientNbtTest {
  
      @Test
@@ -4182,7 +4078,7 @@ index 837eda9fe513972169ed8d0e528cbcdc387e5401..3ffd0f28b520199e8130640d14f8a9cf
          assertNull(BlockUtils.extractClientNbt(Block.STONE));
          assertNull(BlockUtils.extractClientNbt(Block.GRASS));
          assertEquals(NBTCompound.EMPTY, BlockUtils.extractClientNbt(Block.CHEST));
-@@ -30,7 +31,7 @@ public class BlockClientNbtTest {
+@@ -30,7 +30,7 @@ public class BlockClientNbtTest {
      }
  
      @Test
@@ -4192,15 +4088,14 @@ index 837eda9fe513972169ed8d0e528cbcdc387e5401..3ffd0f28b520199e8130640d14f8a9cf
              @Override
              public @NotNull Collection<Tag<?>> getBlockEntityTags() {
 diff --git a/src/test/java/net/minestom/server/instance/BlockPropertiesTest.java b/src/test/java/net/minestom/server/instance/BlockPropertiesTest.java
-index 3fbe44370df7d98fa432de3a9d6eb95e2cc3fbbc..949c9a16a82e44bc1e402ad80e3803ebb2394d1a 100644
+index 3fbe44370df7d98fa432de3a9d6eb95e2cc3fbbc..ca0bf1cf03eb11e1a9efe9e29a4464ca59a33c95 100644
 --- a/src/test/java/net/minestom/server/instance/BlockPropertiesTest.java
 +++ b/src/test/java/net/minestom/server/instance/BlockPropertiesTest.java
-@@ -7,16 +7,17 @@ import java.util.Map;
+@@ -7,16 +7,16 @@ import java.util.Map;
  import static net.minestom.server.utils.block.BlockUtils.parseProperties;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
 -public class BlockPropertiesTest {
-+//Microtus - update java keyword usage
 +class BlockPropertiesTest {
  
      @Test
@@ -4216,7 +4111,7 @@ index 3fbe44370df7d98fa432de3a9d6eb95e2cc3fbbc..949c9a16a82e44bc1e402ad80e3803eb
          assertEquals(Map.of(), parseProperties("random test without brackets"));
          assertEquals(Map.of(), parseProperties("["));
          assertEquals(Map.of(), parseProperties("[end"));
-@@ -27,28 +28,28 @@ public class BlockPropertiesTest {
+@@ -27,28 +27,28 @@ public class BlockPropertiesTest {
      }
  
      @Test
@@ -4250,7 +4145,7 @@ index 3fbe44370df7d98fa432de3a9d6eb95e2cc3fbbc..949c9a16a82e44bc1e402ad80e3803eb
          // Verify all length variations
          for (int i = 0; i < 13; i++) {
              StringBuilder properties = new StringBuilder("[");
-@@ -67,7 +68,7 @@ public class BlockPropertiesTest {
+@@ -67,7 +67,7 @@ public class BlockPropertiesTest {
      }
  
      @Test
@@ -4260,15 +4155,14 @@ index 3fbe44370df7d98fa432de3a9d6eb95e2cc3fbbc..949c9a16a82e44bc1e402ad80e3803eb
          StringBuilder properties = new StringBuilder("[");
          for (int j = 0; j < size; j++) {
 diff --git a/src/test/java/net/minestom/server/instance/BlockTest.java b/src/test/java/net/minestom/server/instance/BlockTest.java
-index 5fa43d5236e483b25b94dc757b98a3a483409c70..6cf65520c5e0763d837b3d1f763717e4183980bc 100644
+index 5fa43d5236e483b25b94dc757b98a3a483409c70..3b8ec507d023e4b10085695caf2fcad708e4418c 100644
 --- a/src/test/java/net/minestom/server/instance/BlockTest.java
 +++ b/src/test/java/net/minestom/server/instance/BlockTest.java
-@@ -13,10 +13,11 @@ import java.util.Objects;
+@@ -13,10 +13,10 @@ import java.util.Objects;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class BlockTest {
-+//Microtus - update java keyword usage
 +class BlockTest {
  
      @Test
@@ -4277,7 +4171,7 @@ index 5fa43d5236e483b25b94dc757b98a3a483409c70..6cf65520c5e0763d837b3d1f763717e4
          Block block = Block.CHEST;
          assertFalse(block.hasNbt());
          assertNull(block.nbt());
-@@ -35,7 +36,7 @@ public class BlockTest {
+@@ -35,7 +35,7 @@ public class BlockTest {
      }
  
      @Test
@@ -4286,7 +4180,7 @@ index 5fa43d5236e483b25b94dc757b98a3a483409c70..6cf65520c5e0763d837b3d1f763717e4
          Block block = Block.CHEST;
          assertEquals(block.properties(), Objects.requireNonNull(Block.fromBlockId(block.id())).properties());
  
-@@ -53,14 +54,14 @@ public class BlockTest {
+@@ -53,14 +53,14 @@ public class BlockTest {
      }
  
      @Test
@@ -4303,7 +4197,7 @@ index 5fa43d5236e483b25b94dc757b98a3a483409c70..6cf65520c5e0763d837b3d1f763717e4
          var nbt = new NBTCompound(Map.of("key", NBT.Int(5)));
          Block b1 = Block.CHEST;
          Block b2 = Block.CHEST;
-@@ -71,14 +72,14 @@ public class BlockTest {
+@@ -71,14 +71,14 @@ public class BlockTest {
      }
  
      @Test
@@ -4321,14 +4215,12 @@ index 5fa43d5236e483b25b94dc757b98a3a483409c70..6cf65520c5e0763d837b3d1f763717e4
          Point end = Block.LANTERN.registry().collisionShape().relativeEnd();
  
 diff --git a/src/test/java/net/minestom/server/instance/ChunkViewerIntegrationTest.java b/src/test/java/net/minestom/server/instance/ChunkViewerIntegrationTest.java
-index 429a26a0a498574bff8109bbaa8d14c9a4b477d2..52cedd7675ee10607a862edcb9765fd039ea451c 100644
+index 429a26a0a498574bff8109bbaa8d14c9a4b477d2..5e9b92c3c5c749ad75351f97d5d9799ae6937096 100644
 --- a/src/test/java/net/minestom/server/instance/ChunkViewerIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/instance/ChunkViewerIntegrationTest.java
-@@ -12,12 +12,13 @@ import org.junit.jupiter.params.provider.ValueSource;
- 
+@@ -13,11 +13,11 @@ import org.junit.jupiter.params.provider.ValueSource;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class ChunkViewerIntegrationTest {
 +class ChunkViewerIntegrationTest {
@@ -4340,7 +4232,7 @@ index 429a26a0a498574bff8109bbaa8d14c9a4b477d2..52cedd7675ee10607a862edcb9765fd0
          Instance instance = env.createFlatInstance();
          if (sharedInstance) {
              // Chunks get their viewers from the instance
-@@ -36,7 +37,7 @@ public class ChunkViewerIntegrationTest {
+@@ -36,7 +36,7 @@ public class ChunkViewerIntegrationTest {
      }
  
      @Test
@@ -4350,14 +4242,12 @@ index 429a26a0a498574bff8109bbaa8d14c9a4b477d2..52cedd7675ee10607a862edcb9765fd0
          final int count = ChunkUtils.getChunkCount(viewRadius);
          var instance = env.createFlatInstance();
 diff --git a/src/test/java/net/minestom/server/instance/EntityTrackerIntegrationTest.java b/src/test/java/net/minestom/server/instance/EntityTrackerIntegrationTest.java
-index 23c78ab95cf4c1d33bbec7a7ded112bf90e5d643..6cd3483cc32d0876d5210df9c7e7042ed6aabb8e 100644
+index 23c78ab95cf4c1d33bbec7a7ded112bf90e5d643..54cf27ff081129e662126ccdeff4e0333dbb4f46 100644
 --- a/src/test/java/net/minestom/server/instance/EntityTrackerIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/instance/EntityTrackerIntegrationTest.java
-@@ -19,11 +19,12 @@ import java.util.concurrent.atomic.AtomicInteger;
- import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -20,10 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertSame;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class EntityTrackerIntegrationTest {
 +class EntityTrackerIntegrationTest {
@@ -4368,7 +4258,7 @@ index 23c78ab95cf4c1d33bbec7a7ded112bf90e5d643..6cd3483cc32d0876d5210df9c7e7042e
          final Instance instance = env.createFlatInstance();
          final Instance anotherInstance = env.createFlatInstance();
          final Pos spawnPos = new Pos(0, 41, 0);
-@@ -55,7 +56,7 @@ public class EntityTrackerIntegrationTest {
+@@ -55,7 +55,7 @@ public class EntityTrackerIntegrationTest {
      }
  
      @Test
@@ -4377,7 +4267,7 @@ index 23c78ab95cf4c1d33bbec7a7ded112bf90e5d643..6cd3483cc32d0876d5210df9c7e7042e
          final Instance instance = env.createFlatInstance();
          final Instance anotherInstance = env.createFlatInstance();
          final Pos spawnPos = new Pos(0, 41, 0);
-@@ -87,7 +88,7 @@ public class EntityTrackerIntegrationTest {
+@@ -87,7 +87,7 @@ public class EntityTrackerIntegrationTest {
      }
  
      @Test
@@ -4386,7 +4276,7 @@ index 23c78ab95cf4c1d33bbec7a7ded112bf90e5d643..6cd3483cc32d0876d5210df9c7e7042e
          final Instance instance = env.createFlatInstance();
          final Pos spawnPos = new Pos(0, 41, 0);
          var viewable = instance.getEntityTracker().viewable(spawnPos.chunkX(), spawnPos.chunkZ());
-@@ -105,7 +106,7 @@ public class EntityTrackerIntegrationTest {
+@@ -105,7 +105,7 @@ public class EntityTrackerIntegrationTest {
      }
  
      @Test
@@ -4396,15 +4286,14 @@ index 23c78ab95cf4c1d33bbec7a7ded112bf90e5d643..6cd3483cc32d0876d5210df9c7e7042e
          var shared = env.process().instance().createSharedInstance(instance);
          var sharedList = instance.getSharedInstances();
 diff --git a/src/test/java/net/minestom/server/instance/EntityTrackerTest.java b/src/test/java/net/minestom/server/instance/EntityTrackerTest.java
-index 45508ef388c32099b2bdac4a7a75808be3ce6d6c..05114ef736b74b1783c200ff7b2785adb76f6090 100644
+index 45508ef388c32099b2bdac4a7a75808be3ce6d6c..fa1ed75e21bb788e634b9202605c26b2fa594d46 100644
 --- a/src/test/java/net/minestom/server/instance/EntityTrackerTest.java
 +++ b/src/test/java/net/minestom/server/instance/EntityTrackerTest.java
-@@ -11,9 +11,10 @@ import java.util.Set;
+@@ -11,9 +11,9 @@ import java.util.Set;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class EntityTrackerTest {
-+//Microtus - update java keyword usage
 +class EntityTrackerTest {
      @Test
 -    public void register() {
@@ -4412,7 +4301,7 @@ index 45508ef388c32099b2bdac4a7a75808be3ce6d6c..05114ef736b74b1783c200ff7b2785ad
          var ent1 = new Entity(EntityType.ZOMBIE);
          var updater = new EntityTracker.Update<>() {
              @Override
-@@ -40,7 +41,7 @@ public class EntityTrackerTest {
+@@ -40,7 +40,7 @@ public class EntityTrackerTest {
      }
  
      @Test
@@ -4421,7 +4310,7 @@ index 45508ef388c32099b2bdac4a7a75808be3ce6d6c..05114ef736b74b1783c200ff7b2785ad
          var ent1 = new Entity(EntityType.ZOMBIE);
          var updater = new EntityTracker.Update<>() {
              @Override
-@@ -65,7 +66,7 @@ public class EntityTrackerTest {
+@@ -65,7 +65,7 @@ public class EntityTrackerTest {
      }
  
      @Test
@@ -4430,7 +4319,7 @@ index 45508ef388c32099b2bdac4a7a75808be3ce6d6c..05114ef736b74b1783c200ff7b2785ad
          var ent1 = new Entity(EntityType.ZOMBIE);
          var ent2 = new Entity(EntityType.ZOMBIE);
  
-@@ -124,7 +125,7 @@ public class EntityTrackerTest {
+@@ -124,7 +124,7 @@ public class EntityTrackerTest {
      }
  
      @Test
@@ -4439,7 +4328,7 @@ index 45508ef388c32099b2bdac4a7a75808be3ce6d6c..05114ef736b74b1783c200ff7b2785ad
          var ent1 = new Entity(EntityType.ZOMBIE);
          var ent2 = new Entity(EntityType.ZOMBIE);
          var ent3 = new Entity(EntityType.ZOMBIE);
-@@ -177,7 +178,7 @@ public class EntityTrackerTest {
+@@ -177,7 +177,7 @@ public class EntityTrackerTest {
      }
  
      @Test
@@ -4448,7 +4337,7 @@ index 45508ef388c32099b2bdac4a7a75808be3ce6d6c..05114ef736b74b1783c200ff7b2785ad
          var ent1 = new Entity(EntityType.ZOMBIE);
          var ent2 = new Entity(EntityType.ZOMBIE);
          var ent3 = new Entity(EntityType.ZOMBIE);
-@@ -217,7 +218,7 @@ public class EntityTrackerTest {
+@@ -217,7 +217,7 @@ public class EntityTrackerTest {
      }
  
      @Test
@@ -4458,14 +4347,12 @@ index 45508ef388c32099b2bdac4a7a75808be3ce6d6c..05114ef736b74b1783c200ff7b2785ad
          var updater = new EntityTracker.Update<>() {
              @Override
 diff --git a/src/test/java/net/minestom/server/instance/GeneratorForkConsumerIntegrationTest.java b/src/test/java/net/minestom/server/instance/GeneratorForkConsumerIntegrationTest.java
-index d4a50690b4a443799941034fd6124078a9336565..844af7f0967761875d5a216dba93f88479f9d1a2 100644
+index d4a50690b4a443799941034fd6124078a9336565..8cdd2f611a9228e3fa50449689625ba6a52ea23e 100644
 --- a/src/test/java/net/minestom/server/instance/GeneratorForkConsumerIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/instance/GeneratorForkConsumerIntegrationTest.java
-@@ -13,11 +13,12 @@ import java.util.concurrent.atomic.AtomicReference;
- import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -14,10 +14,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class GeneratorForkConsumerIntegrationTest {
 +class GeneratorForkConsumerIntegrationTest {
@@ -4476,7 +4363,7 @@ index d4a50690b4a443799941034fd6124078a9336565..844af7f0967761875d5a216dba93f884
          var manager = env.process().instance();
          var instance = manager.createInstanceContainer();
          AtomicReference<Exception> failed = new AtomicReference<>();
-@@ -34,61 +35,55 @@ public class GeneratorForkConsumerIntegrationTest {
+@@ -34,61 +34,55 @@ public class GeneratorForkConsumerIntegrationTest {
      }
  
      @Test
@@ -4570,7 +4457,7 @@ index d4a50690b4a443799941034fd6124078a9336565..844af7f0967761875d5a216dba93f884
          instance.loadChunk(0, 0).join();
          instance.setGenerator(null);
          instance.loadChunk(0, 1).join();
-@@ -97,24 +92,22 @@ public class GeneratorForkConsumerIntegrationTest {
+@@ -97,24 +91,22 @@ public class GeneratorForkConsumerIntegrationTest {
      }
  
      @Test
@@ -4609,7 +4496,7 @@ index d4a50690b4a443799941034fd6124078a9336565..844af7f0967761875d5a216dba93f884
          instance.loadChunk(0, 0).join();
          instance.setGenerator(null);
          instance.loadChunk(1, 0).join();
-@@ -123,31 +116,29 @@ public class GeneratorForkConsumerIntegrationTest {
+@@ -123,31 +115,29 @@ public class GeneratorForkConsumerIntegrationTest {
      }
  
      @Test
@@ -4657,14 +4544,12 @@ index d4a50690b4a443799941034fd6124078a9336565..844af7f0967761875d5a216dba93f884
          var instance = manager.createInstanceContainer();
          Set<Point> points = ConcurrentHashMap.newKeySet();
 diff --git a/src/test/java/net/minestom/server/instance/GeneratorForkIntegrationTest.java b/src/test/java/net/minestom/server/instance/GeneratorForkIntegrationTest.java
-index ec9b91cebac942d77f6e027b5be9fc04bf2f7eb9..666e13eb96c80c14bc8778041137dd207961b8e7 100644
+index ec9b91cebac942d77f6e027b5be9fc04bf2f7eb9..3580264ac43c7268834e53315d968afe480e707c 100644
 --- a/src/test/java/net/minestom/server/instance/GeneratorForkIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/instance/GeneratorForkIntegrationTest.java
-@@ -10,11 +10,12 @@ import org.junit.jupiter.api.Test;
- 
+@@ -11,10 +11,10 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.*;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class GeneratorForkIntegrationTest {
 +class GeneratorForkIntegrationTest {
@@ -4675,7 +4560,7 @@ index ec9b91cebac942d77f6e027b5be9fc04bf2f7eb9..666e13eb96c80c14bc8778041137dd20
          var manager = env.process().instance();
          var instance = manager.createInstanceContainer();
          var block = Block.STONE;
-@@ -29,7 +30,7 @@ public class GeneratorForkIntegrationTest {
+@@ -29,7 +29,7 @@ public class GeneratorForkIntegrationTest {
      }
  
      @Test
@@ -4684,7 +4569,7 @@ index ec9b91cebac942d77f6e027b5be9fc04bf2f7eb9..666e13eb96c80c14bc8778041137dd20
          var manager = env.process().instance();
          var instance = manager.createInstanceContainer();
          // Set the Generator
-@@ -46,7 +47,7 @@ public class GeneratorForkIntegrationTest {
+@@ -46,7 +46,7 @@ public class GeneratorForkIntegrationTest {
      }
  
      @Test
@@ -4693,7 +4578,7 @@ index ec9b91cebac942d77f6e027b5be9fc04bf2f7eb9..666e13eb96c80c14bc8778041137dd20
          var manager = env.process().instance();
          var instance = manager.createInstanceContainer();
          var block = Block.STONE;
-@@ -65,7 +66,7 @@ public class GeneratorForkIntegrationTest {
+@@ -65,7 +65,7 @@ public class GeneratorForkIntegrationTest {
      }
  
      @Test
@@ -4702,7 +4587,7 @@ index ec9b91cebac942d77f6e027b5be9fc04bf2f7eb9..666e13eb96c80c14bc8778041137dd20
          var manager = env.process().instance();
          var instance = manager.createInstanceContainer();
          instance.setGenerator(unit -> {
-@@ -79,7 +80,7 @@ public class GeneratorForkIntegrationTest {
+@@ -79,7 +79,7 @@ public class GeneratorForkIntegrationTest {
      }
  
      @Test
@@ -4711,7 +4596,7 @@ index ec9b91cebac942d77f6e027b5be9fc04bf2f7eb9..666e13eb96c80c14bc8778041137dd20
          var manager = env.process().instance();
          var instance = manager.createInstanceContainer();
          instance.setGenerator(unit -> {
-@@ -95,7 +96,7 @@ public class GeneratorForkIntegrationTest {
+@@ -95,7 +95,7 @@ public class GeneratorForkIntegrationTest {
      }
  
      @Test
@@ -4721,14 +4606,12 @@ index ec9b91cebac942d77f6e027b5be9fc04bf2f7eb9..666e13eb96c80c14bc8778041137dd20
          var instance = manager.createInstanceContainer();
          instance.setGenerator(unit -> {
 diff --git a/src/test/java/net/minestom/server/instance/GeneratorIntegrationTest.java b/src/test/java/net/minestom/server/instance/GeneratorIntegrationTest.java
-index e2ddf7d46b58c61ed33dd81c275428736dcf23b6..cc7972f9e39f8825ad922eca29dc678e6483f56d 100644
+index e2ddf7d46b58c61ed33dd81c275428736dcf23b6..ce1e765ee0f3f0cc4319b63933d62511999d222e 100644
 --- a/src/test/java/net/minestom/server/instance/GeneratorIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/instance/GeneratorIntegrationTest.java
-@@ -14,12 +14,13 @@ import java.util.concurrent.atomic.AtomicReference;
- import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -15,11 +15,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertSame;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class GeneratorIntegrationTest {
 +class GeneratorIntegrationTest {
@@ -4740,7 +4623,7 @@ index e2ddf7d46b58c61ed33dd81c275428736dcf23b6..cc7972f9e39f8825ad922eca29dc678e
          var manager = env.process().instance();
          var block = data ? Block.STONE.withNbt(NBT.Compound(Map.of("key", NBT.String("value")))) : Block.STONE;
          var instance = manager.createInstanceContainer();
-@@ -32,7 +33,7 @@ public class GeneratorIntegrationTest {
+@@ -32,7 +32,7 @@ public class GeneratorIntegrationTest {
      }
  
      @Test
@@ -4749,7 +4632,7 @@ index e2ddf7d46b58c61ed33dd81c275428736dcf23b6..cc7972f9e39f8825ad922eca29dc678e
          var manager = env.process().instance();
          var instance = manager.createInstanceContainer();
  
-@@ -50,7 +51,7 @@ public class GeneratorIntegrationTest {
+@@ -50,7 +50,7 @@ public class GeneratorIntegrationTest {
      }
  
      @Test
@@ -4758,7 +4641,7 @@ index e2ddf7d46b58c61ed33dd81c275428736dcf23b6..cc7972f9e39f8825ad922eca29dc678e
          var manager = env.process().instance();
          var instance = manager.createInstanceContainer();
          instance.setGenerator(unit -> unit.modifier().fillHeight(-64, -60, Block.STONE));
-@@ -64,7 +65,7 @@ public class GeneratorIntegrationTest {
+@@ -64,7 +64,7 @@ public class GeneratorIntegrationTest {
      }
  
      @Test
@@ -4767,7 +4650,7 @@ index e2ddf7d46b58c61ed33dd81c275428736dcf23b6..cc7972f9e39f8825ad922eca29dc678e
          var manager = env.process().instance();
          var instance = manager.createInstanceContainer();
          instance.setGenerator(unit -> unit.modifier().fillHeight(0, 16, Block.GRASS_BLOCK));
-@@ -75,7 +76,7 @@ public class GeneratorIntegrationTest {
+@@ -75,7 +75,7 @@ public class GeneratorIntegrationTest {
      }
  
      @Test
@@ -4776,7 +4659,7 @@ index e2ddf7d46b58c61ed33dd81c275428736dcf23b6..cc7972f9e39f8825ad922eca29dc678e
          var manager = env.process().instance();
          var instance = manager.createInstanceContainer();
          instance.setGenerator(unit -> unit.modifier().fillHeight(4, 5, Block.GRASS_BLOCK));
-@@ -86,7 +87,7 @@ public class GeneratorIntegrationTest {
+@@ -86,7 +86,7 @@ public class GeneratorIntegrationTest {
      }
  
      @Test
@@ -4786,15 +4669,14 @@ index e2ddf7d46b58c61ed33dd81c275428736dcf23b6..cc7972f9e39f8825ad922eca29dc678e
          var instance = manager.createInstanceContainer();
          instance.setGenerator(unit -> {
 diff --git a/src/test/java/net/minestom/server/instance/GeneratorTest.java b/src/test/java/net/minestom/server/instance/GeneratorTest.java
-index 4a53ede725c99c4448e28d11625476eed34189c5..8040d8bcd2c7a7f2751e10d44ab738db9a574be7 100644
+index 4a53ede725c99c4448e28d11625476eed34189c5..ad3ba534f6a91b90a713518aba46ac260fbcdd72 100644
 --- a/src/test/java/net/minestom/server/instance/GeneratorTest.java
 +++ b/src/test/java/net/minestom/server/instance/GeneratorTest.java
-@@ -25,10 +25,11 @@ import static net.minestom.server.utils.chunk.ChunkUtils.ceilSection;
+@@ -25,10 +25,10 @@ import static net.minestom.server.utils.chunk.ChunkUtils.ceilSection;
  import static net.minestom.server.utils.chunk.ChunkUtils.floorSection;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class GeneratorTest {
-+//Microtus - update java keyword usage
 +class GeneratorTest {
  
      @Test
@@ -4803,7 +4685,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..8040d8bcd2c7a7f2751e10d44ab738db
          assertDoesNotThrow(() -> dummyUnit(Vec.ZERO, new Vec(16)));
          assertDoesNotThrow(() -> dummyUnit(new Vec(16), new Vec(32)));
          assertThrows(IllegalArgumentException.class, () -> dummyUnit(new Vec(15), Vec.ZERO));
-@@ -39,7 +40,7 @@ public class GeneratorTest {
+@@ -39,7 +39,7 @@ public class GeneratorTest {
  
      @ParameterizedTest
      @MethodSource("sectionFloorParam")
@@ -4812,7 +4694,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..8040d8bcd2c7a7f2751e10d44ab738db
          assertEquals(expected, floorSection(input), "floorSection(" + input + ")");
      }
  
-@@ -58,7 +59,7 @@ public class GeneratorTest {
+@@ -58,7 +58,7 @@ public class GeneratorTest {
  
      @ParameterizedTest
      @MethodSource("sectionCeilParam")
@@ -4821,7 +4703,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..8040d8bcd2c7a7f2751e10d44ab738db
          assertEquals(expected, ceilSection(input), "ceilSection(" + input + ")");
      }
  
-@@ -76,7 +77,7 @@ public class GeneratorTest {
+@@ -76,7 +76,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4830,7 +4712,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..8040d8bcd2c7a7f2751e10d44ab738db
          final int minSection = 0;
          final int maxSection = 5;
          final int chunkX = 3;
-@@ -91,7 +92,7 @@ public class GeneratorTest {
+@@ -91,7 +91,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4839,7 +4721,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..8040d8bcd2c7a7f2751e10d44ab738db
          final int minSection = -1;
          final int maxSection = 5;
          final int chunkX = 3;
-@@ -106,7 +107,7 @@ public class GeneratorTest {
+@@ -106,7 +106,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4848,7 +4730,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..8040d8bcd2c7a7f2751e10d44ab738db
          final int sectionX = 3;
          final int sectionY = -5;
          final int sectionZ = -2;
-@@ -117,7 +118,7 @@ public class GeneratorTest {
+@@ -117,7 +117,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4857,7 +4739,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..8040d8bcd2c7a7f2751e10d44ab738db
          final int minSection = -1;
          final int maxSection = 5;
          final int chunkX = 3;
-@@ -137,7 +138,7 @@ public class GeneratorTest {
+@@ -137,7 +137,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4866,7 +4748,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..8040d8bcd2c7a7f2751e10d44ab738db
          final int minSection = 0;
          final int maxSection = 5;
          final int chunkX = 3;
-@@ -158,7 +159,7 @@ public class GeneratorTest {
+@@ -158,7 +158,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4875,7 +4757,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..8040d8bcd2c7a7f2751e10d44ab738db
          final int minSection = 0;
          final int maxSection = 5;
          final int chunkX = 3;
-@@ -186,7 +187,7 @@ public class GeneratorTest {
+@@ -186,7 +186,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4884,7 +4766,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..8040d8bcd2c7a7f2751e10d44ab738db
          final int minSection = -1;
          final int maxSection = 5;
          final int chunkX = 3;
-@@ -213,7 +214,7 @@ public class GeneratorTest {
+@@ -213,7 +213,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4893,7 +4775,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..8040d8bcd2c7a7f2751e10d44ab738db
          final int minSection = -1;
          final int maxSection = 5;
          final int chunkX = 3;
-@@ -242,7 +243,7 @@ public class GeneratorTest {
+@@ -242,7 +242,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4902,7 +4784,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..8040d8bcd2c7a7f2751e10d44ab738db
          final int minSection = -1;
          final int maxSection = 5;
          final int chunkX = 3;
-@@ -263,7 +264,7 @@ public class GeneratorTest {
+@@ -263,7 +263,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4911,7 +4793,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..8040d8bcd2c7a7f2751e10d44ab738db
          final int minSection = -1;
          final int maxSection = 5;
          final int chunkX = 3;
-@@ -284,7 +285,7 @@ public class GeneratorTest {
+@@ -284,7 +284,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4920,7 +4802,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..8040d8bcd2c7a7f2751e10d44ab738db
          final int minSection = -1;
          final int maxSection = 5;
          final int sectionCount = maxSection - minSection;
-@@ -308,7 +309,7 @@ public class GeneratorTest {
+@@ -308,7 +308,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4929,7 +4811,7 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..8040d8bcd2c7a7f2751e10d44ab738db
          final int minSection = -1;
          final int maxSection = 5;
          final int sectionCount = maxSection - minSection;
-@@ -346,7 +347,7 @@ public class GeneratorTest {
+@@ -346,7 +346,7 @@ public class GeneratorTest {
      }
  
      @Test
@@ -4939,14 +4821,12 @@ index 4a53ede725c99c4448e28d11625476eed34189c5..8040d8bcd2c7a7f2751e10d44ab738db
          var chunkUnit = GeneratorImpl.section(section, -1, -1, 0);
          Generator generator = chunk -> chunk.modifier().fill(Block.STONE);
 diff --git a/src/test/java/net/minestom/server/instance/InstanceBlockIntegrationTest.java b/src/test/java/net/minestom/server/instance/InstanceBlockIntegrationTest.java
-index 5b0d774bc9d87540382de3b88f48f7542f8f473c..8f58c740b5e38ba2a44e0d08d4379bd53f7aa99b 100644
+index 5b0d774bc9d87540382de3b88f48f7542f8f473c..fc21a2c8e00e201b266f6e71d90249dc71b1cce6 100644
 --- a/src/test/java/net/minestom/server/instance/InstanceBlockIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/instance/InstanceBlockIntegrationTest.java
-@@ -10,11 +10,12 @@ import org.junit.jupiter.api.Test;
- import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -11,10 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertThrows;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class InstanceBlockIntegrationTest {
 +class InstanceBlockIntegrationTest {
@@ -4957,7 +4837,7 @@ index 5b0d774bc9d87540382de3b88f48f7542f8f473c..8f58c740b5e38ba2a44e0d08d4379bd5
          var instance = env.createFlatInstance();
          assertThrows(NullPointerException.class, () -> instance.getBlock(0, 0, 0),
                  "No exception throw when getting a block in an unloaded chunk");
-@@ -35,7 +36,7 @@ public class InstanceBlockIntegrationTest {
+@@ -35,7 +35,7 @@ public class InstanceBlockIntegrationTest {
      }
  
      @Test
@@ -4966,7 +4846,7 @@ index 5b0d774bc9d87540382de3b88f48f7542f8f473c..8f58c740b5e38ba2a44e0d08d4379bd5
          var instance = env.createFlatInstance();
          instance.loadChunk(0, 0).join();
  
-@@ -51,7 +52,7 @@ public class InstanceBlockIntegrationTest {
+@@ -51,7 +51,7 @@ public class InstanceBlockIntegrationTest {
      }
  
      @Test
@@ -4976,14 +4856,12 @@ index 5b0d774bc9d87540382de3b88f48f7542f8f473c..8f58c740b5e38ba2a44e0d08d4379bd5
          assertThrows(NullPointerException.class, () -> instance.getBlock(0, 0, 0),
                  "No exception throw when getting a block in an unloaded chunk");
 diff --git a/src/test/java/net/minestom/server/instance/InstanceBlockPacketIntegrationTest.java b/src/test/java/net/minestom/server/instance/InstanceBlockPacketIntegrationTest.java
-index 32e9b8703842e4e46428f99dc9fed81071e0743d..461e1897b5b834b8bcc7498665ebae02dae26994 100644
+index 32e9b8703842e4e46428f99dc9fed81071e0743d..8b1d5556d34625eaa516499b1c9a702914f4fbf6 100644
 --- a/src/test/java/net/minestom/server/instance/InstanceBlockPacketIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/instance/InstanceBlockPacketIntegrationTest.java
-@@ -21,11 +21,12 @@ import java.util.List;
- 
+@@ -22,10 +22,10 @@ import java.util.List;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class InstanceBlockPacketIntegrationTest {
 +class InstanceBlockPacketIntegrationTest {
@@ -4994,7 +4872,7 @@ index 32e9b8703842e4e46428f99dc9fed81071e0743d..461e1897b5b834b8bcc7498665ebae02
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          connection.connect(instance, new Pos(0, 40, 0)).join();
-@@ -45,7 +46,7 @@ public class InstanceBlockPacketIntegrationTest {
+@@ -45,7 +45,7 @@ public class InstanceBlockPacketIntegrationTest {
      }
  
      @Test
@@ -5003,27 +4881,13 @@ index 32e9b8703842e4e46428f99dc9fed81071e0743d..461e1897b5b834b8bcc7498665ebae02
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          connection.connect(instance, new Pos(0, 40, 0)).join();
-diff --git a/src/test/java/net/minestom/server/instance/InstanceEqualsTest.java b/src/test/java/net/minestom/server/instance/InstanceEqualsTest.java
-index 305be82a87d514f18510d13364f0574f193a093a..9b89ce0d85c07b9a042ea3b241c23e84a507856d 100644
---- a/src/test/java/net/minestom/server/instance/InstanceEqualsTest.java
-+++ b/src/test/java/net/minestom/server/instance/InstanceEqualsTest.java
-@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
- 
- import static org.junit.jupiter.api.Assertions.*;
- 
-+//Microtus - update java keyword usage
- @EnvTest
- class InstanceEqualsTest {
- 
 diff --git a/src/test/java/net/minestom/server/instance/InstanceEventsIntegrationTest.java b/src/test/java/net/minestom/server/instance/InstanceEventsIntegrationTest.java
-index 8f2404e5a4c06d98955ac7e2218ceb203f8b4fe5..9bf8ad84c264a87c854741f93bac920a660f6621 100644
+index 8f2404e5a4c06d98955ac7e2218ceb203f8b4fe5..7fd9f89ee545d55b58c35135ca502cdccadd9cac 100644
 --- a/src/test/java/net/minestom/server/instance/InstanceEventsIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/instance/InstanceEventsIntegrationTest.java
-@@ -6,10 +6,11 @@ import net.minestom.testing.Env;
- import net.minestom.testing.EnvTest;
+@@ -7,9 +7,9 @@ import net.minestom.testing.EnvTest;
  import org.junit.jupiter.api.Test;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class InstanceEventsIntegrationTest {
 +class InstanceEventsIntegrationTest {
@@ -5034,14 +4898,12 @@ index 8f2404e5a4c06d98955ac7e2218ceb203f8b4fe5..9bf8ad84c264a87c854741f93bac920a
          var unregisterListener = env.listen(InstanceUnregisterEvent.class);
  
 diff --git a/src/test/java/net/minestom/server/instance/InstanceUnregisterIntegrationTest.java b/src/test/java/net/minestom/server/instance/InstanceUnregisterIntegrationTest.java
-index ed7173f89fe078072270f4f41e66c22e1c8766a6..df4f3d3bb1b79ad84e20525f2c1140df838ad3d9 100644
+index ed7173f89fe078072270f4f41e66c22e1c8766a6..c830e87e18e6039b5b644945d8e909d987e4bed6 100644
 --- a/src/test/java/net/minestom/server/instance/InstanceUnregisterIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/instance/InstanceUnregisterIntegrationTest.java
-@@ -14,11 +14,12 @@ import java.util.UUID;
- 
+@@ -15,10 +15,10 @@ import java.util.UUID;
  import static net.minestom.testing.TestUtils.waitUntilCleared;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class InstanceUnregisterIntegrationTest {
 +class InstanceUnregisterIntegrationTest {
@@ -5052,7 +4914,7 @@ index ed7173f89fe078072270f4f41e66c22e1c8766a6..df4f3d3bb1b79ad84e20525f2c1140df
          // Ensure that unregistering a shared instance does not unload the container chunks
          var instanceManager = env.process().instance();
          var instance = instanceManager.createInstanceContainer();
-@@ -40,7 +41,7 @@ public class InstanceUnregisterIntegrationTest {
+@@ -40,7 +40,7 @@ public class InstanceUnregisterIntegrationTest {
      }
  
      @Test
@@ -5061,7 +4923,7 @@ index ed7173f89fe078072270f4f41e66c22e1c8766a6..df4f3d3bb1b79ad84e20525f2c1140df
          var instance = env.createFlatInstance();
          var ref = new WeakReference<>(instance);
          env.process().instance().unregisterInstance(instance);
-@@ -51,7 +52,7 @@ public class InstanceUnregisterIntegrationTest {
+@@ -51,7 +51,7 @@ public class InstanceUnregisterIntegrationTest {
      }
  
      @Test
@@ -5070,7 +4932,7 @@ index ed7173f89fe078072270f4f41e66c22e1c8766a6..df4f3d3bb1b79ad84e20525f2c1140df
          final class Game {
              final Instance instance;
  
-@@ -70,7 +71,7 @@ public class InstanceUnregisterIntegrationTest {
+@@ -70,7 +70,7 @@ public class InstanceUnregisterIntegrationTest {
      }
  
      @Test
@@ -5079,7 +4941,7 @@ index ed7173f89fe078072270f4f41e66c22e1c8766a6..df4f3d3bb1b79ad84e20525f2c1140df
          // Ensure that unregistering an instance does release its chunks
          var instance = env.createFlatInstance();
          var chunk = instance.loadChunk(0, 0).join();
-@@ -85,7 +86,7 @@ public class InstanceUnregisterIntegrationTest {
+@@ -85,7 +85,7 @@ public class InstanceUnregisterIntegrationTest {
      }
  
      @Test
@@ -5089,14 +4951,12 @@ index ed7173f89fe078072270f4f41e66c22e1c8766a6..df4f3d3bb1b79ad84e20525f2c1140df
          env.process().instance().registerInstance(ref.get());
  
 diff --git a/src/test/java/net/minestom/server/instance/WorldBorderIntegrationTest.java b/src/test/java/net/minestom/server/instance/WorldBorderIntegrationTest.java
-index 01c4c935fec5e312f6043106acac4d16520a3b9a..143c48b0abd06131bcef1c3733387d3274416f2c 100644
+index 01c4c935fec5e312f6043106acac4d16520a3b9a..01c68deb717f2ce5f43406c93adda353c40cf397 100644
 --- a/src/test/java/net/minestom/server/instance/WorldBorderIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/instance/WorldBorderIntegrationTest.java
-@@ -6,11 +6,12 @@ import org.junit.jupiter.api.Test;
- 
+@@ -7,10 +7,10 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class WorldBorderIntegrationTest {
 +class WorldBorderIntegrationTest {
@@ -5107,7 +4967,7 @@ index 01c4c935fec5e312f6043106acac4d16520a3b9a..143c48b0abd06131bcef1c3733387d32
          Instance instance = env.createFlatInstance();
  
          instance.getWorldBorder().setDiameter(50.0);
-@@ -20,7 +21,7 @@ public class WorldBorderIntegrationTest {
+@@ -20,7 +20,7 @@ public class WorldBorderIntegrationTest {
      }
  
      @Test
@@ -5117,15 +4977,14 @@ index 01c4c935fec5e312f6043106acac4d16520a3b9a..143c48b0abd06131bcef1c3733387d32
  
          instance.getWorldBorder().setDiameter(50.0);
 diff --git a/src/test/java/net/minestom/server/instance/palette/PaletteOptimizationTest.java b/src/test/java/net/minestom/server/instance/palette/PaletteOptimizationTest.java
-index 9916d52ab23c645388ed4c6c215bf7203fb4bdc0..a66d0a083aaa9d8b5064ec4bd34be2b72b8cd279 100644
+index 9916d52ab23c645388ed4c6c215bf7203fb4bdc0..877f265955d81dba590da8166e994c0e4ec8854a 100644
 --- a/src/test/java/net/minestom/server/instance/palette/PaletteOptimizationTest.java
 +++ b/src/test/java/net/minestom/server/instance/palette/PaletteOptimizationTest.java
-@@ -8,23 +8,24 @@ import java.util.Random;
+@@ -8,23 +8,23 @@ import java.util.Random;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertTrue;
  
 -public class PaletteOptimizationTest {
-+//Microtus - update java keyword usage
 +class PaletteOptimizationTest {
  
      @Test
@@ -5149,7 +5008,7 @@ index 9916d52ab23c645388ed4c6c215bf7203fb4bdc0..a66d0a083aaa9d8b5064ec4bd34be2b7
          var random = new Random(12345);
          var palette = createPalette();
          palette.setAll((x, y, z) -> random.nextInt(256));
-@@ -34,7 +35,7 @@ public class PaletteOptimizationTest {
+@@ -34,7 +34,7 @@ public class PaletteOptimizationTest {
      }
  
      @Test
@@ -5159,15 +5018,14 @@ index 9916d52ab23c645388ed4c6c215bf7203fb4bdc0..a66d0a083aaa9d8b5064ec4bd34be2b7
          palette.setAll((x, y, z) -> 1);
          paletteEquals(palette.palette, palette.optimizedPalette());
 diff --git a/src/test/java/net/minestom/server/instance/palette/PaletteTest.java b/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
-index 3372ade456530be692de5f74e8c9515d32614df2..f4d164d0295d6a5272eb24f2b2d8b10cdc1db2fc 100644
+index 3372ade456530be692de5f74e8c9515d32614df2..583214ea6d1a4bb59956ee727644f571bba6484c 100644
 --- a/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
 +++ b/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
-@@ -11,17 +11,18 @@ import java.util.concurrent.atomic.AtomicInteger;
+@@ -11,17 +11,17 @@ import java.util.concurrent.atomic.AtomicInteger;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class PaletteTest {
-+//Microtus - update java keyword usage
 +class PaletteTest {
  
      @Test
@@ -5184,7 +5042,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..f4d164d0295d6a5272eb24f2b2d8b10c
          var palettes = testPalettes();
          for (Palette palette : palettes) {
              final int dimension = palette.dimension();
-@@ -56,7 +57,7 @@ public class PaletteTest {
+@@ -56,7 +56,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -5193,7 +5051,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..f4d164d0295d6a5272eb24f2b2d8b10c
          final int value = 250_000;
          for (Palette palette : testPalettes()) {
              palette.set(0, 0, 1, value);
-@@ -65,7 +66,7 @@ public class PaletteTest {
+@@ -65,7 +65,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -5202,7 +5060,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..f4d164d0295d6a5272eb24f2b2d8b10c
          var palettes = testPalettes();
          for (Palette palette : palettes) {
              assertThrows(IllegalArgumentException.class, () -> palette.set(-1, 0, 0, 64));
-@@ -79,7 +80,7 @@ public class PaletteTest {
+@@ -79,7 +79,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -5211,7 +5069,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..f4d164d0295d6a5272eb24f2b2d8b10c
          Palette palette = Palette.newPalette(16, 5, 2);
          palette.set(0, 0, 0, 1);
          assertEquals(2, palette.bitsPerEntry());
-@@ -98,7 +99,7 @@ public class PaletteTest {
+@@ -98,7 +98,7 @@ public class PaletteTest {
  
  
      @Test
@@ -5220,7 +5078,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..f4d164d0295d6a5272eb24f2b2d8b10c
          var palettes = testPalettes();
          for (Palette palette : palettes) {
              assertEquals(0, palette.count());
-@@ -129,7 +130,7 @@ public class PaletteTest {
+@@ -129,7 +129,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -5229,7 +5087,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..f4d164d0295d6a5272eb24f2b2d8b10c
          var palettes = testPalettes();
          for (Palette palette : palettes) {
              final int dimension = palette.dimension();
-@@ -154,7 +155,7 @@ public class PaletteTest {
+@@ -154,7 +154,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -5238,7 +5096,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..f4d164d0295d6a5272eb24f2b2d8b10c
          var palettes = testPalettes();
          for (Palette palette : palettes) {
              // Fill all entries
-@@ -172,7 +173,7 @@ public class PaletteTest {
+@@ -172,7 +172,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -5247,7 +5105,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..f4d164d0295d6a5272eb24f2b2d8b10c
          var palettes = testPalettes();
          for (Palette palette : palettes) {
              AtomicInteger count = new AtomicInteger();
-@@ -210,7 +211,7 @@ public class PaletteTest {
+@@ -210,7 +210,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -5256,7 +5114,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..f4d164d0295d6a5272eb24f2b2d8b10c
          var palettes = testPalettes();
          for (Palette palette : palettes) {
              palette.setAll((x, y, z) -> 1);
-@@ -219,7 +220,7 @@ public class PaletteTest {
+@@ -219,7 +219,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -5265,7 +5123,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..f4d164d0295d6a5272eb24f2b2d8b10c
          var palettes = testPalettes();
          for (Palette palette : palettes) {
              palette.getAllPresent((x, y, z, value) -> fail("The palette should be empty"));
-@@ -234,7 +235,7 @@ public class PaletteTest {
+@@ -234,7 +234,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -5274,7 +5132,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..f4d164d0295d6a5272eb24f2b2d8b10c
          var palettes = testPalettes();
          for (Palette palette : palettes) {
              palette.setAll((x, y, z) -> x + y + z + 1);
-@@ -247,7 +248,7 @@ public class PaletteTest {
+@@ -247,7 +247,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -5283,7 +5141,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..f4d164d0295d6a5272eb24f2b2d8b10c
          var palettes = testPalettes();
          for (Palette palette : palettes) {
              palette.set(0, 0, 0, 1);
-@@ -260,7 +261,7 @@ public class PaletteTest {
+@@ -260,7 +260,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -5292,7 +5150,7 @@ index 3372ade456530be692de5f74e8c9515d32614df2..f4d164d0295d6a5272eb24f2b2d8b10c
          var palette = Palette.newPalette(2, 15, 4);
          palette.setAll((x, y, z) -> x + y + z);
          final int dimension = palette.dimension();
-@@ -274,7 +275,7 @@ public class PaletteTest {
+@@ -274,7 +274,7 @@ public class PaletteTest {
      }
  
      @Test
@@ -5302,14 +5160,12 @@ index 3372ade456530be692de5f74e8c9515d32614df2..f4d164d0295d6a5272eb24f2b2d8b10c
          assertThrows(Exception.class, () -> Palette.newPalette(0, 5, 3));
          assertThrows(Exception.class, () -> Palette.newPalette(1, 5, 3));
 diff --git a/src/test/java/net/minestom/server/inventory/InventoryIntegrationTest.java b/src/test/java/net/minestom/server/inventory/InventoryIntegrationTest.java
-index d0df75b49e882760cc1813ff813c2882a5870c61..c571ed725611a8cb3648b33ed02e3ed95403b914 100644
+index d0df75b49e882760cc1813ff813c2882a5870c61..ed95d0daf7d90aa7e7ab926500766416aacfc21b 100644
 --- a/src/test/java/net/minestom/server/inventory/InventoryIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/inventory/InventoryIntegrationTest.java
-@@ -14,13 +14,14 @@ import org.junit.jupiter.api.Test;
- 
+@@ -15,12 +15,12 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.*;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class InventoryIntegrationTest {
 +class InventoryIntegrationTest {
@@ -5322,7 +5178,7 @@ index d0df75b49e882760cc1813ff813c2882a5870c61..c571ed725611a8cb3648b33ed02e3ed9
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -44,7 +45,7 @@ public class InventoryIntegrationTest {
+@@ -44,7 +44,7 @@ public class InventoryIntegrationTest {
      }
  
      @Test
@@ -5331,7 +5187,7 @@ index d0df75b49e882760cc1813ff813c2882a5870c61..c571ed725611a8cb3648b33ed02e3ed9
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -68,7 +69,7 @@ public class InventoryIntegrationTest {
+@@ -68,7 +68,7 @@ public class InventoryIntegrationTest {
      }
  
      @Test
@@ -5340,7 +5196,7 @@ index d0df75b49e882760cc1813ff813c2882a5870c61..c571ed725611a8cb3648b33ed02e3ed9
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -111,7 +112,7 @@ public class InventoryIntegrationTest {
+@@ -111,7 +111,7 @@ public class InventoryIntegrationTest {
      }
  
      @Test
@@ -5349,7 +5205,7 @@ index d0df75b49e882760cc1813ff813c2882a5870c61..c571ed725611a8cb3648b33ed02e3ed9
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -123,7 +124,7 @@ public class InventoryIntegrationTest {
+@@ -123,7 +123,7 @@ public class InventoryIntegrationTest {
      }
  
      @Test
@@ -5359,20 +5215,19 @@ index d0df75b49e882760cc1813ff813c2882a5870c61..c571ed725611a8cb3648b33ed02e3ed9
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
 diff --git a/src/test/java/net/minestom/server/inventory/InventoryTest.java b/src/test/java/net/minestom/server/inventory/InventoryTest.java
-index 612e3b162f38d6367dc016530270e38d46913281..890593bc7df9ec1ceadf871d4872bde53894e2d7 100644
+index 612e3b162f38d6367dc016530270e38d46913281..2f3e637b8939987726dd15fdfedafdca51b9cf48 100644
 --- a/src/test/java/net/minestom/server/inventory/InventoryTest.java
 +++ b/src/test/java/net/minestom/server/inventory/InventoryTest.java
-@@ -8,7 +8,8 @@ import org.junit.jupiter.api.Test;
+@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class InventoryTest {
-+//Microtus - update java keyword usage
 +class InventoryTest {
  
      static {
          // Required to prevent initialization error during event call
-@@ -16,7 +17,7 @@ public class InventoryTest {
+@@ -16,7 +16,7 @@ public class InventoryTest {
      }
  
      @Test
@@ -5381,7 +5236,7 @@ index 612e3b162f38d6367dc016530270e38d46913281..890593bc7df9ec1ceadf871d4872bde5
          Inventory inventory = new Inventory(InventoryType.CHEST_1_ROW, "title");
          assertEquals(InventoryType.CHEST_1_ROW, inventory.getInventoryType());
          assertEquals(Component.text("title"), inventory.getTitle());
-@@ -26,7 +27,7 @@ public class InventoryTest {
+@@ -26,7 +26,7 @@ public class InventoryTest {
      }
  
      @Test
@@ -5390,7 +5245,7 @@ index 612e3b162f38d6367dc016530270e38d46913281..890593bc7df9ec1ceadf871d4872bde5
          var item1 = ItemStack.of(Material.DIAMOND);
          var item2 = ItemStack.of(Material.GOLD_INGOT);
  
-@@ -52,7 +53,7 @@ public class InventoryTest {
+@@ -52,7 +52,7 @@ public class InventoryTest {
      }
  
      @Test
@@ -5399,7 +5254,7 @@ index 612e3b162f38d6367dc016530270e38d46913281..890593bc7df9ec1ceadf871d4872bde5
          ItemStack item = ItemStack.of(Material.DIAMOND, 32);
          Inventory inventory = new Inventory(InventoryType.CHEST_1_ROW, "title");
          inventory.setItemStack(0, item);
-@@ -66,7 +67,7 @@ public class InventoryTest {
+@@ -66,7 +66,7 @@ public class InventoryTest {
      }
  
      @Test
@@ -5408,7 +5263,7 @@ index 612e3b162f38d6367dc016530270e38d46913281..890593bc7df9ec1ceadf871d4872bde5
          Inventory inventory = new Inventory(InventoryType.HOPPER, "title");
          assertTrue(inventory.addItemStack(ItemStack.of(Material.DIAMOND, 32), TransactionOption.ALL_OR_NOTHING));
          assertTrue(inventory.addItemStack(ItemStack.of(Material.GOLD_BLOCK, 32), TransactionOption.ALL_OR_NOTHING));
-@@ -77,7 +78,7 @@ public class InventoryTest {
+@@ -77,7 +77,7 @@ public class InventoryTest {
      }
  
      @Test
@@ -5418,14 +5273,12 @@ index 612e3b162f38d6367dc016530270e38d46913281..890593bc7df9ec1ceadf871d4872bde5
              final byte windowId = new Inventory(InventoryType.CHEST_1_ROW, "title").getWindowId();
              assertTrue(windowId > 0);
 diff --git a/src/test/java/net/minestom/server/inventory/PlayerInventoryIntegrationTest.java b/src/test/java/net/minestom/server/inventory/PlayerInventoryIntegrationTest.java
-index 268a34a27684778f116dbbed910a67fff8ffbfc7..3d9f5c323bfef881f647116f66713b847ccf856f 100644
+index 268a34a27684778f116dbbed910a67fff8ffbfc7..762d5e53f5ee07b36ecda7e68ca6e1b4fb95ccfd 100644
 --- a/src/test/java/net/minestom/server/inventory/PlayerInventoryIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/inventory/PlayerInventoryIntegrationTest.java
-@@ -15,13 +15,14 @@ import java.util.Map;
- 
+@@ -16,12 +16,12 @@ import java.util.Map;
  import static org.junit.jupiter.api.Assertions.*;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class PlayerInventoryIntegrationTest {
 +class PlayerInventoryIntegrationTest {
@@ -5438,7 +5291,7 @@ index 268a34a27684778f116dbbed910a67fff8ffbfc7..3d9f5c323bfef881f647116f66713b84
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -41,7 +42,7 @@ public class PlayerInventoryIntegrationTest {
+@@ -41,7 +41,7 @@ public class PlayerInventoryIntegrationTest {
      }
  
      @Test
@@ -5447,7 +5300,7 @@ index 268a34a27684778f116dbbed910a67fff8ffbfc7..3d9f5c323bfef881f647116f66713b84
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -61,7 +62,7 @@ public class PlayerInventoryIntegrationTest {
+@@ -61,7 +61,7 @@ public class PlayerInventoryIntegrationTest {
      }
  
      @Test
@@ -5456,7 +5309,7 @@ index 268a34a27684778f116dbbed910a67fff8ffbfc7..3d9f5c323bfef881f647116f66713b84
          var instance = env.createFlatInstance();
          var connection = env.createConnection();
          var player = connection.connect(instance, new Pos(0, 42, 0)).join();
-@@ -105,7 +106,7 @@ public class PlayerInventoryIntegrationTest {
+@@ -105,7 +105,7 @@ public class PlayerInventoryIntegrationTest {
      }
  
      @Test
@@ -5465,7 +5318,7 @@ index 268a34a27684778f116dbbed910a67fff8ffbfc7..3d9f5c323bfef881f647116f66713b84
          var instance = env.createFlatInstance();
          var connectionArmored = env.createConnection();
          var playerArmored = connectionArmored.connect(instance, new Pos(0, 42, 0)).join();
-@@ -119,9 +120,7 @@ public class PlayerInventoryIntegrationTest {
+@@ -119,9 +119,7 @@ public class PlayerInventoryIntegrationTest {
  
          // Setting to an item should send EntityEquipmentPacket to viewer
          playerArmored.getInventory().setEquipment(EquipmentSlot.HELMET, MAGIC_STACK);
@@ -5476,7 +5329,7 @@ index 268a34a27684778f116dbbed910a67fff8ffbfc7..3d9f5c323bfef881f647116f66713b84
  
          // Setting to the same item shouldn't send packet
          equipmentTracker = connectionViewer.trackIncoming(EntityEquipmentPacket.class);
-@@ -131,13 +130,11 @@ public class PlayerInventoryIntegrationTest {
+@@ -131,13 +129,11 @@ public class PlayerInventoryIntegrationTest {
          // Setting to air should send packet
          equipmentTracker = connectionViewer.trackIncoming(EntityEquipmentPacket.class);
          playerArmored.getInventory().setEquipment(EquipmentSlot.HELMET, ItemStack.AIR);
@@ -5492,7 +5345,7 @@ index 268a34a27684778f116dbbed910a67fff8ffbfc7..3d9f5c323bfef881f647116f66713b84
          var instance = env.createFlatInstance();
          var connectionHolder = env.createConnection();
          var playerHolder = connectionHolder.connect(instance, new Pos(0, 42, 0)).join();
-@@ -152,23 +149,17 @@ public class PlayerInventoryIntegrationTest {
+@@ -152,23 +148,17 @@ public class PlayerInventoryIntegrationTest {
          // Setting held item
          var equipmentTracker = connectionViewer.trackIncoming(EntityEquipmentPacket.class);
          playerHolder.setItemInMainHand(MAGIC_STACK);
@@ -5520,15 +5373,14 @@ index 268a34a27684778f116dbbed910a67fff8ffbfc7..3d9f5c323bfef881f647116f66713b84
  
  }
 diff --git a/src/test/java/net/minestom/server/inventory/PlayerSlotConversionTest.java b/src/test/java/net/minestom/server/inventory/PlayerSlotConversionTest.java
-index 992051039124e3bf50dd4d667cb7433195f8c735..3809de5a1c13c69d36b550ff68037af91f9ebd66 100644
+index 992051039124e3bf50dd4d667cb7433195f8c735..20e112920723b6046de91875a49757bf2c8a4058 100644
 --- a/src/test/java/net/minestom/server/inventory/PlayerSlotConversionTest.java
 +++ b/src/test/java/net/minestom/server/inventory/PlayerSlotConversionTest.java
-@@ -8,10 +8,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -8,10 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  /**
   * Test conversion from packet slots to internal ones (used in events and inventory methods)
   */
 -public class PlayerSlotConversionTest {
-+//Microtus - update java keyword usage
 +class PlayerSlotConversionTest {
  
      @Test
@@ -5537,7 +5389,7 @@ index 992051039124e3bf50dd4d667cb7433195f8c735..3809de5a1c13c69d36b550ff68037af9
          // Convert 36-44 into 0-8
          for (int i = 0; i < 9; i++) {
              assertEquals(i, convertPlayerInventorySlot(i + 36, OFFSET));
-@@ -19,7 +20,7 @@ public class PlayerSlotConversionTest {
+@@ -19,7 +19,7 @@ public class PlayerSlotConversionTest {
      }
  
      @Test
@@ -5546,7 +5398,7 @@ index 992051039124e3bf50dd4d667cb7433195f8c735..3809de5a1c13c69d36b550ff68037af9
          // No conversion, slots should stay 9-35
          for (int i = 9; i < 9 * 4; i++) {
              assertEquals(i, convertPlayerInventorySlot(i, OFFSET));
-@@ -27,7 +28,7 @@ public class PlayerSlotConversionTest {
+@@ -27,7 +27,7 @@ public class PlayerSlotConversionTest {
      }
  
      @Test
@@ -5555,7 +5407,7 @@ index 992051039124e3bf50dd4d667cb7433195f8c735..3809de5a1c13c69d36b550ff68037af9
          assertEquals(HELMET_SLOT, 41);
          assertEquals(CHESTPLATE_SLOT, 42);
          assertEquals(LEGGINGS_SLOT, 43);
-@@ -43,7 +44,7 @@ public class PlayerSlotConversionTest {
+@@ -43,7 +43,7 @@ public class PlayerSlotConversionTest {
      }
  
      @Test
@@ -5565,14 +5417,12 @@ index 992051039124e3bf50dd4d667cb7433195f8c735..3809de5a1c13c69d36b550ff68037af9
          assertEquals(CRAFT_SLOT_1, 37);
          assertEquals(CRAFT_SLOT_2, 38);
 diff --git a/src/test/java/net/minestom/server/inventory/click/integration/HeldClickIntegrationTest.java b/src/test/java/net/minestom/server/inventory/click/integration/HeldClickIntegrationTest.java
-index 93069a5a925fda0d289e03b72281b92d795ac4c2..2061eda80fd9024e8684d8eb66457727767bc9dc 100644
+index 93069a5a925fda0d289e03b72281b92d795ac4c2..55145c0001750c019f83135800e4481e7f89bd28 100644
 --- a/src/test/java/net/minestom/server/inventory/click/integration/HeldClickIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/inventory/click/integration/HeldClickIntegrationTest.java
-@@ -18,11 +18,12 @@ import java.util.List;
- 
+@@ -19,10 +19,10 @@ import java.util.List;
  import static org.junit.jupiter.api.Assertions.*;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class HeldClickIntegrationTest {
 +class HeldClickIntegrationTest {
@@ -5583,7 +5433,7 @@ index 93069a5a925fda0d289e03b72281b92d795ac4c2..2061eda80fd9024e8684d8eb66457727
          var instance = env.createFlatInstance();
          var player = env.createPlayer(instance, new Pos(0, 40, 0));
          var inventory = player.getInventory();
-@@ -96,7 +97,7 @@ public class HeldClickIntegrationTest {
+@@ -96,7 +96,7 @@ public class HeldClickIntegrationTest {
      }
  
      @Test
@@ -5593,14 +5443,12 @@ index 93069a5a925fda0d289e03b72281b92d795ac4c2..2061eda80fd9024e8684d8eb66457727
          var player = env.createPlayer(instance, new Pos(0, 40, 0));
          var inventory = new Inventory(InventoryType.HOPPER, "test");
 diff --git a/src/test/java/net/minestom/server/inventory/click/integration/LeftClickIntegrationTest.java b/src/test/java/net/minestom/server/inventory/click/integration/LeftClickIntegrationTest.java
-index 87a81674699095298ef8614417497025bb70b479..17584cba14f4e071255bbb8db863be071f34de9a 100644
+index 87a81674699095298ef8614417497025bb70b479..57639fad9010c6e1d271bf27d83efed5d2026af9 100644
 --- a/src/test/java/net/minestom/server/inventory/click/integration/LeftClickIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/inventory/click/integration/LeftClickIntegrationTest.java
-@@ -20,11 +20,12 @@ import java.util.List;
- import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -21,10 +21,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class LeftClickIntegrationTest {
 +class LeftClickIntegrationTest {
@@ -5611,7 +5459,7 @@ index 87a81674699095298ef8614417497025bb70b479..17584cba14f4e071255bbb8db863be07
          var instance = env.createFlatInstance();
          var player = env.createPlayer(instance, new Pos(0, 40, 0));
          var inventory = player.getInventory();
-@@ -82,7 +83,7 @@ public class LeftClickIntegrationTest {
+@@ -82,7 +82,7 @@ public class LeftClickIntegrationTest {
      }
  
      @Test
@@ -5621,14 +5469,12 @@ index 87a81674699095298ef8614417497025bb70b479..17584cba14f4e071255bbb8db863be07
          var player = env.createPlayer(instance, new Pos(0, 40, 0));
          var inventory = new Inventory(InventoryType.HOPPER, "test");
 diff --git a/src/test/java/net/minestom/server/inventory/click/integration/RightClickIntegrationTest.java b/src/test/java/net/minestom/server/inventory/click/integration/RightClickIntegrationTest.java
-index c4e4b6e403c628346273597f87507870e62860d3..aaa1c0012e96426897a7fc3c2d8fe1a37a6db892 100644
+index c4e4b6e403c628346273597f87507870e62860d3..ca2706d6dd9aa201043c921ee187bbb48c8df3bd 100644
 --- a/src/test/java/net/minestom/server/inventory/click/integration/RightClickIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/inventory/click/integration/RightClickIntegrationTest.java
-@@ -19,11 +19,12 @@ import java.util.List;
- import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -20,10 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class RightClickIntegrationTest {
 +class RightClickIntegrationTest {
@@ -5639,7 +5485,7 @@ index c4e4b6e403c628346273597f87507870e62860d3..aaa1c0012e96426897a7fc3c2d8fe1a3
          var instance = env.createFlatInstance();
          var player = env.createPlayer(instance, new Pos(0, 40, 0));
          var inventory = player.getInventory();
-@@ -104,7 +105,7 @@ public class RightClickIntegrationTest {
+@@ -104,7 +104,7 @@ public class RightClickIntegrationTest {
      }
  
      @Test
@@ -5649,15 +5495,14 @@ index c4e4b6e403c628346273597f87507870e62860d3..aaa1c0012e96426897a7fc3c2d8fe1a3
          var player = env.createPlayer(instance, new Pos(0, 40, 0));
          var inventory = new Inventory(InventoryType.HOPPER, "test");
 diff --git a/src/test/java/net/minestom/server/item/ItemAirTest.java b/src/test/java/net/minestom/server/item/ItemAirTest.java
-index db3d855f8114fe9cf0e2e61e834dd3de1157a135..e715204e06627e37634cc3f89d1ca4dbbef3e588 100644
+index db3d855f8114fe9cf0e2e61e834dd3de1157a135..17720b6b3b43d6b92c590864467dbfbac547609e 100644
 --- a/src/test/java/net/minestom/server/item/ItemAirTest.java
 +++ b/src/test/java/net/minestom/server/item/ItemAirTest.java
-@@ -4,9 +4,10 @@ import org.junit.jupiter.api.Test;
+@@ -4,9 +4,9 @@ import org.junit.jupiter.api.Test;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class ItemAirTest {
-+//Microtus - update java keyword usage
 +class ItemAirTest {
      @Test
 -    public void testAir() {
@@ -5666,7 +5511,7 @@ index db3d855f8114fe9cf0e2e61e834dd3de1157a135..e715204e06627e37634cc3f89d1ca4db
          assertFalse(item.isAir());
          assertTrue(ItemStack.AIR.isAir());
 diff --git a/src/test/java/net/minestom/server/item/ItemAttributeTest.java b/src/test/java/net/minestom/server/item/ItemAttributeTest.java
-index 4111ba13173056cfc36b9c9602f62e33f6ae98a5..c8b96d5576948b74ba6f07ea88a5c0f66fbf2f59 100644
+index 4111ba13173056cfc36b9c9602f62e33f6ae98a5..f8ea7c7d8c1b68b1914732c290f6936a318a12ee 100644
 --- a/src/test/java/net/minestom/server/item/ItemAttributeTest.java
 +++ b/src/test/java/net/minestom/server/item/ItemAttributeTest.java
 @@ -5,9 +5,6 @@ import net.minestom.server.attribute.AttributeOperation;
@@ -5679,12 +5524,11 @@ index 4111ba13173056cfc36b9c9602f62e33f6ae98a5..c8b96d5576948b74ba6f07ea88a5c0f6
  import org.junit.jupiter.api.Test;
  
  import java.util.List;
-@@ -16,10 +13,11 @@ import java.util.UUID;
+@@ -16,10 +13,10 @@ import java.util.UUID;
  import static net.minestom.testing.TestUtils.assertEqualsSNBT;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
 -public class ItemAttributeTest {
-+//Microtus - update java keyword usage
 +class ItemAttributeTest {
  
      @Test
@@ -5693,7 +5537,7 @@ index 4111ba13173056cfc36b9c9602f62e33f6ae98a5..c8b96d5576948b74ba6f07ea88a5c0f6
          var attributes = List.of(new ItemAttribute(
                  new UUID(0, 0), "generic.attack_damage", Attribute.ATTACK_DAMAGE,
                  AttributeOperation.ADDITION, 2, AttributeSlot.MAINHAND));
-@@ -30,7 +28,7 @@ public class ItemAttributeTest {
+@@ -30,7 +27,7 @@ public class ItemAttributeTest {
      }
  
      @Test
@@ -5702,7 +5546,7 @@ index 4111ba13173056cfc36b9c9602f62e33f6ae98a5..c8b96d5576948b74ba6f07ea88a5c0f6
          var attributes = List.of(new ItemAttribute(
                  new UUID(0, 0), "generic.attack_damage", Attribute.ATTACK_DAMAGE,
                  AttributeOperation.ADDITION, 2, AttributeSlot.MAINHAND));
-@@ -43,7 +41,7 @@ public class ItemAttributeTest {
+@@ -43,7 +40,7 @@ public class ItemAttributeTest {
      }
  
      @Test
@@ -5712,15 +5556,14 @@ index 4111ba13173056cfc36b9c9602f62e33f6ae98a5..c8b96d5576948b74ba6f07ea88a5c0f6
                  .meta(builder -> builder.attributes(
                          List.of(new ItemAttribute(
 diff --git a/src/test/java/net/minestom/server/item/ItemBlockTest.java b/src/test/java/net/minestom/server/item/ItemBlockTest.java
-index 495e3de4962bdae90b9392c9ea4629d09eb966c2..363686964e904b3762cc4dd2181ecb4b4477ef01 100644
+index 495e3de4962bdae90b9392c9ea4629d09eb966c2..5eda2abf47994345b2be8a7fe4dbf511039ae4aa 100644
 --- a/src/test/java/net/minestom/server/item/ItemBlockTest.java
 +++ b/src/test/java/net/minestom/server/item/ItemBlockTest.java
-@@ -6,10 +6,11 @@ import org.junit.jupiter.api.Test;
+@@ -6,10 +6,10 @@ import org.junit.jupiter.api.Test;
  import static net.minestom.testing.TestUtils.assertEqualsSNBT;
  import static org.junit.jupiter.api.Assertions.assertTrue;
  
 -public class ItemBlockTest {
-+//Microtus - update java keyword usage
 +class ItemBlockTest {
  
      @Test
@@ -5729,7 +5572,7 @@ index 495e3de4962bdae90b9392c9ea4629d09eb966c2..363686964e904b3762cc4dd2181ecb4b
          var item = ItemStack.builder(Material.STONE)
                  .meta(builder -> builder.canPlaceOn(Block.STONE))
                  .build();
-@@ -18,7 +19,7 @@ public class ItemBlockTest {
+@@ -18,7 +18,7 @@ public class ItemBlockTest {
      }
  
      @Test
@@ -5738,7 +5581,7 @@ index 495e3de4962bdae90b9392c9ea4629d09eb966c2..363686964e904b3762cc4dd2181ecb4b
          var item = ItemStack.builder(Material.STONE)
                  .meta(builder -> builder.canPlaceOn(Block.STONE))
                  .build();
-@@ -28,7 +29,7 @@ public class ItemBlockTest {
+@@ -28,7 +28,7 @@ public class ItemBlockTest {
      }
  
      @Test
@@ -5747,7 +5590,7 @@ index 495e3de4962bdae90b9392c9ea4629d09eb966c2..363686964e904b3762cc4dd2181ecb4b
          var item = ItemStack.builder(Material.STONE)
                  .meta(builder -> builder.canPlaceOn(Block.SANDSTONE_STAIRS.withProperty("facing", "south")))
                  .build();
-@@ -38,7 +39,7 @@ public class ItemBlockTest {
+@@ -38,7 +38,7 @@ public class ItemBlockTest {
      }
  
      @Test
@@ -5756,7 +5599,7 @@ index 495e3de4962bdae90b9392c9ea4629d09eb966c2..363686964e904b3762cc4dd2181ecb4b
          var item = ItemStack.builder(Material.STONE)
                  .meta(builder -> builder.canDestroy(Block.STONE))
                  .build();
-@@ -47,7 +48,7 @@ public class ItemBlockTest {
+@@ -47,7 +47,7 @@ public class ItemBlockTest {
      }
  
      @Test
@@ -5765,7 +5608,7 @@ index 495e3de4962bdae90b9392c9ea4629d09eb966c2..363686964e904b3762cc4dd2181ecb4b
          var item = ItemStack.builder(Material.STONE)
                  .meta(builder -> builder.canDestroy(Block.STONE))
                  .build();
-@@ -57,7 +58,7 @@ public class ItemBlockTest {
+@@ -57,7 +57,7 @@ public class ItemBlockTest {
      }
  
      @Test
@@ -5775,15 +5618,14 @@ index 495e3de4962bdae90b9392c9ea4629d09eb966c2..363686964e904b3762cc4dd2181ecb4b
                  .meta(builder -> builder.canDestroy(Block.SANDSTONE_STAIRS.withProperty("facing", "south")))
                  .build();
 diff --git a/src/test/java/net/minestom/server/item/ItemDisplayTest.java b/src/test/java/net/minestom/server/item/ItemDisplayTest.java
-index 87700dc15cf193078b0da417f1129a41d80fec7e..d02e09758b75d8c3d5dfc20ee4cf3a221b87b8a0 100644
+index 87700dc15cf193078b0da417f1129a41d80fec7e..98072ec96294ae4d61fee6252b446bbe2d5d4167 100644
 --- a/src/test/java/net/minestom/server/item/ItemDisplayTest.java
 +++ b/src/test/java/net/minestom/server/item/ItemDisplayTest.java
-@@ -10,10 +10,11 @@ import java.util.stream.Stream;
+@@ -10,10 +10,10 @@ import java.util.stream.Stream;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class ItemDisplayTest {
-+//Microtus - update java keyword usage
 +class ItemDisplayTest {
  
      @Test
@@ -5793,15 +5635,14 @@ index 87700dc15cf193078b0da417f1129a41d80fec7e..d02e09758b75d8c3d5dfc20ee4cf3a22
          assertEquals(List.of(), item.getLore());
          assertNull(item.meta().toNBT().get("display"));
 diff --git a/src/test/java/net/minestom/server/item/ItemEnchantTest.java b/src/test/java/net/minestom/server/item/ItemEnchantTest.java
-index 46f818bcb3e2c8651be5dcf9e9e8fabb0a73cea7..6d2797cf6f15e60e72b8048ad008883ed384a9c9 100644
+index 46f818bcb3e2c8651be5dcf9e9e8fabb0a73cea7..bae7902020fa913c163c25966cc13a7245bf907b 100644
 --- a/src/test/java/net/minestom/server/item/ItemEnchantTest.java
 +++ b/src/test/java/net/minestom/server/item/ItemEnchantTest.java
-@@ -7,22 +7,23 @@ import java.util.Map;
+@@ -7,22 +7,22 @@ import java.util.Map;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertTrue;
  
 -public class ItemEnchantTest {
-+//Microtus - update java keyword usage
 +class ItemEnchantTest {
  
      @Test
@@ -5825,15 +5666,14 @@ index 46f818bcb3e2c8651be5dcf9e9e8fabb0a73cea7..6d2797cf6f15e60e72b8048ad008883e
          assertEquals(enchantments.get(Enchantment.INFINITY), (short) 5);
  
 diff --git a/src/test/java/net/minestom/server/item/ItemMetaTest.java b/src/test/java/net/minestom/server/item/ItemMetaTest.java
-index fc8d2b7faf989c1e5003e3fc24de98ef25151430..931a2be1b4888bfd1c65cfbde61b8161fcb6b49c 100644
+index fc8d2b7faf989c1e5003e3fc24de98ef25151430..43b17d140000b1d1341293adc7cf263d33557319 100644
 --- a/src/test/java/net/minestom/server/item/ItemMetaTest.java
 +++ b/src/test/java/net/minestom/server/item/ItemMetaTest.java
-@@ -18,22 +18,23 @@ import java.util.UUID;
+@@ -18,22 +18,22 @@ import java.util.UUID;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNotNull;
  
 -public class ItemMetaTest {
-+//Microtus - update java keyword usage
 +class ItemMetaTest {
      @Test
 -    public void defaultMeta() {
@@ -5856,7 +5696,7 @@ index fc8d2b7faf989c1e5003e3fc24de98ef25151430..931a2be1b4888bfd1c65cfbde61b8161
          var item = ItemStack.builder(Material.BUNDLE)
                  .meta(BundleMeta.class, bundleMetaBuilder -> {
                      bundleMetaBuilder.addItem(ItemStack.of(Material.DIAMOND, 5));
-@@ -44,7 +45,7 @@ public class ItemMetaTest {
+@@ -44,7 +44,7 @@ public class ItemMetaTest {
      }
  
      @Test
@@ -5866,15 +5706,14 @@ index fc8d2b7faf989c1e5003e3fc24de98ef25151430..931a2be1b4888bfd1c65cfbde61b8161
          var skin = new PlayerSkin("xx", "yy");
          var meta = new PlayerHeadMeta.Builder()
 diff --git a/src/test/java/net/minestom/server/item/ItemMetaViewTest.java b/src/test/java/net/minestom/server/item/ItemMetaViewTest.java
-index 4c20e7b822990b4e2e0baeb1de0a2a6d9ddd53ab..2a4eb1244f12111827d7ceddc81bdd2eec647aab 100644
+index 4c20e7b822990b4e2e0baeb1de0a2a6d9ddd53ab..d39bb6024fc06807a14ac9db52bac54e1fb5b358 100644
 --- a/src/test/java/net/minestom/server/item/ItemMetaViewTest.java
 +++ b/src/test/java/net/minestom/server/item/ItemMetaViewTest.java
-@@ -7,14 +7,15 @@ import org.junit.jupiter.api.Test;
+@@ -7,14 +7,14 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertInstanceOf;
  
 -public class ItemMetaViewTest {
-+//Microtus - update java keyword usage
 +class ItemMetaViewTest {
      @Test
 -    public void viewType() {
@@ -5889,15 +5728,14 @@ index 4c20e7b822990b4e2e0baeb1de0a2a6d9ddd53ab..2a4eb1244f12111827d7ceddc81bdd2e
      }
  }
 diff --git a/src/test/java/net/minestom/server/item/ItemMetaWrittenBookTest.java b/src/test/java/net/minestom/server/item/ItemMetaWrittenBookTest.java
-index f8eb46b2fb547a5052659fe963223ef1e5adecc4..d7494c40c2a2c541d8749aa556fd4b261cd432fa 100644
+index f8eb46b2fb547a5052659fe963223ef1e5adecc4..fc6891e20469de757dcc05d5e861cdc0a7a3be2f 100644
 --- a/src/test/java/net/minestom/server/item/ItemMetaWrittenBookTest.java
 +++ b/src/test/java/net/minestom/server/item/ItemMetaWrittenBookTest.java
-@@ -18,9 +18,10 @@ import java.util.List;
+@@ -18,9 +18,9 @@ import java.util.List;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.fail;
  
 -public class ItemMetaWrittenBookTest {
-+//Microtus - update java keyword usage
 +class ItemMetaWrittenBookTest {
      @Test
 -    public void testPages() {
@@ -5905,7 +5743,7 @@ index f8eb46b2fb547a5052659fe963223ef1e5adecc4..d7494c40c2a2c541d8749aa556fd4b26
          ItemStack book = ItemStack.of(Material.WRITTEN_BOOK);
  
          Component pageA = Component.text("Page A");
-@@ -36,7 +37,7 @@ public class ItemMetaWrittenBookTest {
+@@ -36,7 +36,7 @@ public class ItemMetaWrittenBookTest {
      }
  
      @Test
@@ -5914,7 +5752,7 @@ index f8eb46b2fb547a5052659fe963223ef1e5adecc4..d7494c40c2a2c541d8749aa556fd4b26
          List<TextColor> colors = List.of(NamedTextColor.BLUE, NamedTextColor.WHITE, NamedTextColor.DARK_BLUE);
          List<TextDecoration> decorations = List.of(TextDecoration.UNDERLINED, TextDecoration.STRIKETHROUGH, TextDecoration.ITALIC);
          List<ClickEvent> clicks = List.of(
-@@ -79,7 +80,7 @@ public class ItemMetaWrittenBookTest {
+@@ -79,7 +79,7 @@ public class ItemMetaWrittenBookTest {
      }
  
      @Test
@@ -5924,15 +5762,14 @@ index f8eb46b2fb547a5052659fe963223ef1e5adecc4..d7494c40c2a2c541d8749aa556fd4b26
  {
      pages:['[
 diff --git a/src/test/java/net/minestom/server/item/ItemTest.java b/src/test/java/net/minestom/server/item/ItemTest.java
-index c7fa1ca1fd0a6d4a8180581e8f1aa3962ab51f01..86cc7e967d323c2f057b769474fa258afd3fc6c8 100644
+index c7fa1ca1fd0a6d4a8180581e8f1aa3962ab51f01..4171f07682bf707e5e314d15a4c79e8e0e941d4a 100644
 --- a/src/test/java/net/minestom/server/item/ItemTest.java
 +++ b/src/test/java/net/minestom/server/item/ItemTest.java
-@@ -9,40 +9,41 @@ import java.util.Map;
+@@ -9,40 +9,40 @@ import java.util.Map;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class ItemTest {
-+//Microtus - update java keyword usage
 +class ItemTest {
  
      @Test
@@ -5979,7 +5816,7 @@ index c7fa1ca1fd0a6d4a8180581e8f1aa3962ab51f01..86cc7e967d323c2f057b769474fa258a
          var item1 = ItemStack.of(Material.DIAMOND_SWORD);
          var item2 = ItemStack.of(Material.DIAMOND_SWORD);
          assertEquals(item1, item2);
-@@ -54,7 +55,7 @@ public class ItemTest {
+@@ -54,7 +54,7 @@ public class ItemTest {
      }
  
      @Test
@@ -5988,7 +5825,7 @@ index c7fa1ca1fd0a6d4a8180581e8f1aa3962ab51f01..86cc7e967d323c2f057b769474fa258a
          var itemNbt = createItem().toItemNBT();
          assertEquals(itemNbt.getString("id"), createItem().material().name(), "id string should be the material name");
          assertEquals(itemNbt.getByte("Count"), (byte) createItem().amount(), "Count byte should be the item amount");
-@@ -64,7 +65,7 @@ public class ItemTest {
+@@ -64,7 +64,7 @@ public class ItemTest {
      }
  
      @Test
@@ -5997,7 +5834,7 @@ index c7fa1ca1fd0a6d4a8180581e8f1aa3962ab51f01..86cc7e967d323c2f057b769474fa258a
          var itemNbt = createItem().toItemNBT();
          var item = ItemStack.fromItemNBT(itemNbt);
          assertEquals(createItem(), item, "Items must be equal if created from the same item nbt");
-@@ -76,7 +77,7 @@ public class ItemTest {
+@@ -76,7 +76,7 @@ public class ItemTest {
      }
  
      @Test
@@ -6006,7 +5843,7 @@ index c7fa1ca1fd0a6d4a8180581e8f1aa3962ab51f01..86cc7e967d323c2f057b769474fa258a
          var builder = ItemStack.builder(Material.DIAMOND);
          var item1 = builder.build();
          var item2 = builder.displayName(Component.text("Name")).build();
-@@ -86,7 +87,7 @@ public class ItemTest {
+@@ -86,7 +86,7 @@ public class ItemTest {
      }
  
      @Test
@@ -6015,7 +5852,7 @@ index c7fa1ca1fd0a6d4a8180581e8f1aa3962ab51f01..86cc7e967d323c2f057b769474fa258a
          var nbt = NBT.Compound(Map.of("key", NBT.String("value")));
          var item1 = ItemStack.fromNBT(Material.DIAMOND, nbt, 5);
          var item2 = item1.withMaterial(Material.GOLD_INGOT);
-@@ -102,7 +103,7 @@ public class ItemTest {
+@@ -102,7 +102,7 @@ public class ItemTest {
      }
  
      @Test
@@ -6025,15 +5862,14 @@ index c7fa1ca1fd0a6d4a8180581e8f1aa3962ab51f01..86cc7e967d323c2f057b769474fa258a
          assertEquals(5, item1.amount());
          assertEquals(6, item1.withAmount(6).amount());
 diff --git a/src/test/java/net/minestom/server/network/NetworkBufferTest.java b/src/test/java/net/minestom/server/network/NetworkBufferTest.java
-index 107e1c53a77414a300beb46143875dda25a4503f..a6dfda4e5c7ce9f9c6aaafd2fe7f3d1b2330b446 100644
+index 107e1c53a77414a300beb46143875dda25a4503f..ac349777f80d2711dcb120908ea8dd9b0e095fa3 100644
 --- a/src/test/java/net/minestom/server/network/NetworkBufferTest.java
 +++ b/src/test/java/net/minestom/server/network/NetworkBufferTest.java
-@@ -15,10 +15,11 @@ import static net.minestom.server.network.NetworkBuffer.*;
+@@ -15,10 +15,10 @@ import static net.minestom.server.network.NetworkBuffer.*;
  import static org.junit.jupiter.api.Assertions.assertArrayEquals;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
 -public class NetworkBufferTest {
-+//Microtus - update java keyword usage
 +class NetworkBufferTest {
  
      @Test
@@ -6042,7 +5878,7 @@ index 107e1c53a77414a300beb46143875dda25a4503f..a6dfda4e5c7ce9f9c6aaafd2fe7f3d1b
          var buffer = new NetworkBuffer(6);
          buffer.write(INT, 6);
          assertEquals(4, buffer.writeIndex());
-@@ -42,7 +43,7 @@ public class NetworkBufferTest {
+@@ -42,7 +42,7 @@ public class NetworkBufferTest {
      }
  
      @Test
@@ -6051,7 +5887,7 @@ index 107e1c53a77414a300beb46143875dda25a4503f..a6dfda4e5c7ce9f9c6aaafd2fe7f3d1b
          var buffer = new NetworkBuffer();
          assertEquals(0, buffer.readableBytes());
  
-@@ -60,7 +61,7 @@ public class NetworkBufferTest {
+@@ -60,7 +60,7 @@ public class NetworkBufferTest {
      }
  
      @Test
@@ -6060,7 +5896,7 @@ index 107e1c53a77414a300beb46143875dda25a4503f..a6dfda4e5c7ce9f9c6aaafd2fe7f3d1b
          var buffer = new NetworkBuffer();
  
          buffer.write(BYTE, (byte) 25);
-@@ -87,7 +88,7 @@ public class NetworkBufferTest {
+@@ -87,7 +87,7 @@ public class NetworkBufferTest {
      }
  
      @Test
@@ -6069,7 +5905,7 @@ index 107e1c53a77414a300beb46143875dda25a4503f..a6dfda4e5c7ce9f9c6aaafd2fe7f3d1b
          assertArrayEquals(new byte[0], NetworkBuffer.makeArray(buffer -> {
          }));
  
-@@ -100,7 +101,7 @@ public class NetworkBufferTest {
+@@ -100,7 +100,7 @@ public class NetworkBufferTest {
      }
  
      @Test
@@ -6078,7 +5914,7 @@ index 107e1c53a77414a300beb46143875dda25a4503f..a6dfda4e5c7ce9f9c6aaafd2fe7f3d1b
          assertBufferType(BOOLEAN, false, new byte[]{0x00});
          assertBufferType(BOOLEAN, true, new byte[]{0x01});
  
-@@ -193,7 +194,7 @@ public class NetworkBufferTest {
+@@ -193,7 +193,7 @@ public class NetworkBufferTest {
      }
  
      @Test
@@ -6087,7 +5923,7 @@ index 107e1c53a77414a300beb46143875dda25a4503f..a6dfda4e5c7ce9f9c6aaafd2fe7f3d1b
          assertBufferType(VAR_INT, 0, new byte[]{0});
          assertBufferType(VAR_INT, 1, new byte[]{0x01});
          assertBufferType(VAR_INT, 2, new byte[]{0x02});
-@@ -209,7 +210,7 @@ public class NetworkBufferTest {
+@@ -209,7 +209,7 @@ public class NetworkBufferTest {
      }
  
      @Test
@@ -6096,7 +5932,7 @@ index 107e1c53a77414a300beb46143875dda25a4503f..a6dfda4e5c7ce9f9c6aaafd2fe7f3d1b
          assertBufferType(VAR_LONG, 0L, new byte[]{0});
          assertBufferType(VAR_LONG, 1L, new byte[]{0x01});
          assertBufferType(VAR_LONG, 2L, new byte[]{0x02});
-@@ -224,49 +225,49 @@ public class NetworkBufferTest {
+@@ -224,49 +224,49 @@ public class NetworkBufferTest {
      }
  
      @Test
@@ -6155,7 +5991,7 @@ index 107e1c53a77414a300beb46143875dda25a4503f..a6dfda4e5c7ce9f9c6aaafd2fe7f3d1b
          assertBufferTypeCollection(BOOLEAN, List.of(true), new byte[]{0x01, 0x01});
      }
 diff --git a/src/test/java/net/minestom/server/network/PacketWriteReadTest.java b/src/test/java/net/minestom/server/network/PacketWriteReadTest.java
-index 3e424c24f5c7064992c469439a0049f040ef038c..57d14448eab5a9f1fba8ae6a5730ee6690cfc6f6 100644
+index 3e424c24f5c7064992c469439a0049f040ef038c..eb265352ab3a27a6bb8fb31df610027789570b83 100644
 --- a/src/test/java/net/minestom/server/network/PacketWriteReadTest.java
 +++ b/src/test/java/net/minestom/server/network/PacketWriteReadTest.java
 @@ -1,15 +1,9 @@
@@ -6193,15 +6029,7 @@ index 3e424c24f5c7064992c469439a0049f040ef038c..57d14448eab5a9f1fba8ae6a5730ee66
  import java.util.ArrayList;
  import java.util.List;
  import java.util.Map;
-@@ -50,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.fail;
- /**
-  * Ensures that packet can be written and read correctly.
-  */
-+//Microtus - update java keyword usage
- public class PacketWriteReadTest {
-     private static final List<ServerPacket> SERVER_PACKETS = new ArrayList<>();
-     private static final List<ClientPacket> CLIENT_PACKETS = new ArrayList<>();
-@@ -148,12 +136,12 @@ public class PacketWriteReadTest {
+@@ -148,12 +135,12 @@ public class PacketWriteReadTest {
      }
  
      @Test
@@ -6217,15 +6045,14 @@ index 3e424c24f5c7064992c469439a0049f040ef038c..57d14448eab5a9f1fba8ae6a5730ee66
      }
  
 diff --git a/src/test/java/net/minestom/server/network/SendablePacketTest.java b/src/test/java/net/minestom/server/network/SendablePacketTest.java
-index e1f05206055e80600e5fc3dcfb45599c081ab337..831a922cbc0f3256a4114f2df12a9227d03963c9 100644
+index e1f05206055e80600e5fc3dcfb45599c081ab337..05527ae21b137891c54990d8a76f577bb47ad91b 100644
 --- a/src/test/java/net/minestom/server/network/SendablePacketTest.java
 +++ b/src/test/java/net/minestom/server/network/SendablePacketTest.java
-@@ -11,10 +11,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
+@@ -11,10 +11,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class SendablePacketTest {
-+//Microtus - update java keyword usage
 +class SendablePacketTest {
  
      @Test
@@ -6234,7 +6061,7 @@ index e1f05206055e80600e5fc3dcfb45599c081ab337..831a922cbc0f3256a4114f2df12a9227
          var packet = new SystemChatPacket(Component.text("Hello World!"), false);
          AtomicBoolean called = new AtomicBoolean(false);
          var lazy = new LazyPacket(() -> {
-@@ -27,7 +28,7 @@ public class SendablePacketTest {
+@@ -27,7 +27,7 @@ public class SendablePacketTest {
      }
  
      @Test
@@ -6244,15 +6071,14 @@ index e1f05206055e80600e5fc3dcfb45599c081ab337..831a922cbc0f3256a4114f2df12a9227
          var cached = new CachedPacket(packet);
          assertSame(packet, cached.packet());
 diff --git a/src/test/java/net/minestom/server/network/SocketReadTest.java b/src/test/java/net/minestom/server/network/SocketReadTest.java
-index 0f168ab61b905901d8aaca71d16526bcd8473d42..0e97d1e73c3fe60549fb202438a75a5a606f315e 100644
+index 0f168ab61b905901d8aaca71d16526bcd8473d42..b86f9f16335d294f5ab0fe2b8211713aa99ad052 100644
 --- a/src/test/java/net/minestom/server/network/SocketReadTest.java
 +++ b/src/test/java/net/minestom/server/network/SocketReadTest.java
-@@ -16,11 +16,12 @@ import java.util.zip.DataFormatException;
+@@ -16,11 +16,11 @@ import java.util.zip.DataFormatException;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class SocketReadTest {
-+//Microtus - update java keyword usage
 +class SocketReadTest {
  
      @ParameterizedTest
@@ -6262,7 +6088,7 @@ index 0f168ab61b905901d8aaca71d16526bcd8473d42..0e97d1e73c3fe60549fb202438a75a5a
          var packet = new ClientPluginMessagePacket("channel", new byte[2000]);
  
          var buffer = ObjectPool.PACKET_POOL.get();
-@@ -44,7 +45,7 @@ public class SocketReadTest {
+@@ -44,7 +44,7 @@ public class SocketReadTest {
  
      @ParameterizedTest
      @ValueSource(booleans = {false, true})
@@ -6271,7 +6097,7 @@ index 0f168ab61b905901d8aaca71d16526bcd8473d42..0e97d1e73c3fe60549fb202438a75a5a
          var packet = new ClientPluginMessagePacket("channel", new byte[2000]);
  
          var buffer = ObjectPool.PACKET_POOL.get();
-@@ -70,7 +71,7 @@ public class SocketReadTest {
+@@ -70,7 +70,7 @@ public class SocketReadTest {
  
      @ParameterizedTest
      @ValueSource(booleans = {false, true})
@@ -6280,7 +6106,7 @@ index 0f168ab61b905901d8aaca71d16526bcd8473d42..0e97d1e73c3fe60549fb202438a75a5a
          // Write a complete packet then the next packet length without any payload
  
          var packet = new ClientPluginMessagePacket("channel", new byte[2000]);
-@@ -98,7 +99,7 @@ public class SocketReadTest {
+@@ -98,7 +98,7 @@ public class SocketReadTest {
  
      @ParameterizedTest
      @ValueSource(booleans = {false, true})
@@ -6290,20 +6116,19 @@ index 0f168ab61b905901d8aaca71d16526bcd8473d42..0e97d1e73c3fe60549fb202438a75a5a
  
          var packet = new ClientPluginMessagePacket("channel", new byte[2000]);
 diff --git a/src/test/java/net/minestom/server/network/SocketWriteTest.java b/src/test/java/net/minestom/server/network/SocketWriteTest.java
-index 1202eeb1f2e1d9d11f82ddd99e9da43dec5d2f96..674d72f5879d9f7e2bf695e6590dbbfb3011b102 100644
+index 1202eeb1f2e1d9d11f82ddd99e9da43dec5d2f96..8f8aee350f584b5ef886f8529f56f21fa922be12 100644
 --- a/src/test/java/net/minestom/server/network/SocketWriteTest.java
 +++ b/src/test/java/net/minestom/server/network/SocketWriteTest.java
-@@ -14,7 +14,8 @@ import static net.minestom.server.network.NetworkBuffer.STRING;
+@@ -14,7 +14,7 @@ import static net.minestom.server.network.NetworkBuffer.STRING;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNotEquals;
  
 -public class SocketWriteTest {
-+//Microtus - update java keyword usage
 +class SocketWriteTest {
  
      record IntPacket(int value) implements ServerPacket {
          @Override
-@@ -41,7 +42,7 @@ public class SocketWriteTest {
+@@ -41,7 +41,7 @@ public class SocketWriteTest {
      }
  
      @Test
@@ -6312,7 +6137,7 @@ index 1202eeb1f2e1d9d11f82ddd99e9da43dec5d2f96..674d72f5879d9f7e2bf695e6590dbbfb
          var packet = new IntPacket(5);
  
          var buffer = ObjectPool.PACKET_POOL.get();
-@@ -53,7 +54,7 @@ public class SocketWriteTest {
+@@ -53,7 +53,7 @@ public class SocketWriteTest {
      }
  
      @Test
@@ -6321,7 +6146,7 @@ index 1202eeb1f2e1d9d11f82ddd99e9da43dec5d2f96..674d72f5879d9f7e2bf695e6590dbbfb
          var packet = new IntPacket(5);
  
          var buffer = ObjectPool.PACKET_POOL.get();
-@@ -66,7 +67,7 @@ public class SocketWriteTest {
+@@ -66,7 +66,7 @@ public class SocketWriteTest {
      }
  
      @Test
@@ -6330,7 +6155,7 @@ index 1202eeb1f2e1d9d11f82ddd99e9da43dec5d2f96..674d72f5879d9f7e2bf695e6590dbbfb
          var string = "Hello world!".repeat(200);
          var stringLength = string.getBytes(StandardCharsets.UTF_8).length;
          var lengthLength = Utils.getVarIntSize(stringLength);
-@@ -82,7 +83,7 @@ public class SocketWriteTest {
+@@ -82,7 +82,7 @@ public class SocketWriteTest {
      }
  
      @Test
@@ -6339,7 +6164,7 @@ index 1202eeb1f2e1d9d11f82ddd99e9da43dec5d2f96..674d72f5879d9f7e2bf695e6590dbbfb
          var packet = new IntPacket(5);
  
          var buffer = ObjectPool.PACKET_POOL.get();
-@@ -94,7 +95,7 @@ public class SocketWriteTest {
+@@ -94,7 +94,7 @@ public class SocketWriteTest {
      }
  
      @Test
@@ -6349,15 +6174,14 @@ index 1202eeb1f2e1d9d11f82ddd99e9da43dec5d2f96..674d72f5879d9f7e2bf695e6590dbbfb
  
          var buffer = ObjectPool.PACKET_POOL.get();
 diff --git a/src/test/java/net/minestom/server/network/socket/ServerAddressTest.java b/src/test/java/net/minestom/server/network/socket/ServerAddressTest.java
-index 1836cf2b698dbbc8004a3a168448f1e13f3edd92..a922911e74f2efd98bdfa3954291005cd6b861f6 100644
+index 1836cf2b698dbbc8004a3a168448f1e13f3edd92..75680c92345e95f46e0528e618080f3217315381 100644
 --- a/src/test/java/net/minestom/server/network/socket/ServerAddressTest.java
 +++ b/src/test/java/net/minestom/server/network/socket/ServerAddressTest.java
-@@ -10,10 +10,11 @@ import java.nio.file.Files;
+@@ -10,10 +10,10 @@ import java.nio.file.Files;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class ServerAddressTest {
-+//Microtus - update java keyword usage
 +class ServerAddressTest {
  
      @Test
@@ -6366,7 +6190,7 @@ index 1836cf2b698dbbc8004a3a168448f1e13f3edd92..a922911e74f2efd98bdfa3954291005c
          InetSocketAddress address = new InetSocketAddress("localhost", 25565);
          var server = new Server(new PacketProcessor());
          server.init(address);
-@@ -26,7 +27,7 @@ public class ServerAddressTest {
+@@ -26,7 +26,7 @@ public class ServerAddressTest {
      }
  
      @Test
@@ -6375,7 +6199,7 @@ index 1836cf2b698dbbc8004a3a168448f1e13f3edd92..a922911e74f2efd98bdfa3954291005c
          InetSocketAddress address = new InetSocketAddress("localhost", 0);
          var server = new Server(new PacketProcessor());
          server.init(address);
-@@ -39,7 +40,7 @@ public class ServerAddressTest {
+@@ -39,7 +39,7 @@ public class ServerAddressTest {
      }
  
      @Test
@@ -6384,7 +6208,7 @@ index 1836cf2b698dbbc8004a3a168448f1e13f3edd92..a922911e74f2efd98bdfa3954291005c
          UnixDomainSocketAddress address = UnixDomainSocketAddress.of("minestom.sock");
          var server = new Server(new PacketProcessor());
          server.init(address);
-@@ -54,7 +55,7 @@ public class ServerAddressTest {
+@@ -54,7 +54,7 @@ public class ServerAddressTest {
      }
  
      @Test
@@ -6394,15 +6218,14 @@ index 1836cf2b698dbbc8004a3a168448f1e13f3edd92..a922911e74f2efd98bdfa3954291005c
          assertDoesNotThrow(server::stop);
      }
 diff --git a/src/test/java/net/minestom/server/permission/TestPermissions.java b/src/test/java/net/minestom/server/permission/TestPermissions.java
-index c5604540d92ca2b579b79a8b2f1c33c89d5efe80..133796acdbce4a892f66d3d11aae597be1abd929 100644
+index c5604540d92ca2b579b79a8b2f1c33c89d5efe80..38c785b7dcf897634932897a538de40534b2f529 100644
 --- a/src/test/java/net/minestom/server/permission/TestPermissions.java
 +++ b/src/test/java/net/minestom/server/permission/TestPermissions.java
-@@ -14,14 +14,15 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
+@@ -14,14 +14,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  import static org.junit.jupiter.api.Assertions.assertTrue;
  
  // TODO: more tests
 -public class TestPermissions {
-+//Microtus - update java keyword usage
 +class TestPermissions {
  
      private Player player;
@@ -6415,7 +6238,7 @@ index c5604540d92ca2b579b79a8b2f1c33c89d5efe80..133796acdbce4a892f66d3d11aae597b
          MinecraftServer.init(); // for entity manager
          player = new Player(UUID.randomUUID(), "TestPlayer", null) {
              @Override
-@@ -49,13 +50,13 @@ public class TestPermissions {
+@@ -49,13 +49,13 @@ public class TestPermissions {
      }
  
      @Test
@@ -6431,7 +6254,7 @@ index c5604540d92ca2b579b79a8b2f1c33c89d5efe80..133796acdbce4a892f66d3d11aae597b
  
          assertFalse(player.hasPermission(permission1));
          player.addPermission(permission1);
-@@ -67,7 +68,7 @@ public class TestPermissions {
+@@ -67,7 +67,7 @@ public class TestPermissions {
      }
  
      @Test
@@ -6440,7 +6263,7 @@ index c5604540d92ca2b579b79a8b2f1c33c89d5efe80..133796acdbce4a892f66d3d11aae597b
          player.addPermission(permission1);
          assertTrue(player.hasPermission("perm.name"));
          assertTrue(player.hasPermission("perm.name",
-@@ -81,7 +82,7 @@ public class TestPermissions {
+@@ -81,7 +81,7 @@ public class TestPermissions {
      }
  
      @Test
@@ -6449,7 +6272,7 @@ index c5604540d92ca2b579b79a8b2f1c33c89d5efe80..133796acdbce4a892f66d3d11aae597b
          Permission permission = new Permission("foo.b*r.baz");
          Permission match = new Permission("foo.baaar.baz");
          Permission match2 = new Permission("foo.br.baz");
-@@ -105,7 +106,7 @@ public class TestPermissions {
+@@ -105,7 +105,7 @@ public class TestPermissions {
      }
  
      @Test
@@ -6458,7 +6281,7 @@ index c5604540d92ca2b579b79a8b2f1c33c89d5efe80..133796acdbce4a892f66d3d11aae597b
          Permission permission = new Permission("foo.b*");
          Permission match = new Permission("foo.baaar.baz");
          Permission match2 = new Permission("foo.b");
-@@ -129,7 +130,7 @@ public class TestPermissions {
+@@ -129,7 +129,7 @@ public class TestPermissions {
      }
  
      @Test
@@ -6467,7 +6290,7 @@ index c5604540d92ca2b579b79a8b2f1c33c89d5efe80..133796acdbce4a892f66d3d11aae597b
          assertFalse(player.hasPermission(permission2));
          assertFalse(player.hasPermission(permission3));
          player.addPermission(wildcard);
-@@ -138,7 +139,7 @@ public class TestPermissions {
+@@ -138,7 +138,7 @@ public class TestPermissions {
      }
  
      @AfterEach
@@ -6477,14 +6300,12 @@ index c5604540d92ca2b579b79a8b2f1c33c89d5efe80..133796acdbce4a892f66d3d11aae597b
      }
  }
 diff --git a/src/test/java/net/minestom/server/snapshot/ChunkSnapshotIntegrationTest.java b/src/test/java/net/minestom/server/snapshot/ChunkSnapshotIntegrationTest.java
-index 6f0809d0cbabffda885bea76a0eb8a8c9cefaf77..b7a3bc80f7d745cf3736b55abb2d08bb9b2af4eb 100644
+index 6f0809d0cbabffda885bea76a0eb8a8c9cefaf77..35ffcf8aa1139c530ce37ff34b9412795abd4d3b 100644
 --- a/src/test/java/net/minestom/server/snapshot/ChunkSnapshotIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/snapshot/ChunkSnapshotIntegrationTest.java
-@@ -7,11 +7,12 @@ import org.junit.jupiter.api.Test;
- 
+@@ -8,10 +8,10 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class ChunkSnapshotIntegrationTest {
 +class ChunkSnapshotIntegrationTest {
@@ -6496,14 +6317,12 @@ index 6f0809d0cbabffda885bea76a0eb8a8c9cefaf77..b7a3bc80f7d745cf3736b55abb2d08bb
          instance.setBlock(0, 0, 0, Block.STONE);
          var snapshot = ServerSnapshot.update();
 diff --git a/src/test/java/net/minestom/server/snapshot/EntitySnapshotIntegrationTest.java b/src/test/java/net/minestom/server/snapshot/EntitySnapshotIntegrationTest.java
-index 734b3c8889285b157dc081061db3cdd161ad40bc..473191437cfa99dde50c0b554d53fcd1673b0a9c 100644
+index 734b3c8889285b157dc081061db3cdd161ad40bc..c471c4873159e18d10db004fdb03a1fa2c0c1c08 100644
 --- a/src/test/java/net/minestom/server/snapshot/EntitySnapshotIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/snapshot/EntitySnapshotIntegrationTest.java
-@@ -9,11 +9,12 @@ import org.junit.jupiter.api.Test;
- import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -10,10 +10,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class EntitySnapshotIntegrationTest {
 +class EntitySnapshotIntegrationTest {
@@ -6515,14 +6334,12 @@ index 734b3c8889285b157dc081061db3cdd161ad40bc..473191437cfa99dde50c0b554d53fcd1
          var ent = new Entity(EntityType.ZOMBIE);
          ent.setInstance(instance).join();
 diff --git a/src/test/java/net/minestom/server/snapshot/InstanceSnapshotIntegrationTest.java b/src/test/java/net/minestom/server/snapshot/InstanceSnapshotIntegrationTest.java
-index 7863e30ea16ca00b351222b71f731836792c4e27..f7f27d631c780d7f14850c1cd7da023933844c45 100644
+index 7863e30ea16ca00b351222b71f731836792c4e27..973a3401ae0aae9e97dde19c11db9cf12754e73d 100644
 --- a/src/test/java/net/minestom/server/snapshot/InstanceSnapshotIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/snapshot/InstanceSnapshotIntegrationTest.java
-@@ -6,11 +6,12 @@ import org.junit.jupiter.api.Test;
- 
+@@ -7,10 +7,10 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class InstanceSnapshotIntegrationTest {
 +class InstanceSnapshotIntegrationTest {
@@ -6534,15 +6351,14 @@ index 7863e30ea16ca00b351222b71f731836792c4e27..f7f27d631c780d7f14850c1cd7da0239
          var snapshot = ServerSnapshot.update();
  
 diff --git a/src/test/java/net/minestom/server/tag/TagComponentTest.java b/src/test/java/net/minestom/server/tag/TagComponentTest.java
-index 44c126e1795196110fc799a7d5cf5d8536cf393d..f4e89d8e339f88cf84719d6ea38378071d343b4d 100644
+index 44c126e1795196110fc799a7d5cf5d8536cf393d..55a37fd275dd3a1bf92476c21124f7df778d5c62 100644
 --- a/src/test/java/net/minestom/server/tag/TagComponentTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagComponentTest.java
-@@ -6,10 +6,11 @@ import org.junit.jupiter.api.Test;
+@@ -6,10 +6,10 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
 -public class TagComponentTest {
-+//Microtus - update java keyword usage
 +class TagComponentTest {
  
      @Test
@@ -6551,7 +6367,7 @@ index 44c126e1795196110fc799a7d5cf5d8536cf393d..f4e89d8e339f88cf84719d6ea3837807
          var component = Component.text("Hey");
          var tag = Tag.Component("component");
          var handler = TagHandler.newHandler();
-@@ -18,14 +19,14 @@ public class TagComponentTest {
+@@ -18,14 +18,14 @@ public class TagComponentTest {
      }
  
      @Test
@@ -6568,7 +6384,7 @@ index 44c126e1795196110fc799a7d5cf5d8536cf393d..f4e89d8e339f88cf84719d6ea3837807
          var tag = Tag.Component("entry");
          var handler = TagHandler.newHandler();
          handler.setTag(Tag.Integer("entry"), 1);
-@@ -33,7 +34,7 @@ public class TagComponentTest {
+@@ -33,7 +33,7 @@ public class TagComponentTest {
      }
  
      @Test
@@ -6578,15 +6394,14 @@ index 44c126e1795196110fc799a7d5cf5d8536cf393d..f4e89d8e339f88cf84719d6ea3837807
          var tag = Tag.Component("component");
          var handler = TagHandler.newHandler();
 diff --git a/src/test/java/net/minestom/server/tag/TagEqualityTest.java b/src/test/java/net/minestom/server/tag/TagEqualityTest.java
-index 79905d4ee8e881b547e8c754ad1f1838f30e7f55..960456c44e8e35761e328a1638a89f3497ed05d8 100644
+index 79905d4ee8e881b547e8c754ad1f1838f30e7f55..5bba1cbbbc77a12eab24abd0b5efb4297569f67e 100644
 --- a/src/test/java/net/minestom/server/tag/TagEqualityTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagEqualityTest.java
-@@ -5,10 +5,11 @@ import org.junit.jupiter.api.Test;
+@@ -5,10 +5,10 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNotEquals;
  
 -public class TagEqualityTest {
-+//Microtus - update java keyword usage
 +class TagEqualityTest {
  
      @Test
@@ -6595,7 +6410,7 @@ index 79905d4ee8e881b547e8c754ad1f1838f30e7f55..960456c44e8e35761e328a1638a89f34
          var tag1 = Tag.Integer("key");
          var tag2 = Tag.Integer("key");
          assertEquals(tag1, tag1);
-@@ -17,49 +18,49 @@ public class TagEqualityTest {
+@@ -17,49 +17,49 @@ public class TagEqualityTest {
      }
  
      @Test
@@ -6653,15 +6468,14 @@ index 79905d4ee8e881b547e8c754ad1f1838f30e7f55..960456c44e8e35761e328a1638a89f34
          var tag2 = Tag.Integer("key").path("path");
          assertNotEquals(tag1, tag2);
 diff --git a/src/test/java/net/minestom/server/tag/TagHandlerCopyTest.java b/src/test/java/net/minestom/server/tag/TagHandlerCopyTest.java
-index 11b8660c3502e61735195931bd24377d773f7bbc..48f8d5f8375b04fede5fab3386eaa0352db645c4 100644
+index 11b8660c3502e61735195931bd24377d773f7bbc..aca9523ad96a04af17b301257a46c26ac723582a 100644
 --- a/src/test/java/net/minestom/server/tag/TagHandlerCopyTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagHandlerCopyTest.java
-@@ -6,10 +6,11 @@ import static net.minestom.testing.TestUtils.assertEqualsSNBT;
+@@ -6,10 +6,10 @@ import static net.minestom.testing.TestUtils.assertEqualsSNBT;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
 -public class TagHandlerCopyTest {
-+//Microtus - update java keyword usage
 +class TagHandlerCopyTest {
  
      @Test
@@ -6670,7 +6484,7 @@ index 11b8660c3502e61735195931bd24377d773f7bbc..48f8d5f8375b04fede5fab3386eaa035
          var handler = TagHandler.newHandler();
          handler.setTag(Tag.String("key"), "test");
  
-@@ -18,7 +19,7 @@ public class TagHandlerCopyTest {
+@@ -18,7 +18,7 @@ public class TagHandlerCopyTest {
      }
  
      @Test
@@ -6679,7 +6493,7 @@ index 11b8660c3502e61735195931bd24377d773f7bbc..48f8d5f8375b04fede5fab3386eaa035
          var tag = Tag.String("key").path("path");
          var handler = TagHandler.newHandler();
          handler.setTag(tag, "test");
-@@ -43,7 +44,7 @@ public class TagHandlerCopyTest {
+@@ -43,7 +43,7 @@ public class TagHandlerCopyTest {
      }
  
      @Test
@@ -6688,7 +6502,7 @@ index 11b8660c3502e61735195931bd24377d773f7bbc..48f8d5f8375b04fede5fab3386eaa035
          var tag = Tag.String("key");
          var handler = TagHandler.newHandler();
          handler.setTag(tag, "test");
-@@ -71,7 +72,7 @@ public class TagHandlerCopyTest {
+@@ -71,7 +71,7 @@ public class TagHandlerCopyTest {
      }
  
      @Test
@@ -6698,15 +6512,14 @@ index 11b8660c3502e61735195931bd24377d773f7bbc..48f8d5f8375b04fede5fab3386eaa035
          TagHandler handlerCopy;
          for (int i = 0; i < 1000; i++) {
 diff --git a/src/test/java/net/minestom/server/tag/TagHandlerReadableCopyTest.java b/src/test/java/net/minestom/server/tag/TagHandlerReadableCopyTest.java
-index 90d4a6466541c6aeb3f0d0ac75201c1ef7c7507f..501f7c905b755b590199083fb90e7df16df5f992 100644
+index 90d4a6466541c6aeb3f0d0ac75201c1ef7c7507f..82774de7c0083501796f42b3cc11c8a36b8d44a1 100644
 --- a/src/test/java/net/minestom/server/tag/TagHandlerReadableCopyTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagHandlerReadableCopyTest.java
-@@ -6,10 +6,11 @@ import static net.minestom.testing.TestUtils.assertEqualsSNBT;
+@@ -6,10 +6,10 @@ import static net.minestom.testing.TestUtils.assertEqualsSNBT;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertSame;
  
 -public class TagHandlerReadableCopyTest {
-+//Microtus - update java keyword usage
 +class TagHandlerReadableCopyTest {
  
      @Test
@@ -6715,7 +6528,7 @@ index 90d4a6466541c6aeb3f0d0ac75201c1ef7c7507f..501f7c905b755b590199083fb90e7df1
          var tag = Tag.String("key");
          var handler = TagHandler.newHandler();
          handler.setTag(tag, "test");
-@@ -23,7 +24,7 @@ public class TagHandlerReadableCopyTest {
+@@ -23,7 +23,7 @@ public class TagHandlerReadableCopyTest {
      }
  
      @Test
@@ -6724,7 +6537,7 @@ index 90d4a6466541c6aeb3f0d0ac75201c1ef7c7507f..501f7c905b755b590199083fb90e7df1
          var tag = Tag.String("key").path("path");
          var handler = TagHandler.newHandler();
          handler.setTag(tag, "test");
-@@ -38,14 +39,14 @@ public class TagHandlerReadableCopyTest {
+@@ -38,14 +38,14 @@ public class TagHandlerReadableCopyTest {
      }
  
      @Test
@@ -6742,15 +6555,14 @@ index 90d4a6466541c6aeb3f0d0ac75201c1ef7c7507f..501f7c905b755b590199083fb90e7df1
          var handler = TagHandler.newHandler();
          handler.setTag(tag, "test");
 diff --git a/src/test/java/net/minestom/server/tag/TagItemTest.java b/src/test/java/net/minestom/server/tag/TagItemTest.java
-index d3ab11a63bb4bec693621031c0b2fa711ef10e4b..b57cdfc40e9fba4fed7f5b15ea2605aec245f36e 100644
+index d3ab11a63bb4bec693621031c0b2fa711ef10e4b..862ab326cef5bb0ac14a91ef7b94c31720e7a263 100644
 --- a/src/test/java/net/minestom/server/tag/TagItemTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagItemTest.java
-@@ -11,10 +11,11 @@ import static net.minestom.testing.TestUtils.waitUntilCleared;
+@@ -11,10 +11,10 @@ import static net.minestom.testing.TestUtils.waitUntilCleared;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
 -public class TagItemTest {
-+//Microtus - update java keyword usage
 +class TagItemTest {
  
      @Test
@@ -6759,7 +6571,7 @@ index d3ab11a63bb4bec693621031c0b2fa711ef10e4b..b57cdfc40e9fba4fed7f5b15ea2605ae
          var item = ItemStack.of(Material.DIAMOND);
          var tag = Tag.ItemStack("item");
          var handler = TagHandler.newHandler();
-@@ -24,7 +25,7 @@ public class TagItemTest {
+@@ -24,7 +24,7 @@ public class TagItemTest {
      }
  
      @Test
@@ -6768,7 +6580,7 @@ index d3ab11a63bb4bec693621031c0b2fa711ef10e4b..b57cdfc40e9fba4fed7f5b15ea2605ae
          var item = ItemStack.of(Material.DIAMOND);
          var handler = TagHandler.newHandler();
          handler.setTag(Tag.ItemStack("item"), item);
-@@ -33,7 +34,7 @@ public class TagItemTest {
+@@ -33,7 +33,7 @@ public class TagItemTest {
      }
  
      @Test
@@ -6777,7 +6589,7 @@ index d3ab11a63bb4bec693621031c0b2fa711ef10e4b..b57cdfc40e9fba4fed7f5b15ea2605ae
          var item = ItemStack.of(Material.DIAMOND);
          var tag = Tag.ItemStack("item");
          var handler = TagHandler.newHandler();
-@@ -45,7 +46,7 @@ public class TagItemTest {
+@@ -45,7 +45,7 @@ public class TagItemTest {
      }
  
      @Test
@@ -6786,7 +6598,7 @@ index d3ab11a63bb4bec693621031c0b2fa711ef10e4b..b57cdfc40e9fba4fed7f5b15ea2605ae
          var item = ItemStack.of(Material.DIAMOND);
          var tag = Tag.ItemStack("item");
          var handler = TagHandler.newHandler();
-@@ -60,7 +61,7 @@ public class TagItemTest {
+@@ -60,7 +60,7 @@ public class TagItemTest {
      }
  
      @Test
@@ -6795,7 +6607,7 @@ index d3ab11a63bb4bec693621031c0b2fa711ef10e4b..b57cdfc40e9fba4fed7f5b15ea2605ae
          var item = ItemStack.of(Material.DIAMOND);
          var item2 = ItemStack.of(Material.DIAMOND, 2);
          var handler = TagHandler.newHandler();
-@@ -73,7 +74,7 @@ public class TagItemTest {
+@@ -73,7 +73,7 @@ public class TagItemTest {
      }
  
      @Test
@@ -6804,7 +6616,7 @@ index d3ab11a63bb4bec693621031c0b2fa711ef10e4b..b57cdfc40e9fba4fed7f5b15ea2605ae
          var item = ItemStack.of(Material.DIAMOND);
          var item2 = ItemStack.of(Material.DIAMOND, 2);
          var handler = TagHandler.newHandler();
-@@ -95,7 +96,7 @@ public class TagItemTest {
+@@ -95,7 +95,7 @@ public class TagItemTest {
      }
  
      @Test
@@ -6814,15 +6626,14 @@ index d3ab11a63bb4bec693621031c0b2fa711ef10e4b..b57cdfc40e9fba4fed7f5b15ea2605ae
          var tag = Tag.ItemStack("item");
          handler.setTag(tag, ItemStack.of(Material.DIAMOND));
 diff --git a/src/test/java/net/minestom/server/tag/TagListTest.java b/src/test/java/net/minestom/server/tag/TagListTest.java
-index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..04e4f4d515d5900acdb45367ef62bc795485f4fa 100644
+index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..ae025e28379b91947e6d665d2d788f3eb5c6d106 100644
 --- a/src/test/java/net/minestom/server/tag/TagListTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagListTest.java
-@@ -9,10 +9,11 @@ import java.util.List;
+@@ -9,10 +9,10 @@ import java.util.List;
  import static net.minestom.testing.TestUtils.assertEqualsSNBT;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class TagListTest {
-+//Microtus - update java keyword usage
 +class TagListTest {
  
      @Test
@@ -6831,7 +6642,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..04e4f4d515d5900acdb45367ef62bc79
          var handler = TagHandler.newHandler();
          Tag<Integer> tag = Tag.Integer("number");
          Tag<List<Integer>> list = tag.list();
-@@ -27,7 +28,7 @@ public class TagListTest {
+@@ -27,7 +27,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6840,7 +6651,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..04e4f4d515d5900acdb45367ef62bc79
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("number").list();
          var val = List.of(1, 2, 3);
-@@ -37,7 +38,7 @@ public class TagListTest {
+@@ -37,7 +37,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6849,7 +6660,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..04e4f4d515d5900acdb45367ef62bc79
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("number").list().list();
          var val = List.of(List.of(1, 2, 3), List.of(4, 5, 6));
-@@ -49,7 +50,7 @@ public class TagListTest {
+@@ -49,7 +49,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6858,7 +6669,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..04e4f4d515d5900acdb45367ef62bc79
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("number").list().list();
          var val = List.of(List.of(1, 2, 3), new ArrayList<>(Arrays.asList(4, 5, 6)));
-@@ -62,7 +63,7 @@ public class TagListTest {
+@@ -62,7 +62,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6867,7 +6678,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..04e4f4d515d5900acdb45367ef62bc79
          var handler = TagHandler.newHandler();
          Tag<List<Integer>> tag = Tag.Integer("numbers").list();
  
-@@ -75,7 +76,7 @@ public class TagListTest {
+@@ -75,7 +75,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6876,7 +6687,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..04e4f4d515d5900acdb45367ef62bc79
          var handler = TagHandler.newHandler();
          Tag<List<Integer>> tag = Tag.Integer("numbers").list();
          handler.setTag(tag, List.of());
-@@ -83,7 +84,7 @@ public class TagListTest {
+@@ -83,7 +83,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6885,7 +6696,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..04e4f4d515d5900acdb45367ef62bc79
          var handler = TagHandler.newHandler();
          Tag<List<Integer>> tag = Tag.Integer("numbers").list();
          handler.setTag(tag, List.of());
-@@ -95,7 +96,7 @@ public class TagListTest {
+@@ -95,7 +95,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6894,7 +6705,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..04e4f4d515d5900acdb45367ef62bc79
          var handler = TagHandler.newHandler();
          Tag<List<Integer>> tag = Tag.Integer("numbers").list();
          handler.setTag(tag, List.of(1));
-@@ -105,7 +106,7 @@ public class TagListTest {
+@@ -105,7 +105,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6903,7 +6714,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..04e4f4d515d5900acdb45367ef62bc79
          var handler = TagHandler.newHandler();
          Tag<List<Integer>> tag = Tag.Integer("numbers").list();
          handler.setTag(tag, List.of(1));
-@@ -119,7 +120,7 @@ public class TagListTest {
+@@ -119,7 +119,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6912,7 +6723,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..04e4f4d515d5900acdb45367ef62bc79
          var handler = TagHandler.newHandler();
          Tag<List<List<Integer>>> tag = Tag.Integer("numbers").list().list();
          var integers = List.of(List.of(1, 2, 3), List.of(4, 5, 6));
-@@ -130,7 +131,7 @@ public class TagListTest {
+@@ -130,7 +130,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6921,7 +6732,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..04e4f4d515d5900acdb45367ef62bc79
          var handler = TagHandler.newHandler();
          Tag<List<List<Integer>>> tag = Tag.Integer("numbers").list().list();
          var integers = List.of(List.of(1, 2, 3), List.of(4, 5, 6));
-@@ -148,7 +149,7 @@ public class TagListTest {
+@@ -148,7 +148,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6930,7 +6741,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..04e4f4d515d5900acdb45367ef62bc79
          var handler = TagHandler.newHandler();
          var val = List.of(1, 2, 3);
          var tag = Tag.Integer("number").list().defaultValue(val);
-@@ -156,7 +157,7 @@ public class TagListTest {
+@@ -156,7 +156,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6939,7 +6750,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..04e4f4d515d5900acdb45367ef62bc79
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("number").defaultValue(5);
          var list = tag.list();
-@@ -165,7 +166,7 @@ public class TagListTest {
+@@ -165,7 +165,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6948,7 +6759,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..04e4f4d515d5900acdb45367ef62bc79
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("number").list();
          List<Integer> val = new ArrayList<>();
-@@ -181,7 +182,7 @@ public class TagListTest {
+@@ -181,7 +181,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6957,7 +6768,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..04e4f4d515d5900acdb45367ef62bc79
          var handler = TagHandler.newHandler();
          Tag<List<List<Integer>>> tag = Tag.Integer("numbers").list().list();
          List<List<Integer>> val = new ArrayList<>();
-@@ -201,7 +202,7 @@ public class TagListTest {
+@@ -201,7 +201,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6966,7 +6777,7 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..04e4f4d515d5900acdb45367ef62bc79
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("numbers").list();
          List<Integer> val = new ArrayList<>();
-@@ -223,7 +224,7 @@ public class TagListTest {
+@@ -223,7 +223,7 @@ public class TagListTest {
      }
  
      @Test
@@ -6976,15 +6787,14 @@ index 28ba07d2c86e65d0bb4d2640aab7dca01a6a3756..04e4f4d515d5900acdb45367ef62bc79
          Tag<List<List<Integer>>> tag = Tag.Integer("numbers").list().list();
          List<List<Integer>> val = new ArrayList<>();
 diff --git a/src/test/java/net/minestom/server/tag/TagMapTest.java b/src/test/java/net/minestom/server/tag/TagMapTest.java
-index 08595008d38f29988b368940439c46f1994d1a5a..e658dec07e3a3955ce0338bc782b4bde8a4604fd 100644
+index 08595008d38f29988b368940439c46f1994d1a5a..c2ea9ead15f1e86dfc31829c1b8cc234ce9bba8f 100644
 --- a/src/test/java/net/minestom/server/tag/TagMapTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagMapTest.java
-@@ -5,13 +5,14 @@ import org.junit.jupiter.api.Test;
+@@ -5,13 +5,13 @@ import org.junit.jupiter.api.Test;
  import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNull;
  
 -public class TagMapTest {
-+//Microtus - update java keyword usage
 +class TagMapTest {
  
      private record Entry(int value) {
@@ -6996,7 +6806,7 @@ index 08595008d38f29988b368940439c46f1994d1a5a..e658dec07e3a3955ce0338bc782b4bde
          var handler = TagHandler.newHandler();
          var intTag = Tag.Integer("key");
          var tag = intTag.map(Entry::new, Entry::value);
-@@ -22,7 +23,7 @@ public class TagMapTest {
+@@ -22,7 +22,7 @@ public class TagMapTest {
      }
  
      @Test
@@ -7005,7 +6815,7 @@ index 08595008d38f29988b368940439c46f1994d1a5a..e658dec07e3a3955ce0338bc782b4bde
          var handler = TagHandler.newHandler();
          var intTag = Tag.Integer("key");
          var tag = intTag.map(Entry::new, Entry::value);
-@@ -35,7 +36,7 @@ public class TagMapTest {
+@@ -35,7 +35,7 @@ public class TagMapTest {
      }
  
      @Test
@@ -7015,15 +6825,14 @@ index 08595008d38f29988b368940439c46f1994d1a5a..e658dec07e3a3955ce0338bc782b4bde
          var tag = Tag.Integer("key").map(Entry::new, Entry::value);
          assertNull(handler.getTag(tag));
 diff --git a/src/test/java/net/minestom/server/tag/TagNbtSeparatorTest.java b/src/test/java/net/minestom/server/tag/TagNbtSeparatorTest.java
-index 4e9f46c4143323f403ca2d2cf4fb419681323261..3c0056c06d64aa929388dbf3fb1e8ae239c485e7 100644
+index 4e9f46c4143323f403ca2d2cf4fb419681323261..ed0d861d3abf80094695479cfdad7a3b9b960e2d 100644
 --- a/src/test/java/net/minestom/server/tag/TagNbtSeparatorTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagNbtSeparatorTest.java
-@@ -11,10 +11,11 @@ import java.util.Set;
+@@ -11,10 +11,10 @@ import java.util.Set;
  
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
 -public class TagNbtSeparatorTest {
-+//Microtus - update java keyword usage
 +class TagNbtSeparatorTest {
  
      @Test
@@ -7032,7 +6841,7 @@ index 4e9f46c4143323f403ca2d2cf4fb419681323261..3c0056c06d64aa929388dbf3fb1e8ae2
          assertSeparation(new TagNbtSeparator.Entry<>(Tag.Byte("key"), (byte) 1),
                  "key", NBT.Byte(1));
          assertSeparation(new TagNbtSeparator.Entry<>(Tag.Short("key"), (short) 1),
-@@ -30,20 +31,20 @@ public class TagNbtSeparatorTest {
+@@ -30,20 +30,20 @@ public class TagNbtSeparatorTest {
      }
  
      @Test
@@ -7057,15 +6866,14 @@ index 4e9f46c4143323f403ca2d2cf4fb419681323261..3c0056c06d64aa929388dbf3fb1e8ae2
                  "key", NBT.List(NBTType.TAG_Int, NBT.Int(1)));
      }
 diff --git a/src/test/java/net/minestom/server/tag/TagNbtTest.java b/src/test/java/net/minestom/server/tag/TagNbtTest.java
-index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..b96c618d13a0f84f430b61a9296d90b7beca361b 100644
+index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..40c970ef055dec4955fdd93e62f6e9dd58d34a10 100644
 --- a/src/test/java/net/minestom/server/tag/TagNbtTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagNbtTest.java
-@@ -15,10 +15,11 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
+@@ -15,10 +15,10 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
  /**
   * Ensure that NBT tag can be read from other tags properly.
   */
 -public class TagNbtTest {
-+//Microtus - update java keyword usage
 +class TagNbtTest {
  
      @Test
@@ -7074,7 +6882,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..b96c618d13a0f84f430b61a9296d90b7
          var handler = TagHandler.newHandler();
          var tag = Tag.NBT("nbt").list();
          List<NBT> list = List.of(NBT.Int(1), NBT.Int(2), NBT.Int(3));
-@@ -35,7 +36,7 @@ public class TagNbtTest {
+@@ -35,7 +35,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -7083,7 +6891,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..b96c618d13a0f84f430b61a9296d90b7
          var handler = TagHandler.newHandler();
          var tag = Tag.NBT("nbt").map(nbt -> ((NBTInt) nbt).getValue(), NBT::Int);
          handler.setTag(tag, 5);
-@@ -51,7 +52,7 @@ public class TagNbtTest {
+@@ -51,7 +51,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -7092,7 +6900,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..b96c618d13a0f84f430b61a9296d90b7
          var compound = NBT.Compound(Map.of("key", NBT.Int(5)));
          var handler = TagHandler.fromCompound(compound);
          assertEquals(compound, handler.asCompound());
-@@ -71,7 +72,7 @@ public class TagNbtTest {
+@@ -71,7 +71,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -7101,7 +6909,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..b96c618d13a0f84f430b61a9296d90b7
          var compound = NBT.Compound(Map.of("path", NBT.Compound(Map.of("key", NBT.Int(5)))));
          var handler = TagHandler.fromCompound(compound);
          var tag = Tag.Integer("key").path("path");
-@@ -88,7 +89,7 @@ public class TagNbtTest {
+@@ -88,7 +88,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -7110,7 +6918,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..b96c618d13a0f84f430b61a9296d90b7
          var compound = NBT.Compound(Map.of("path", NBT.Compound(Map.of("path2",
                  NBT.Compound(Map.of("key", NBT.Int(5)))))));
          var handler = TagHandler.fromCompound(compound);
-@@ -106,7 +107,7 @@ public class TagNbtTest {
+@@ -106,7 +106,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -7119,7 +6927,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..b96c618d13a0f84f430b61a9296d90b7
          var handler = TagHandler.newHandler();
          var nbtTag = Tag.NBT("path1");
  
-@@ -120,7 +121,7 @@ public class TagNbtTest {
+@@ -120,7 +120,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -7128,7 +6936,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..b96c618d13a0f84f430b61a9296d90b7
          var handler = TagHandler.newHandler();
          var nbtTag = Tag.NBT("path1");
  
-@@ -133,7 +134,7 @@ public class TagNbtTest {
+@@ -133,7 +133,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -7137,7 +6945,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..b96c618d13a0f84f430b61a9296d90b7
          var handler = TagHandler.newHandler();
          var nbtTag = Tag.NBT("compound").path("path");
  
-@@ -146,7 +147,7 @@ public class TagNbtTest {
+@@ -146,7 +146,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -7146,7 +6954,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..b96c618d13a0f84f430b61a9296d90b7
          var handler = TagHandler.newHandler();
          var nbtTag = Tag.NBT("path1");
  
-@@ -159,7 +160,7 @@ public class TagNbtTest {
+@@ -159,7 +159,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -7155,7 +6963,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..b96c618d13a0f84f430b61a9296d90b7
          var handler = TagHandler.newHandler();
          var nbtTag = Tag.NBT("path1");
  
-@@ -174,7 +175,7 @@ public class TagNbtTest {
+@@ -174,7 +174,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -7164,7 +6972,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..b96c618d13a0f84f430b61a9296d90b7
          var handler = TagHandler.newHandler();
          var nbtTag = Tag.NBT("list");
          var list = NBT.List(NBTType.TAG_Int, NBT.Int(1));
-@@ -183,7 +184,7 @@ public class TagNbtTest {
+@@ -183,7 +183,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -7173,7 +6981,7 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..b96c618d13a0f84f430b61a9296d90b7
          var handler = TagHandler.newHandler();
          var nbtTag = Tag.NBT("list");
          var listTag = Tag.Integer("list").list();
-@@ -196,7 +197,7 @@ public class TagNbtTest {
+@@ -196,7 +196,7 @@ public class TagNbtTest {
      }
  
      @Test
@@ -7183,15 +6991,14 @@ index 81fa51a86206fcf2f80dd032ed135e011b3cb0c8..b96c618d13a0f84f430b61a9296d90b7
          var nbtTag = Tag.NBT("array");
          var array = NBT.IntArray(1, 2, 3);
 diff --git a/src/test/java/net/minestom/server/tag/TagPathTest.java b/src/test/java/net/minestom/server/tag/TagPathTest.java
-index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..197e3c394a54395bc41c9e271880dbb114b7526c 100644
+index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..53d6ade4e248c72c811e3057e8e0d42bfeee1190 100644
 --- a/src/test/java/net/minestom/server/tag/TagPathTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagPathTest.java
-@@ -7,10 +7,11 @@ import org.junit.jupiter.api.Test;
+@@ -7,10 +7,10 @@ import org.junit.jupiter.api.Test;
  import static net.minestom.testing.TestUtils.assertEqualsSNBT;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class TagPathTest {
-+//Microtus - update java keyword usage
 +class TagPathTest {
  
      @Test
@@ -7200,7 +7007,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..197e3c394a54395bc41c9e271880dbb1
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("number");
          var path = tag.path("display");
-@@ -28,13 +29,13 @@ public class TagPathTest {
+@@ -28,13 +28,13 @@ public class TagPathTest {
      }
  
      @Test
@@ -7216,7 +7023,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..197e3c394a54395bc41c9e271880dbb1
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("number").path("display");
          handler.removeTag(tag);
-@@ -43,7 +44,7 @@ public class TagPathTest {
+@@ -43,7 +43,7 @@ public class TagPathTest {
      }
  
      @Test
@@ -7225,7 +7032,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..197e3c394a54395bc41c9e271880dbb1
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("number").path("display");
          handler.setTag(tag, 5);
-@@ -60,7 +61,7 @@ public class TagPathTest {
+@@ -60,7 +60,7 @@ public class TagPathTest {
      }
  
      @Test
@@ -7234,7 +7041,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..197e3c394a54395bc41c9e271880dbb1
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("number").path("display");
          var tag1 = Tag.String("string").path("display");
-@@ -90,7 +91,7 @@ public class TagPathTest {
+@@ -90,7 +90,7 @@ public class TagPathTest {
      }
  
      @Test
@@ -7243,7 +7050,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..197e3c394a54395bc41c9e271880dbb1
          var handler = TagHandler.newHandler();
          var numberTag = Tag.Integer("number").path("path1", "path2");
          var stringTag = Tag.String("string").path("path1");
-@@ -118,7 +119,7 @@ public class TagPathTest {
+@@ -118,7 +118,7 @@ public class TagPathTest {
      }
  
      @Test
@@ -7252,7 +7059,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..197e3c394a54395bc41c9e271880dbb1
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("number");
          var path = tag.path("display");
-@@ -150,7 +151,7 @@ public class TagPathTest {
+@@ -150,7 +150,7 @@ public class TagPathTest {
      }
  
      @Test
@@ -7261,7 +7068,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..197e3c394a54395bc41c9e271880dbb1
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("key");
          var tag1 = Tag.Integer("value").path("key");
-@@ -172,7 +173,7 @@ public class TagPathTest {
+@@ -172,7 +172,7 @@ public class TagPathTest {
      }
  
      @Test
@@ -7270,7 +7077,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..197e3c394a54395bc41c9e271880dbb1
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("key");
          var path = Tag.Integer("value").path("key");
-@@ -181,7 +182,7 @@ public class TagPathTest {
+@@ -181,7 +181,7 @@ public class TagPathTest {
      }
  
      @Test
@@ -7279,7 +7086,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..197e3c394a54395bc41c9e271880dbb1
          var handler = TagHandler.newHandler();
          var tag1 = Tag.Integer("pathInvalidClear1").path("key");
          var tag2 = Tag.Integer("pathInvalidClear2").path("key");
-@@ -190,7 +191,7 @@ public class TagPathTest {
+@@ -190,7 +190,7 @@ public class TagPathTest {
      }
  
      @Test
@@ -7288,7 +7095,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..197e3c394a54395bc41c9e271880dbb1
          var handler = TagHandler.newHandler();
          var tag = Tag.Integer("key");
          var path = Tag.Integer("key").path("first", "second");
-@@ -213,7 +214,7 @@ public class TagPathTest {
+@@ -213,7 +213,7 @@ public class TagPathTest {
      }
  
      @Test
@@ -7297,7 +7104,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..197e3c394a54395bc41c9e271880dbb1
          var handler = TagHandler.newHandler();
          var path = Tag.Integer("key").path("first", "second");
          var path1 = Tag.Integer("key").path("first");
-@@ -257,7 +258,7 @@ public class TagPathTest {
+@@ -257,7 +257,7 @@ public class TagPathTest {
      }
  
      @Test
@@ -7306,7 +7113,7 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..197e3c394a54395bc41c9e271880dbb1
          record Entry(int value) {
          }
  
-@@ -311,7 +312,7 @@ public class TagPathTest {
+@@ -311,7 +311,7 @@ public class TagPathTest {
      }
  
      @Test
@@ -7316,15 +7123,14 @@ index 67fcdcbcc3cca93e68af38b88bded7f2b8c3d4f7..197e3c394a54395bc41c9e271880dbb1
          var tag = Tag.Integer("key");
          var path = Tag.Integer("value").path("key", "second");
 diff --git a/src/test/java/net/minestom/server/tag/TagRecordTest.java b/src/test/java/net/minestom/server/tag/TagRecordTest.java
-index 1dfed907baf20311a82d5d4094500703454893e6..c0e60ad81d4b6d8e64e4a3fffb95e1d8c3c40f31 100644
+index 1dfed907baf20311a82d5d4094500703454893e6..b189f7aa45fb74477dd54abbbeac7b1ca731be47 100644
 --- a/src/test/java/net/minestom/server/tag/TagRecordTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagRecordTest.java
-@@ -13,10 +13,11 @@ import java.util.Map;
+@@ -13,10 +13,10 @@ import java.util.Map;
  import static net.minestom.testing.TestUtils.assertEqualsSNBT;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class TagRecordTest {
-+//Microtus - update java keyword usage
 +class TagRecordTest {
  
      @Test
@@ -7333,7 +7139,7 @@ index 1dfed907baf20311a82d5d4094500703454893e6..c0e60ad81d4b6d8e64e4a3fffb95e1d8
          var handler = TagHandler.newHandler();
          var tag = Tag.Structure("vec", Vec.class);
          var vec = new Vec(1, 2, 3);
-@@ -26,7 +27,7 @@ public class TagRecordTest {
+@@ -26,7 +26,7 @@ public class TagRecordTest {
      }
  
      @Test
@@ -7342,7 +7148,7 @@ index 1dfed907baf20311a82d5d4094500703454893e6..c0e60ad81d4b6d8e64e4a3fffb95e1d8
          var vecCompound = NBT.Compound(Map.of(
                  "x", NBT.Double(1),
                  "y", NBT.Double(2),
-@@ -37,7 +38,7 @@ public class TagRecordTest {
+@@ -37,7 +37,7 @@ public class TagRecordTest {
      }
  
      @Test
@@ -7351,7 +7157,7 @@ index 1dfed907baf20311a82d5d4094500703454893e6..c0e60ad81d4b6d8e64e4a3fffb95e1d8
          var handler = TagHandler.fromCompound(NBT.Compound(Map.of(
                  "x", NBT.Double(1),
                  "y", NBT.Double(2),
-@@ -47,7 +48,7 @@ public class TagRecordTest {
+@@ -47,7 +47,7 @@ public class TagRecordTest {
      }
  
      @Test
@@ -7360,7 +7166,7 @@ index 1dfed907baf20311a82d5d4094500703454893e6..c0e60ad81d4b6d8e64e4a3fffb95e1d8
          var handler = TagHandler.newHandler();
          var serializer = TagRecord.serializer(Vec.class);
          serializer.write(handler, new Vec(1, 2, 3));
-@@ -55,7 +56,7 @@ public class TagRecordTest {
+@@ -55,7 +55,7 @@ public class TagRecordTest {
      }
  
      @Test
@@ -7369,7 +7175,7 @@ index 1dfed907baf20311a82d5d4094500703454893e6..c0e60ad81d4b6d8e64e4a3fffb95e1d8
          var handler = TagHandler.newHandler();
          var tag = Tag.Structure("vec", Vec.class);
          var vec = new Vec(1, 2, 3);
-@@ -74,7 +75,7 @@ public class TagRecordTest {
+@@ -74,7 +74,7 @@ public class TagRecordTest {
      }
  
      @Test
@@ -7378,7 +7184,7 @@ index 1dfed907baf20311a82d5d4094500703454893e6..c0e60ad81d4b6d8e64e4a3fffb95e1d8
          record CompoundRecord(NBTCompound compound) {
          }
          var test = new CompoundRecord(NBT.Compound(Map.of("key", NBT.String("value"))));
-@@ -85,26 +86,26 @@ public class TagRecordTest {
+@@ -85,26 +85,26 @@ public class TagRecordTest {
      }
  
      @Test
@@ -7410,15 +7216,14 @@ index 1dfed907baf20311a82d5d4094500703454893e6..c0e60ad81d4b6d8e64e4a3fffb95e1d8
          // the item record components
          assertThrows(Throwable.class, () -> Tag.Structure("item", Class.class.cast(ItemStack.class)));
 diff --git a/src/test/java/net/minestom/server/tag/TagSerializerTest.java b/src/test/java/net/minestom/server/tag/TagSerializerTest.java
-index 2f7c6e91e46910f8536218f9d85b9ee3f1468802..aacdef1cd32ddca4789bfeb2668609dbf1e8db13 100644
+index 2f7c6e91e46910f8536218f9d85b9ee3f1468802..e3ca53d336f58f78ba359cce392e9ff3dffdff81 100644
 --- a/src/test/java/net/minestom/server/tag/TagSerializerTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagSerializerTest.java
-@@ -7,9 +7,10 @@ import org.junit.jupiter.api.Test;
+@@ -7,9 +7,9 @@ import org.junit.jupiter.api.Test;
  
  import java.util.List;
  
 -public class TagSerializerTest {
-+//Microtus - update java keyword usage
 +class TagSerializerTest {
      @Test
 -    public void fromCompound(){
@@ -7427,20 +7232,19 @@ index 2f7c6e91e46910f8536218f9d85b9ee3f1468802..aacdef1cd32ddca4789bfeb2668609db
          var effect = new FireworkEffect(false, false, FireworkEffectType.BURST, List.of(), List.of());
          TagHandler handler = TagHandler.newHandler();
 diff --git a/src/test/java/net/minestom/server/tag/TagStructureTest.java b/src/test/java/net/minestom/server/tag/TagStructureTest.java
-index d4f271c89568f90bd6eae7078602ba48cf4f0941..35009dff4eb6a5ea0247b87dedee2d2a8d24eed1 100644
+index d4f271c89568f90bd6eae7078602ba48cf4f0941..1c4f4e128624ecf265986d186341f8dd5fb85d07 100644
 --- a/src/test/java/net/minestom/server/tag/TagStructureTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagStructureTest.java
-@@ -10,7 +10,8 @@ import java.util.UUID;
+@@ -10,7 +10,7 @@ import java.util.UUID;
  import static net.minestom.testing.TestUtils.assertEqualsSNBT;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class TagStructureTest {
-+//Microtus - update java keyword usage
 +class TagStructureTest {
  
      private static final Tag<Entry> STRUCTURE_TAG = Tag.Structure("entry", new TagSerializer<>() {
          private static final Tag<String> VALUE_TAG = Tag.String("value");
-@@ -46,7 +47,7 @@ public class TagStructureTest {
+@@ -46,7 +46,7 @@ public class TagStructureTest {
      }
  
      @Test
@@ -7449,7 +7253,7 @@ index d4f271c89568f90bd6eae7078602ba48cf4f0941..35009dff4eb6a5ea0247b87dedee2d2a
          var handler = TagHandler.newHandler();
          assertNull(handler.getTag(STRUCTURE_TAG));
          assertFalse(handler.hasTag(STRUCTURE_TAG));
-@@ -62,7 +63,7 @@ public class TagStructureTest {
+@@ -62,7 +62,7 @@ public class TagStructureTest {
      }
  
      @Test
@@ -7458,7 +7262,7 @@ index d4f271c89568f90bd6eae7078602ba48cf4f0941..35009dff4eb6a5ea0247b87dedee2d2a
          var handler = TagHandler.newHandler();
          var entry = new Entry("hello");
          handler.setTag(STRUCTURE_TAG, entry);
-@@ -79,7 +80,7 @@ public class TagStructureTest {
+@@ -79,7 +79,7 @@ public class TagStructureTest {
      }
  
      @Test
@@ -7467,7 +7271,7 @@ index d4f271c89568f90bd6eae7078602ba48cf4f0941..35009dff4eb6a5ea0247b87dedee2d2a
          var handler = TagHandler.newHandler();
          assertNull(handler.getTag(STRUCTURE_TAG));
          assertFalse(handler.hasTag(STRUCTURE_TAG));
-@@ -105,7 +106,7 @@ public class TagStructureTest {
+@@ -105,7 +105,7 @@ public class TagStructureTest {
      }
  
      @Test
@@ -7476,7 +7280,7 @@ index d4f271c89568f90bd6eae7078602ba48cf4f0941..35009dff4eb6a5ea0247b87dedee2d2a
          var handler = TagHandler.newHandler();
          var entry1 = new Entry("hello");
          var entry2 = new Entry("hello2");
-@@ -134,7 +135,7 @@ public class TagStructureTest {
+@@ -134,7 +134,7 @@ public class TagStructureTest {
      }
  
      @Test
@@ -7486,15 +7290,14 @@ index d4f271c89568f90bd6eae7078602ba48cf4f0941..35009dff4eb6a5ea0247b87dedee2d2a
          Tag<UUID> uuidTag = Tag.UUID("Id").path("SkullOwner");
          Tag<PlayerSkin> skinTag = Tag.Structure("Properties", new TagSerializer<PlayerSkin>() {
 diff --git a/src/test/java/net/minestom/server/tag/TagTest.java b/src/test/java/net/minestom/server/tag/TagTest.java
-index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..0a19bfd4d716e9ccc3e4b0f2789955fd878c6076 100644
+index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..ba4ff92e14b8c3dfb486d47ab53ab38f2b905d00 100644
 --- a/src/test/java/net/minestom/server/tag/TagTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagTest.java
-@@ -11,10 +11,11 @@ import java.util.Map;
+@@ -11,10 +11,10 @@ import java.util.Map;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class TagTest {
-+//Microtus - update java keyword usage
 +class TagTest {
  
      @Test
@@ -7503,7 +7306,7 @@ index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..0a19bfd4d716e9ccc3e4b0f2789955fd
          var mutable = new MutableNBTCompound().setInt("key", 5);
          var tag = Tag.Integer("key");
          var handler = TagHandler.fromCompound(new MutableNBTCompound());
-@@ -28,7 +29,7 @@ public class TagTest {
+@@ -28,7 +28,7 @@ public class TagTest {
      }
  
      @Test
@@ -7512,7 +7315,7 @@ index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..0a19bfd4d716e9ccc3e4b0f2789955fd
          var handler = TagHandler.fromCompound(new MutableNBTCompound().set("key", NBT.Int(5)));
          // Removal
          var tag = Tag.Integer("key");
-@@ -38,7 +39,7 @@ public class TagTest {
+@@ -38,7 +38,7 @@ public class TagTest {
      }
  
      @Test
@@ -7521,7 +7324,7 @@ index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..0a19bfd4d716e9ccc3e4b0f2789955fd
          var handler = TagHandler.fromCompound(new MutableNBTCompound().set("key", NBT.Int(5)));
          // Removal
          var tag = Tag.Integer("key");
-@@ -48,14 +49,14 @@ public class TagTest {
+@@ -48,14 +48,14 @@ public class TagTest {
      }
  
      @Test
@@ -7538,7 +7341,7 @@ index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..0a19bfd4d716e9ccc3e4b0f2789955fd
          var mutable = new MutableNBTCompound().setInt("key", 5);
          var handler = TagHandler.fromCompound(mutable);
          assertEquals(5, handler.getTag(Tag.Integer("key")));
-@@ -63,7 +64,7 @@ public class TagTest {
+@@ -63,7 +63,7 @@ public class TagTest {
      }
  
      @Test
@@ -7547,7 +7350,7 @@ index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..0a19bfd4d716e9ccc3e4b0f2789955fd
          // Ensure that TagHandler#asCompound reuse the same compound used for construction
          var compound = NBT.Compound(Map.of("key", NBT.Int(5)));
          var handler = TagHandler.fromCompound(compound);
-@@ -71,7 +72,7 @@ public class TagTest {
+@@ -71,7 +71,7 @@ public class TagTest {
      }
  
      @Test
@@ -7556,7 +7359,7 @@ index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..0a19bfd4d716e9ccc3e4b0f2789955fd
          var nullable = Tag.String("key");
          var notNull = nullable.defaultValue("Hey");
          assertNotSame(nullable, notNull);
-@@ -86,7 +87,7 @@ public class TagTest {
+@@ -86,7 +86,7 @@ public class TagTest {
      }
  
      @Test
@@ -7565,7 +7368,7 @@ index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..0a19bfd4d716e9ccc3e4b0f2789955fd
          var tag1 = Tag.Integer("key");
          var tag2 = Tag.String("key");
  
-@@ -99,7 +100,7 @@ public class TagTest {
+@@ -99,7 +99,7 @@ public class TagTest {
      }
  
      @Test
@@ -7574,7 +7377,7 @@ index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..0a19bfd4d716e9ccc3e4b0f2789955fd
          var item = ItemStack.of(Material.DIAMOND);
          var tag = Tag.ItemStack("item");
          var handler = TagHandler.newHandler();
-@@ -108,7 +109,7 @@ public class TagTest {
+@@ -108,7 +108,7 @@ public class TagTest {
      }
  
      @Test
@@ -7583,7 +7386,7 @@ index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..0a19bfd4d716e9ccc3e4b0f2789955fd
          var tag1 = Tag.Integer("tag1");
          var tag2 = Tag.Integer("tag2");
          var handler = TagHandler.newHandler();
-@@ -121,7 +122,7 @@ public class TagTest {
+@@ -121,7 +121,7 @@ public class TagTest {
      }
  
      @Test
@@ -7592,7 +7395,7 @@ index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..0a19bfd4d716e9ccc3e4b0f2789955fd
          var handler = TagHandler.fromCompound(NBT.Compound(Map.of(
                  "tag1", NBT.Int(5),
                  "tag2", NBT.Int(1))));
-@@ -131,7 +132,7 @@ public class TagTest {
+@@ -131,7 +131,7 @@ public class TagTest {
      }
  
      @Test
@@ -7602,15 +7405,14 @@ index d1376f66c9eb7b586a7e6c066ca2adf3fe1b146d..0a19bfd4d716e9ccc3e4b0f2789955fd
          for (int i = 0; i < 1000; i++) {
              handler.setTag(Tag.Integer("rehashing" + i), i);
 diff --git a/src/test/java/net/minestom/server/tag/TagUpdateTest.java b/src/test/java/net/minestom/server/tag/TagUpdateTest.java
-index 222b875de2388871adbf7c0f84affa60481f992a..38f77120d931fff7c3965ff3d50aa865e6b01f0d 100644
+index 222b875de2388871adbf7c0f84affa60481f992a..59a64d77c7cc4a5a40b569897cf6131060bc4902 100644
 --- a/src/test/java/net/minestom/server/tag/TagUpdateTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagUpdateTest.java
-@@ -6,10 +6,11 @@ import org.junit.jupiter.api.Test;
+@@ -6,10 +6,10 @@ import org.junit.jupiter.api.Test;
  import static net.minestom.testing.TestUtils.assertEqualsSNBT;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class TagUpdateTest {
-+//Microtus - update java keyword usage
 +class TagUpdateTest {
  
      @Test
@@ -7619,7 +7421,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..38f77120d931fff7c3965ff3d50aa865
          var tag = Tag.Integer("coin");
          var handler = TagHandler.newHandler();
          handler.updateTag(tag, integer -> {
-@@ -25,7 +26,7 @@ public class TagUpdateTest {
+@@ -25,7 +25,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7628,7 +7430,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..38f77120d931fff7c3965ff3d50aa865
          var tag = Tag.Integer("coin").defaultValue(25);
          var handler = TagHandler.newHandler();
          handler.updateTag(tag, integer -> {
-@@ -41,7 +42,7 @@ public class TagUpdateTest {
+@@ -41,7 +41,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7637,7 +7439,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..38f77120d931fff7c3965ff3d50aa865
          var tag = Tag.Integer("coin");
          var handler = TagHandler.newHandler();
          handler.setTag(tag, 5);
-@@ -54,7 +55,7 @@ public class TagUpdateTest {
+@@ -54,7 +54,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7646,7 +7448,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..38f77120d931fff7c3965ff3d50aa865
          var tag = Tag.Integer("coin").path("path");
          var handler = TagHandler.newHandler();
          handler.setTag(tag, 5);
-@@ -67,7 +68,7 @@ public class TagUpdateTest {
+@@ -67,7 +67,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7655,7 +7457,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..38f77120d931fff7c3965ff3d50aa865
          var tag = Tag.Integer("coin");
          var handler = TagHandler.newHandler();
          var result = handler.updateAndGetTag(tag, integer -> {
-@@ -83,7 +84,7 @@ public class TagUpdateTest {
+@@ -83,7 +83,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7664,7 +7466,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..38f77120d931fff7c3965ff3d50aa865
          var tag = Tag.Integer("coin");
          var handler = TagHandler.newHandler();
          var result = handler.getAndUpdateTag(tag, integer -> {
-@@ -99,7 +100,7 @@ public class TagUpdateTest {
+@@ -99,7 +99,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7673,7 +7475,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..38f77120d931fff7c3965ff3d50aa865
          var tag1 = Tag.Integer("coin");
          var tag2 = Tag.Integer("coin").map(i -> i + 1, i -> i - 1);
          var handler = TagHandler.newHandler();
-@@ -110,7 +111,7 @@ public class TagUpdateTest {
+@@ -110,7 +110,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7682,7 +7484,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..38f77120d931fff7c3965ff3d50aa865
          record Test(int coin) {
          }
  
-@@ -131,7 +132,7 @@ public class TagUpdateTest {
+@@ -131,7 +131,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7691,7 +7493,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..38f77120d931fff7c3965ff3d50aa865
          record Test(int coin) {
          }
  
-@@ -152,7 +153,7 @@ public class TagUpdateTest {
+@@ -152,7 +152,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7700,7 +7502,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..38f77120d931fff7c3965ff3d50aa865
          record Test(int coin) {
          }
          record Structure(Test test) {
-@@ -176,7 +177,7 @@ public class TagUpdateTest {
+@@ -176,7 +176,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7709,7 +7511,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..38f77120d931fff7c3965ff3d50aa865
          record Test(int coin) {
          }
  
-@@ -194,7 +195,7 @@ public class TagUpdateTest {
+@@ -194,7 +194,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7718,7 +7520,7 @@ index 222b875de2388871adbf7c0f84affa60481f992a..38f77120d931fff7c3965ff3d50aa865
          var tagI = Tag.Integer("coin");
          var tagD = Tag.Double("coin");
          var handler = TagHandler.newHandler();
-@@ -203,7 +204,7 @@ public class TagUpdateTest {
+@@ -203,7 +203,7 @@ public class TagUpdateTest {
      }
  
      @Test
@@ -7728,15 +7530,14 @@ index 222b875de2388871adbf7c0f84affa60481f992a..38f77120d931fff7c3965ff3d50aa865
          var tagX = Tag.Double("x").path("vec");
          var handler = TagHandler.newHandler();
 diff --git a/src/test/java/net/minestom/server/tag/TagUuidTest.java b/src/test/java/net/minestom/server/tag/TagUuidTest.java
-index 7867639d8e7566b15ca176627dcafa69cd1be41f..b26fa5495ee98357b377ca5c620dc4032f3e345d 100644
+index 7867639d8e7566b15ca176627dcafa69cd1be41f..2cdcbe1aa884b444fbe45a8cebb593bc34ecd2de 100644
 --- a/src/test/java/net/minestom/server/tag/TagUuidTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagUuidTest.java
-@@ -8,10 +8,11 @@ import java.util.UUID;
+@@ -8,10 +8,10 @@ import java.util.UUID;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class TagUuidTest {
-+//Microtus - update java keyword usage
 +class TagUuidTest {
  
      @Test
@@ -7745,7 +7546,7 @@ index 7867639d8e7566b15ca176627dcafa69cd1be41f..b26fa5495ee98357b377ca5c620dc403
          var uuid = UUID.randomUUID();
          var tag = Tag.UUID("uuid");
          var handler = TagHandler.newHandler();
-@@ -20,14 +21,14 @@ public class TagUuidTest {
+@@ -20,14 +20,14 @@ public class TagUuidTest {
      }
  
      @Test
@@ -7762,7 +7563,7 @@ index 7867639d8e7566b15ca176627dcafa69cd1be41f..b26fa5495ee98357b377ca5c620dc403
          var tag = Tag.UUID("entry");
          var handler = TagHandler.newHandler();
          handler.setTag(Tag.Integer("entry"), 1);
-@@ -35,7 +36,7 @@ public class TagUuidTest {
+@@ -35,7 +35,7 @@ public class TagUuidTest {
      }
  
      @Test
@@ -7771,7 +7572,7 @@ index 7867639d8e7566b15ca176627dcafa69cd1be41f..b26fa5495ee98357b377ca5c620dc403
          var tag = Tag.UUID("uuid");
          var handler = TagHandler.newHandler();
          handler.setTag(tag, UUID.fromString("9ab8ca63-3d7b-43ba-b805-a20a352dae9c"));
-@@ -46,7 +47,7 @@ public class TagUuidTest {
+@@ -46,7 +46,7 @@ public class TagUuidTest {
      }
  
      @Test
@@ -7781,15 +7582,14 @@ index 7867639d8e7566b15ca176627dcafa69cd1be41f..b26fa5495ee98357b377ca5c620dc403
          var handler = TagHandler.newHandler();
          handler.setTag(Tag.NBT("uuid"), NBT.IntArray(-1699165597, 1031488442, -1207590390, 892186268));
 diff --git a/src/test/java/net/minestom/server/tag/TagValueShareTest.java b/src/test/java/net/minestom/server/tag/TagValueShareTest.java
-index bbed3b075d006d8c6cc92545337e428d14422c72..f2b62c543143582a7f63e6aaf6f05eab3bb0f027 100644
+index bbed3b075d006d8c6cc92545337e428d14422c72..b375a45d41a8b04d2b7f4a9046db10841547187c 100644
 --- a/src/test/java/net/minestom/server/tag/TagValueShareTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagValueShareTest.java
-@@ -11,40 +11,41 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
+@@ -11,40 +11,40 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  /**
   * Test tags that can share cached values.
   */
 -public class TagValueShareTest {
-+//Microtus - update java keyword usage
 +class TagValueShareTest {
  
      record Entry(int value) {
@@ -7832,7 +7632,7 @@ index bbed3b075d006d8c6cc92545337e428d14422c72..f2b62c543143582a7f63e6aaf6f05eab
          // Force identical functions
          Function<Integer, Entry> t1 = Entry::new;
          Function<Entry, Integer> t2 = Entry::value;
-@@ -56,26 +57,26 @@ public class TagValueShareTest {
+@@ -56,26 +56,26 @@ public class TagValueShareTest {
      }
  
      @Test
@@ -7863,7 +7663,7 @@ index bbed3b075d006d8c6cc92545337e428d14422c72..f2b62c543143582a7f63e6aaf6f05eab
          var tag = Tag.String("test").list();
          var tag2 = Tag.String("test").list();
          assertTrue(tag.shareValue(tag2));
-@@ -83,7 +84,7 @@ public class TagValueShareTest {
+@@ -83,7 +83,7 @@ public class TagValueShareTest {
      }
  
      @Test
@@ -7872,7 +7672,7 @@ index bbed3b075d006d8c6cc92545337e428d14422c72..f2b62c543143582a7f63e6aaf6f05eab
          var tag = Tag.String("test").list();
          var tag2 = Tag.String("test").list();
          assertFalse(tag.shareValue(tag2.list()));
-@@ -91,7 +92,7 @@ public class TagValueShareTest {
+@@ -91,7 +91,7 @@ public class TagValueShareTest {
      }
  
      @Test
@@ -7881,7 +7681,7 @@ index bbed3b075d006d8c6cc92545337e428d14422c72..f2b62c543143582a7f63e6aaf6f05eab
          var tag = Tag.String("test").list();
          var tag2 = Tag.Integer("test").list();
          assertFalse(tag.shareValue(tag2));
-@@ -99,14 +100,14 @@ public class TagValueShareTest {
+@@ -99,14 +99,14 @@ public class TagValueShareTest {
      }
  
      @Test
@@ -7899,20 +7699,19 @@ index bbed3b075d006d8c6cc92545337e428d14422c72..f2b62c543143582a7f63e6aaf6f05eab
          var tag2 = Tag.Structure("test", Vec.class).list();
          assertTrue(tag.shareValue(tag2));
 diff --git a/src/test/java/net/minestom/server/tag/TagViewTest.java b/src/test/java/net/minestom/server/tag/TagViewTest.java
-index 718d84a6bb77d1ccb9cf5a00358c9df20e141ddd..fde49e58b400a346905314ff85a4492abc951adf 100644
+index 718d84a6bb77d1ccb9cf5a00358c9df20e141ddd..8ab88efa4bcf663f11ac9392adb425ac86cb9fbd 100644
 --- a/src/test/java/net/minestom/server/tag/TagViewTest.java
 +++ b/src/test/java/net/minestom/server/tag/TagViewTest.java
-@@ -11,7 +11,8 @@ import java.util.Map;
+@@ -11,7 +11,7 @@ import java.util.Map;
  import static net.minestom.testing.TestUtils.assertEqualsSNBT;
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class TagViewTest {
-+//Microtus - update java keyword usage
 +class TagViewTest {
  
      private static final Tag<Entry> VIEW_TAG = Tag.View(new TagSerializer<>() {
          private static final Tag<String> VALUE_TAG = Tag.String("value");
-@@ -32,7 +33,7 @@ public class TagViewTest {
+@@ -32,7 +32,7 @@ public class TagViewTest {
      }
  
      @Test
@@ -7921,7 +7720,7 @@ index 718d84a6bb77d1ccb9cf5a00358c9df20e141ddd..fde49e58b400a346905314ff85a4492a
          var handler = TagHandler.newHandler();
          assertNull(handler.getTag(VIEW_TAG));
          assertFalse(handler.hasTag(VIEW_TAG));
-@@ -48,7 +49,7 @@ public class TagViewTest {
+@@ -48,7 +48,7 @@ public class TagViewTest {
      }
  
      @Test
@@ -7930,7 +7729,7 @@ index 718d84a6bb77d1ccb9cf5a00358c9df20e141ddd..fde49e58b400a346905314ff85a4492a
          var handler = TagHandler.newHandler();
          var entry = new Entry("hello");
          handler.setTag(VIEW_TAG, entry);
-@@ -63,7 +64,7 @@ public class TagViewTest {
+@@ -63,7 +63,7 @@ public class TagViewTest {
      }
  
      @Test
@@ -7939,7 +7738,7 @@ index 718d84a6bb77d1ccb9cf5a00358c9df20e141ddd..fde49e58b400a346905314ff85a4492a
          var handler = TagHandler.newHandler();
          var entry = new Entry("hello");
          handler.setTag(VIEW_TAG, entry);
-@@ -82,7 +83,7 @@ public class TagViewTest {
+@@ -82,7 +82,7 @@ public class TagViewTest {
      }
  
      @Test
@@ -7948,7 +7747,7 @@ index 718d84a6bb77d1ccb9cf5a00358c9df20e141ddd..fde49e58b400a346905314ff85a4492a
          var handler = TagHandler.newHandler();
          var tag = Tag.View(new TagSerializer<Entry>() {
              @Override
-@@ -112,7 +113,7 @@ public class TagViewTest {
+@@ -112,7 +112,7 @@ public class TagViewTest {
      }
  
      @Test
@@ -7957,7 +7756,7 @@ index 718d84a6bb77d1ccb9cf5a00358c9df20e141ddd..fde49e58b400a346905314ff85a4492a
          var handler = TagHandler.newHandler();
          var tag = VIEW_TAG.path("path");
          assertNull(handler.getTag(tag));
-@@ -129,7 +130,7 @@ public class TagViewTest {
+@@ -129,7 +129,7 @@ public class TagViewTest {
      }
  
      @Test
@@ -7966,7 +7765,7 @@ index 718d84a6bb77d1ccb9cf5a00358c9df20e141ddd..fde49e58b400a346905314ff85a4492a
          var handler = TagHandler.newHandler();
          var tag = VIEW_TAG.path("path");
          var entry = new Entry("hello");
-@@ -147,7 +148,7 @@ public class TagViewTest {
+@@ -147,7 +147,7 @@ public class TagViewTest {
      }
  
      @Test
@@ -7975,28 +7774,15 @@ index 718d84a6bb77d1ccb9cf5a00358c9df20e141ddd..fde49e58b400a346905314ff85a4492a
          var tag = Tag.View(TagSerializer.COMPOUND);
          var handler = TagHandler.newHandler();
          handler.setTag(tag, NBT.Compound(Map.of("value", NBT.String("hello"))));
-diff --git a/src/test/java/net/minestom/server/terminal/TerminalColorConverterTest.java b/src/test/java/net/minestom/server/terminal/TerminalColorConverterTest.java
-index a4e527d1561e748fe0add6e589ba97600feb7b3e..7c68370dbcd97cdd7dddba6aaed8978873da72eb 100644
---- a/src/test/java/net/minestom/server/terminal/TerminalColorConverterTest.java
-+++ b/src/test/java/net/minestom/server/terminal/TerminalColorConverterTest.java
-@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
- 
- import static org.junit.jupiter.api.Assertions.assertEquals;
- 
-+//Microtus - update java keyword usage
- class TerminalColorConverterTest {
-     @Test
-     void testFormat() {
 diff --git a/src/test/java/net/minestom/server/thread/AcquirableTest.java b/src/test/java/net/minestom/server/thread/AcquirableTest.java
-index 43753f558743fb6d8cdc7a15211e23b57e033e66..247585e7060c4049114b22c9b9245707a9bb5060 100644
+index 43753f558743fb6d8cdc7a15211e23b57e033e66..af6812e4251131fe3750600aae6ee1143f09375f 100644
 --- a/src/test/java/net/minestom/server/thread/AcquirableTest.java
 +++ b/src/test/java/net/minestom/server/thread/AcquirableTest.java
-@@ -9,10 +9,11 @@ import java.util.concurrent.atomic.AtomicReference;
+@@ -9,10 +9,10 @@ import java.util.concurrent.atomic.AtomicReference;
  import static org.junit.jupiter.api.Assertions.assertNotEquals;
  import static org.junit.jupiter.api.Assertions.assertNotNull;
  
 -public class AcquirableTest {
-+//Microtus - update java keyword usage
 +class AcquirableTest {
  
      @Test
@@ -8006,15 +7792,14 @@ index 43753f558743fb6d8cdc7a15211e23b57e033e66..247585e7060c4049114b22c9b9245707
          Entity entity = new Entity(EntityType.ZOMBIE) {
              @Override
 diff --git a/src/test/java/net/minestom/server/thread/ThreadDispatcherTest.java b/src/test/java/net/minestom/server/thread/ThreadDispatcherTest.java
-index 00f7b48addb0e4ba2ff77f2ea2b49faa374fa4b8..dc4fac5cf5ecc2dcfdc1f6e6fd4e59b90e0be53e 100644
+index 00f7b48addb0e4ba2ff77f2ea2b49faa374fa4b8..d9de83b15b836ca618f7b9e170062569e8d6e2f3 100644
 --- a/src/test/java/net/minestom/server/thread/ThreadDispatcherTest.java
 +++ b/src/test/java/net/minestom/server/thread/ThreadDispatcherTest.java
-@@ -14,10 +14,11 @@ import java.util.stream.IntStream;
+@@ -14,10 +14,10 @@ import java.util.stream.IntStream;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class ThreadDispatcherTest {
-+//Microtus - update java keyword usage
 +class ThreadDispatcherTest {
  
      @Test
@@ -8023,7 +7808,7 @@ index 00f7b48addb0e4ba2ff77f2ea2b49faa374fa4b8..dc4fac5cf5ecc2dcfdc1f6e6fd4e59b9
          final AtomicInteger counter = new AtomicInteger();
          ThreadDispatcher<Object> dispatcher = ThreadDispatcher.singleThread();
          assertEquals(1, dispatcher.threads().size());
-@@ -45,7 +46,7 @@ public class ThreadDispatcherTest {
+@@ -45,7 +45,7 @@ public class ThreadDispatcherTest {
      }
  
      @Test
@@ -8032,7 +7817,7 @@ index 00f7b48addb0e4ba2ff77f2ea2b49faa374fa4b8..dc4fac5cf5ecc2dcfdc1f6e6fd4e59b9
          // Partitions implementing Tickable should be ticked same as elements
          final AtomicInteger counter1 = new AtomicInteger();
          final AtomicInteger counter2 = new AtomicInteger();
-@@ -74,7 +75,7 @@ public class ThreadDispatcherTest {
+@@ -74,7 +74,7 @@ public class ThreadDispatcherTest {
      }
  
      @Test
@@ -8041,7 +7826,7 @@ index 00f7b48addb0e4ba2ff77f2ea2b49faa374fa4b8..dc4fac5cf5ecc2dcfdc1f6e6fd4e59b9
          // Ensure that partitions are properly dispatched across threads
          final int threadCount = 10;
          ThreadDispatcher<Tickable> dispatcher = ThreadDispatcher.of(ThreadProvider.counter(), threadCount);
-@@ -103,7 +104,7 @@ public class ThreadDispatcherTest {
+@@ -103,7 +103,7 @@ public class ThreadDispatcherTest {
      }
  
      @Test
@@ -8051,15 +7836,14 @@ index 00f7b48addb0e4ba2ff77f2ea2b49faa374fa4b8..dc4fac5cf5ecc2dcfdc1f6e6fd4e59b9
          // when RefreshType.ALWAYS is used
          interface Updater extends Tickable {
 diff --git a/src/test/java/net/minestom/server/timer/TestScheduler.java b/src/test/java/net/minestom/server/timer/TestScheduler.java
-index fdbb080822e6110b4dfbe8dcb2b51c0f868170af..da04b40abba2c4ecc745b30ea81778ca6af4d9d7 100644
+index fdbb080822e6110b4dfbe8dcb2b51c0f868170af..3ebcb5bfc47cbb6de2579938560c224cda81b8d8 100644
 --- a/src/test/java/net/minestom/server/timer/TestScheduler.java
 +++ b/src/test/java/net/minestom/server/timer/TestScheduler.java
-@@ -8,10 +8,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
+@@ -8,10 +8,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class TestScheduler {
-+//Microtus - update java keyword usage
 +class TestScheduler {
  
      @Test
@@ -8068,7 +7852,7 @@ index fdbb080822e6110b4dfbe8dcb2b51c0f868170af..da04b40abba2c4ecc745b30ea81778ca
          Scheduler scheduler = Scheduler.newScheduler();
          AtomicBoolean result = new AtomicBoolean(false);
          Task task = scheduler.scheduleNextTick(() -> result.set(true));
-@@ -26,7 +27,7 @@ public class TestScheduler {
+@@ -26,7 +26,7 @@ public class TestScheduler {
      }
  
      @Test
@@ -8077,7 +7861,7 @@ index fdbb080822e6110b4dfbe8dcb2b51c0f868170af..da04b40abba2c4ecc745b30ea81778ca
          Scheduler scheduler = Scheduler.newScheduler();
          AtomicBoolean result = new AtomicBoolean(false);
          scheduler.buildTask(() -> result.set(true))
-@@ -41,7 +42,7 @@ public class TestScheduler {
+@@ -41,7 +41,7 @@ public class TestScheduler {
      }
  
      @Test
@@ -8086,7 +7870,7 @@ index fdbb080822e6110b4dfbe8dcb2b51c0f868170af..da04b40abba2c4ecc745b30ea81778ca
          Scheduler scheduler = Scheduler.newScheduler();
          AtomicBoolean result = new AtomicBoolean(false);
          scheduler.scheduleNextProcess(() -> result.set(true));
-@@ -55,7 +56,7 @@ public class TestScheduler {
+@@ -55,7 +55,7 @@ public class TestScheduler {
      }
  
      @Test
@@ -8095,7 +7879,7 @@ index fdbb080822e6110b4dfbe8dcb2b51c0f868170af..da04b40abba2c4ecc745b30ea81778ca
          Scheduler scheduler = Scheduler.newScheduler();
          AtomicBoolean result = new AtomicBoolean(false);
          var task = scheduler.buildTask(() -> result.set(true))
-@@ -68,7 +69,7 @@ public class TestScheduler {
+@@ -68,7 +68,7 @@ public class TestScheduler {
      }
  
      @Test
@@ -8104,7 +7888,7 @@ index fdbb080822e6110b4dfbe8dcb2b51c0f868170af..da04b40abba2c4ecc745b30ea81778ca
          Scheduler scheduler = Scheduler.newScheduler();
          AtomicBoolean result = new AtomicBoolean(false);
          var task = scheduler.buildTask(() -> result.set(true))
-@@ -84,7 +85,7 @@ public class TestScheduler {
+@@ -84,7 +84,7 @@ public class TestScheduler {
      }
  
      @Test
@@ -8113,7 +7897,7 @@ index fdbb080822e6110b4dfbe8dcb2b51c0f868170af..da04b40abba2c4ecc745b30ea81778ca
          Scheduler scheduler = Scheduler.newScheduler();
          // Ignored parked task
          scheduler.buildTask(() -> fail("This parked task should never be executed"))
-@@ -108,7 +109,7 @@ public class TestScheduler {
+@@ -108,7 +108,7 @@ public class TestScheduler {
      }
  
      @Test
@@ -8122,7 +7906,7 @@ index fdbb080822e6110b4dfbe8dcb2b51c0f868170af..da04b40abba2c4ecc745b30ea81778ca
          Scheduler scheduler = Scheduler.newScheduler();
          CompletableFuture<Void> future = new CompletableFuture<>();
          AtomicBoolean result = new AtomicBoolean(false);
-@@ -123,7 +124,7 @@ public class TestScheduler {
+@@ -123,7 +123,7 @@ public class TestScheduler {
      }
  
      @Test
@@ -8132,15 +7916,14 @@ index fdbb080822e6110b4dfbe8dcb2b51c0f868170af..da04b40abba2c4ecc745b30ea81778ca
          Scheduler scheduler = Scheduler.newScheduler();
          AtomicBoolean result = new AtomicBoolean(false);
 diff --git a/src/test/java/net/minestom/server/utils/ChunkUtilsTest.java b/src/test/java/net/minestom/server/utils/ChunkUtilsTest.java
-index 5327ad0533a6262b55575da0e7851d3fe4e77f2b..7b0e91f720a5b3f34e5207d6e5554b07ca5c231e 100644
+index 5327ad0533a6262b55575da0e7851d3fe4e77f2b..c6d314ab4f1c99aed9d662432844a0edb28e014d 100644
 --- a/src/test/java/net/minestom/server/utils/ChunkUtilsTest.java
 +++ b/src/test/java/net/minestom/server/utils/ChunkUtilsTest.java
-@@ -9,11 +9,12 @@ import org.junit.jupiter.api.Assertions;
+@@ -9,11 +9,11 @@ import org.junit.jupiter.api.Assertions;
  import java.util.*;
  import java.util.stream.Stream;
  
 -public class ChunkUtilsTest {
-+//Microtus - update java keyword usage
 +class ChunkUtilsTest {
  
      @ParameterizedTest
@@ -8151,15 +7934,14 @@ index 5327ad0533a6262b55575da0e7851d3fe4e77f2b..7b0e91f720a5b3f34e5207d6e5554b07
          final Set<ChunkCoordinate> o = new HashSet<>();
          ChunkUtils.forChunksInRange(nx, nz, r, (x, z) -> n.add(new ChunkCoordinate(x, z)));
 diff --git a/src/test/java/net/minestom/server/utils/NamespaceIDTest.java b/src/test/java/net/minestom/server/utils/NamespaceIDTest.java
-index 5bae45cd92299a01210869345899018fa4c646af..3f6016ba4d2eae35daceb3898af01b6a2d286c91 100644
+index 5bae45cd92299a01210869345899018fa4c646af..07ce514e9d8268495d2e4ee632f6760a81a120e8 100644
 --- a/src/test/java/net/minestom/server/utils/NamespaceIDTest.java
 +++ b/src/test/java/net/minestom/server/utils/NamespaceIDTest.java
-@@ -5,10 +5,11 @@ import org.junit.jupiter.api.Test;
+@@ -5,10 +5,10 @@ import org.junit.jupiter.api.Test;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class NamespaceIDTest {
-+//Microtus - update java keyword usage
 +class NamespaceIDTest {
  
      @Test
@@ -8168,7 +7950,7 @@ index 5bae45cd92299a01210869345899018fa4c646af..3f6016ba4d2eae35daceb3898af01b6a
          var namespace = NamespaceID.from("minecraft:any");
          assertEquals("minecraft", namespace.domain());
          assertEquals("any", namespace.path());
-@@ -21,7 +22,7 @@ public class NamespaceIDTest {
+@@ -21,7 +21,7 @@ public class NamespaceIDTest {
      }
  
      @Test
@@ -8177,7 +7959,7 @@ index 5bae45cd92299a01210869345899018fa4c646af..3f6016ba4d2eae35daceb3898af01b6a
          var namespace = NamespaceID.from("minecraft:any");
          assertEquals(namespace, NamespaceID.from("minecraft:any"));
          assertNotEquals(namespace, NamespaceID.from("minecraft:any2"));
-@@ -29,7 +30,7 @@ public class NamespaceIDTest {
+@@ -29,7 +29,7 @@ public class NamespaceIDTest {
      }
      // Microtus start - Fix namespace hashcode and equals
      @Test
@@ -8186,7 +7968,7 @@ index 5bae45cd92299a01210869345899018fa4c646af..3f6016ba4d2eae35daceb3898af01b6a
          var namespace = NamespaceID.from("minecraft:any");
          var key = Key.key("minecraft:any");
  
-@@ -39,50 +40,50 @@ public class NamespaceIDTest {
+@@ -39,50 +39,50 @@ public class NamespaceIDTest {
      // Microtus end - Fix namespace hashcode and equals
  
      @Test
@@ -8247,15 +8029,14 @@ index 5bae45cd92299a01210869345899018fa4c646af..3f6016ba4d2eae35daceb3898af01b6a
      }
  }
 diff --git a/src/test/java/net/minestom/server/utils/ObjectPoolTest.java b/src/test/java/net/minestom/server/utils/ObjectPoolTest.java
-index 42c8557addf779784d57fc5eac5147fd533e4025..1eb8403d2d2f26727556020108a0e96971f21659 100644
+index 42c8557addf779784d57fc5eac5147fd533e4025..d3dc473514df009b1df3957ae5bdfde0e46cd05f 100644
 --- a/src/test/java/net/minestom/server/utils/ObjectPoolTest.java
 +++ b/src/test/java/net/minestom/server/utils/ObjectPoolTest.java
-@@ -8,10 +8,11 @@ import java.util.Set;
+@@ -8,10 +8,10 @@ import java.util.Set;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class ObjectPoolTest {
-+//Microtus - update java keyword usage
 +class ObjectPoolTest {
  
      @Test
@@ -8264,7 +8045,7 @@ index 42c8557addf779784d57fc5eac5147fd533e4025..1eb8403d2d2f26727556020108a0e969
          var pool = ObjectPool.BUFFER_POOL;
          Set<BinaryBuffer> pooledBuffers = new HashSet<>();
          pool.clear();
-@@ -31,7 +32,7 @@ public class ObjectPoolTest {
+@@ -31,7 +31,7 @@ public class ObjectPoolTest {
      }
  
      @Test
@@ -8274,15 +8055,14 @@ index 42c8557addf779784d57fc5eac5147fd533e4025..1eb8403d2d2f26727556020108a0e969
          assertEquals(0, pool.count());
          try (var ignored = pool.hold()) {
 diff --git a/src/test/java/net/minestom/server/utils/PositionUtilsTest.java b/src/test/java/net/minestom/server/utils/PositionUtilsTest.java
-index 888bee67eda2820ebb9944e04073dcb020c162dd..15fb4494aac4122ba54b0c2c6d3549761b680c2b 100644
+index 888bee67eda2820ebb9944e04073dcb020c162dd..aeba8005db97d16d04b385b388ff469f533ac6a6 100644
 --- a/src/test/java/net/minestom/server/utils/PositionUtilsTest.java
 +++ b/src/test/java/net/minestom/server/utils/PositionUtilsTest.java
-@@ -5,10 +5,11 @@ import org.junit.jupiter.api.Test;
+@@ -5,10 +5,10 @@ import org.junit.jupiter.api.Test;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class PositionUtilsTest {
-+//Microtus - update java keyword usage
 +class PositionUtilsTest {
  
      @Test
@@ -8291,7 +8071,7 @@ index 888bee67eda2820ebb9944e04073dcb020c162dd..15fb4494aac4122ba54b0c2c6d354976
          float plusX = PositionUtils.getLookYaw(10, 0);
          assertEquals(-90, plusX, 1E-5);
  
-@@ -34,7 +35,7 @@ public class PositionUtilsTest {
+@@ -34,7 +34,7 @@ public class PositionUtilsTest {
      }
  
      @Test
@@ -8301,15 +8081,14 @@ index 888bee67eda2820ebb9944e04073dcb020c162dd..15fb4494aac4122ba54b0c2c6d354976
          assertEquals(-90, high, 1E-5);
  
 diff --git a/src/test/java/net/minestom/server/utils/TestMojangUtils.java b/src/test/java/net/minestom/server/utils/TestMojangUtils.java
-index eee508bc380ebb9a8668b80acacfedf342bde903..61abc8efbe2e94b279b0226241aa6201d35be914 100644
+index eee508bc380ebb9a8668b80acacfedf342bde903..4eb0a8407815dc946a268d5eeb6c09658e4c85c6 100644
 --- a/src/test/java/net/minestom/server/utils/TestMojangUtils.java
 +++ b/src/test/java/net/minestom/server/utils/TestMojangUtils.java
-@@ -5,22 +5,23 @@ import org.junit.jupiter.api.Test;
+@@ -5,22 +5,22 @@ import org.junit.jupiter.api.Test;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class TestMojangUtils {
-+//Microtus - update java keyword usage
 +class TestMojangUtils {
      @Test
 -    public void testValidNameWorks() {
@@ -8332,7 +8111,7 @@ index eee508bc380ebb9a8668b80acacfedf342bde903..61abc8efbe2e94b279b0226241aa6201
          var result = MojangUtils.fromUuid("853c80ef3c3749fdaa49938b674adae6");
          assertNotNull(result);
          assertEquals("jeb_", result.get("name").getAsString());
-@@ -28,13 +29,13 @@ public class TestMojangUtils {
+@@ -28,13 +28,13 @@ public class TestMojangUtils {
      }
  
      @Test
@@ -8349,21 +8128,19 @@ index eee508bc380ebb9a8668b80acacfedf342bde903..61abc8efbe2e94b279b0226241aa6201
          assertNull(result);
      }
 diff --git a/src/test/java/net/minestom/server/utils/TranslationIntegrationTest.java b/src/test/java/net/minestom/server/utils/TranslationIntegrationTest.java
-index fe070a1d1754c08e9143bd357bf63695c738c2a1..91ee91f5589b2243d26d41d43148832c68704220 100644
+index fe070a1d1754c08e9143bd357bf63695c738c2a1..feb26612e86ad2d576a2d2f28600b01b340e4566 100644
 --- a/src/test/java/net/minestom/server/utils/TranslationIntegrationTest.java
 +++ b/src/test/java/net/minestom/server/utils/TranslationIntegrationTest.java
-@@ -18,8 +18,9 @@ import java.util.List;
- import static org.junit.jupiter.api.Assertions.assertEquals;
+@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  import static org.junit.jupiter.api.Assertions.assertNotEquals;
  
-+//Microtus - update java keyword usage
  @EnvTest
 -public class TranslationIntegrationTest {
 +class TranslationIntegrationTest {
  
      @BeforeAll
      static void translator() {
-@@ -30,7 +31,7 @@ public class TranslationIntegrationTest {
+@@ -30,7 +30,7 @@ public class TranslationIntegrationTest {
      }
  
      @Test
@@ -8372,7 +8149,7 @@ index fe070a1d1754c08e9143bd357bf63695c738c2a1..91ee91f5589b2243d26d41d43148832c
          final var instance = env.createFlatInstance();
          final var connection = env.createConnection();
          final var player = connection.connect(instance, new Pos(0, 40, 0)).join();
-@@ -49,7 +50,7 @@ public class TranslationIntegrationTest {
+@@ -49,7 +49,7 @@ public class TranslationIntegrationTest {
      }
  
      @Test
@@ -8382,28 +8159,26 @@ index fe070a1d1754c08e9143bd357bf63695c738c2a1..91ee91f5589b2243d26d41d43148832c
          final var connection = env.createConnection();
          final var player = connection.connect(instance, new Pos(0, 40, 0)).join();
 diff --git a/src/test/java/net/minestom/server/utils/UniqueIdUtilsTest.java b/src/test/java/net/minestom/server/utils/UniqueIdUtilsTest.java
-index f7bc989b8f89f37798e2645a54d71127fa5a767d..02cadd1d6d9a90910d45ac5cc6d11482ab6d1357 100644
+index f7bc989b8f89f37798e2645a54d71127fa5a767d..a12b906b9a79cfbb86127776166e3b82f8174de6 100644
 --- a/src/test/java/net/minestom/server/utils/UniqueIdUtilsTest.java
 +++ b/src/test/java/net/minestom/server/utils/UniqueIdUtilsTest.java
-@@ -7,7 +7,7 @@ import java.util.UUID;
+@@ -7,7 +7,6 @@ import java.util.UUID;
  import static net.minestom.server.utils.UniqueIdUtils.*;
  import static org.junit.jupiter.api.Assertions.*;
  
 -// Microtus - improve string pattern usage + test
-+//Microtus - update java keyword usage
  class UniqueIdUtilsTest {
  
      @Test
 diff --git a/src/test/java/net/minestom/server/utils/block/BlockIteratorTest.java b/src/test/java/net/minestom/server/utils/block/BlockIteratorTest.java
-index 12ba498890d53c76c1847fb0df1367943a33b4fe..16403be2ca015673e5cadd693aa7126363158de0 100644
+index 12ba498890d53c76c1847fb0df1367943a33b4fe..a944e04ef851f120970e6e12a76a7dd670997c89 100644
 --- a/src/test/java/net/minestom/server/utils/block/BlockIteratorTest.java
 +++ b/src/test/java/net/minestom/server/utils/block/BlockIteratorTest.java
-@@ -9,13 +9,14 @@ import java.util.List;
+@@ -9,13 +9,13 @@ import java.util.List;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class BlockIteratorTest {
-+//Microtus - update java keyword usage
 +class BlockIteratorTest {
      private void assertContains(List<Point> points, Point point) {
          assertTrue(points.contains(point), "Expected " + points + " to contain " + point);
@@ -8415,7 +8190,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..16403be2ca015673e5cadd693aa71263
          Vec s = new Vec(0,  0.1, 0);
          Vec e = new Vec(2, 1, 0);
          BlockIterator iterator = new BlockIterator(s, e, 0, 4);
-@@ -29,7 +30,7 @@ public class BlockIteratorTest {
+@@ -29,7 +29,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8424,7 +8199,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..16403be2ca015673e5cadd693aa71263
          Vec s = new Vec(0,  0.1, 0);
          Vec e = new Vec(-2, 1, 0);
          BlockIterator iterator = new BlockIterator(s, e, 0, 4);
-@@ -44,7 +45,7 @@ public class BlockIteratorTest {
+@@ -44,7 +44,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8433,7 +8208,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..16403be2ca015673e5cadd693aa71263
          Vec s = new Vec(0,  -0.1, 0);
          Vec e = new Vec(2, 1, 0);
          BlockIterator iterator = new BlockIterator(s, e, 0, 4);
-@@ -59,7 +60,7 @@ public class BlockIteratorTest {
+@@ -59,7 +59,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8442,7 +8217,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..16403be2ca015673e5cadd693aa71263
          Vec s = new Vec(0,  -0.1, 0);
          Vec e = new Vec(-2, 1, 0);
          BlockIterator iterator = new BlockIterator(s, e, 0, 4);
-@@ -75,7 +76,7 @@ public class BlockIteratorTest {
+@@ -75,7 +75,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8451,7 +8226,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..16403be2ca015673e5cadd693aa71263
          Vec s = new Vec(0,  0, 0);
          Vec e = new Vec(0, 0, 0);
          BlockIterator iterator = new BlockIterator(s, e, 0, 4);
-@@ -83,7 +84,7 @@ public class BlockIteratorTest {
+@@ -83,7 +83,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8460,7 +8235,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..16403be2ca015673e5cadd693aa71263
          Vec s = new Vec(42.5, 0, 51.5);
          Vec e = new Vec(-12, 0, -36);
          BlockIterator iterator = new BlockIterator(s, e, 0, 37);
-@@ -163,7 +164,7 @@ public class BlockIteratorTest {
+@@ -163,7 +163,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8469,7 +8244,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..16403be2ca015673e5cadd693aa71263
          Vec s = new Vec(0.5, 40, 0.5);
          Vec e = new Vec(27, 0, 21);
          BlockIterator iterator = new BlockIterator(s, e, 0, 34);
-@@ -235,7 +236,7 @@ public class BlockIteratorTest {
+@@ -235,7 +235,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8478,7 +8253,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..16403be2ca015673e5cadd693aa71263
          Vec s = new Vec(0.5,  0, 0.5);
          Vec e = new Vec(0, 1, 0);
          BlockIterator iterator = new BlockIterator(s, e, 0, 1);
-@@ -245,7 +246,7 @@ public class BlockIteratorTest {
+@@ -245,7 +245,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8487,7 +8262,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..16403be2ca015673e5cadd693aa71263
          Vec s = new Vec(0.5,  0, 0.5);
          Vec e = new Vec(0, 1, 0);
          BlockIterator iterator = new BlockIterator(s, e, 0, 0.5);
-@@ -254,7 +255,7 @@ public class BlockIteratorTest {
+@@ -254,7 +254,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8496,7 +8271,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..16403be2ca015673e5cadd693aa71263
          Vec s = new Vec(0.1,  0.1, 0.1);
          Vec e = new Vec(1, 1, 1);
          BlockIterator iterator = new BlockIterator(s, e, 0, 4);
-@@ -283,7 +284,7 @@ public class BlockIteratorTest {
+@@ -283,7 +283,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8505,7 +8280,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..16403be2ca015673e5cadd693aa71263
          Vec s = new Vec(0,  0, 0);
          Vec e = new Vec(2, 1, 0);
          BlockIterator iterator = new BlockIterator(s, e, 0, 4);
-@@ -309,7 +310,7 @@ public class BlockIteratorTest {
+@@ -309,7 +309,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8514,7 +8289,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..16403be2ca015673e5cadd693aa71263
          Vec s = new Vec(0,  0, 0);
          Vec e = new Vec(-2, 1, 0);
          BlockIterator iterator = new BlockIterator(s, e, 0, 4);
-@@ -336,7 +337,7 @@ public class BlockIteratorTest {
+@@ -336,7 +336,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8523,7 +8298,7 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..16403be2ca015673e5cadd693aa71263
          Vec s = new Vec(0,  0, 0);
          Vec e = new Vec(-2, -1, 0);
          BlockIterator iterator = new BlockIterator(s, e, 0, 4);
-@@ -365,7 +366,7 @@ public class BlockIteratorTest {
+@@ -365,7 +365,7 @@ public class BlockIteratorTest {
      }
  
      @Test
@@ -8533,15 +8308,14 @@ index 12ba498890d53c76c1847fb0df1367943a33b4fe..16403be2ca015673e5cadd693aa71263
          Vec e = new Vec(0, -10, 0);
          BlockIterator iterator = new BlockIterator(s, e, 0, 14.142135623730951);
 diff --git a/src/test/java/net/minestom/server/utils/collection/AutoIncrementMapTest.java b/src/test/java/net/minestom/server/utils/collection/AutoIncrementMapTest.java
-index b19454170b525977d6a59353a8da6bc70896bad1..6e968e39c3178a1f7cc7ec2edfe8656b275879e7 100644
+index b19454170b525977d6a59353a8da6bc70896bad1..04946c4ab86fe6aad9cebcd510f64251af5c8a55 100644
 --- a/src/test/java/net/minestom/server/utils/collection/AutoIncrementMapTest.java
 +++ b/src/test/java/net/minestom/server/utils/collection/AutoIncrementMapTest.java
-@@ -4,9 +4,10 @@ import org.junit.jupiter.api.Test;
+@@ -4,9 +4,9 @@ import org.junit.jupiter.api.Test;
  
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
 -public class AutoIncrementMapTest {
-+//Microtus - update java keyword usage
 +class AutoIncrementMapTest {
      @Test
 -    public void test() {
@@ -8550,15 +8324,14 @@ index b19454170b525977d6a59353a8da6bc70896bad1..6e968e39c3178a1f7cc7ec2edfe8656b
          for (int i = 0; i < 1000; i++) {
              assertEquals(i, map.get("test" + i));
 diff --git a/src/test/java/net/minestom/server/utils/collection/ObjectArrayTest.java b/src/test/java/net/minestom/server/utils/collection/ObjectArrayTest.java
-index ee2f9544050ed61ad3467949cbdc80004d0739e4..fe49b7e40d2eca3479d8a81daca8300b09e9ee56 100644
+index ee2f9544050ed61ad3467949cbdc80004d0739e4..cece245e05262a23325a48f8bd7194d7e87462e1 100644
 --- a/src/test/java/net/minestom/server/utils/collection/ObjectArrayTest.java
 +++ b/src/test/java/net/minestom/server/utils/collection/ObjectArrayTest.java
-@@ -5,11 +5,12 @@ import org.junit.jupiter.params.provider.ValueSource;
+@@ -5,11 +5,11 @@ import org.junit.jupiter.params.provider.ValueSource;
  
  import static org.junit.jupiter.api.Assertions.*;
  
 -public class ObjectArrayTest {
-+//Microtus - update java keyword usage
 +class ObjectArrayTest {
  
      @ParameterizedTest
@@ -8568,7 +8341,7 @@ index ee2f9544050ed61ad3467949cbdc80004d0739e4..fe49b7e40d2eca3479d8a81daca8300b
          ObjectArray<String> array = concurrent ? ObjectArray.concurrent() : ObjectArray.singleThread();
  
          array.set(50, "Hey");
-@@ -37,7 +38,7 @@ public class ObjectArrayTest {
+@@ -37,7 +37,7 @@ public class ObjectArrayTest {
  
      @ParameterizedTest
      @ValueSource(booleans = {false, true})

--- a/minestom-patches/0015-Update-java-keyword-usage.patch
+++ b/minestom-patches/0015-Update-java-keyword-usage.patch
@@ -4,6 +4,99 @@ Date: Tue, 5 Dec 2023 13:06:18 +0100
 Subject: [PATCH] Update java keyword usage
 
 
+diff --git a/src/main/java/net/minestom/server/adventure/AdventurePacketConvertor.java b/src/main/java/net/minestom/server/adventure/AdventurePacketConvertor.java
+index 04244d43a556e33b5ce9cb4cf727433f976af35b..f95e46f468b17bf2b6d20e8cab866b5a787ceb7e 100644
+--- a/src/main/java/net/minestom/server/adventure/AdventurePacketConvertor.java
++++ b/src/main/java/net/minestom/server/adventure/AdventurePacketConvertor.java
+@@ -46,6 +46,8 @@ public class AdventurePacketConvertor {
+         NAMED_TEXT_COLOR_ID_MAP.put(NamedTextColor.WHITE, 15);
+     }
+ 
++    private AdventurePacketConvertor() { }
++
+     /**
+      * Gets the int value of a boss bar overlay.
+      *
+diff --git a/src/main/java/net/minestom/server/command/builder/arguments/ArgumentEnum.java b/src/main/java/net/minestom/server/command/builder/arguments/ArgumentEnum.java
+index 3ac12d8d67644ef8fdbfe7fb0fbbd442907c04db..a104ebbe4934e4c3427e6f0588f856bc5bc416b5 100644
+--- a/src/main/java/net/minestom/server/command/builder/arguments/ArgumentEnum.java
++++ b/src/main/java/net/minestom/server/command/builder/arguments/ArgumentEnum.java
+@@ -11,7 +11,7 @@ import java.util.function.UnaryOperator;
+ @SuppressWarnings("rawtypes")
+ public class ArgumentEnum<E extends Enum> extends Argument<E> {
+ 
+-    public final static int NOT_ENUM_VALUE_ERROR = 1;
++    public static final int NOT_ENUM_VALUE_ERROR = 1;
+ 
+     private final Class<E> enumClass;
+     private final E[] values;
+diff --git a/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentRange.java b/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentRange.java
+index cd15c02a785b35c3ef4f387958fd6cd80aea2e43..aaf19016451bf8ae361c7eded9f608b00e1fb229 100644
+--- a/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentRange.java
++++ b/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentRange.java
+@@ -22,7 +22,7 @@ public abstract class ArgumentRange<T extends Range<N>, N extends Number> extend
+     private final Function<String, N> parser;
+     private final BiFunction<N, N, T> rangeConstructor;
+ 
+-    public ArgumentRange(@NotNull String id, N min, N max, Function<String, N> parser, BiFunction<N, N, T> rangeConstructor) {
++    ArgumentRange(@NotNull String id, N min, N max, Function<String, N> parser, BiFunction<N, N, T> rangeConstructor) {
+         super(id);
+         this.min = min;
+         this.max = max;
+diff --git a/src/main/java/net/minestom/server/command/builder/arguments/minecraft/registry/ArgumentRegistry.java b/src/main/java/net/minestom/server/command/builder/arguments/minecraft/registry/ArgumentRegistry.java
+index 83570542f3bce400238b45d067aad19444669b36..0f163c4448cef8116b6d7dc307e0b59b9cc9f262 100644
+--- a/src/main/java/net/minestom/server/command/builder/arguments/minecraft/registry/ArgumentRegistry.java
++++ b/src/main/java/net/minestom/server/command/builder/arguments/minecraft/registry/ArgumentRegistry.java
+@@ -8,7 +8,7 @@ public abstract class ArgumentRegistry<T> extends Argument<T> {
+ 
+     public static final int INVALID_NAME = -2;
+ 
+-    public ArgumentRegistry(String id) {
++    ArgumentRegistry(String id) {
+         super(id);
+     }
+ 
+diff --git a/src/main/java/net/minestom/server/command/builder/arguments/relative/ArgumentRelativeVec.java b/src/main/java/net/minestom/server/command/builder/arguments/relative/ArgumentRelativeVec.java
+index 66400d55272e182692398aec8d509ce51f782744..d0814278cbc31332e529ba44ad42baa2a48fa901 100644
+--- a/src/main/java/net/minestom/server/command/builder/arguments/relative/ArgumentRelativeVec.java
++++ b/src/main/java/net/minestom/server/command/builder/arguments/relative/ArgumentRelativeVec.java
+@@ -27,7 +27,7 @@ abstract class ArgumentRelativeVec extends Argument<RelativeVec> {
+ 
+     private final int numberCount;
+ 
+-    public ArgumentRelativeVec(@NotNull String id, int numberCount) {
++    ArgumentRelativeVec(@NotNull String id, int numberCount) {
+         super(id, true);
+         this.numberCount = numberCount;
+     }
+diff --git a/src/main/java/net/minestom/server/entity/EntityProjectile.java b/src/main/java/net/minestom/server/entity/EntityProjectile.java
+index 82685ae08e5806f749995e293b63e7ac7f7223b7..e3080b8fc56ab8db6f0f5f36166ad62f8f1e67f0 100644
+--- a/src/main/java/net/minestom/server/entity/EntityProjectile.java
++++ b/src/main/java/net/minestom/server/entity/EntityProjectile.java
+@@ -157,8 +157,8 @@ public class EntityProjectile extends Entity {
+                 chunk = currentChunk;
+                 entities = instance.getChunkEntities(chunk)
+                         .stream()
+-                        .filter(entity -> entity instanceof LivingEntity)
+-                        .map(entity -> (LivingEntity) entity)
++                        .filter(LivingEntity.class::isInstance)
++                        .map(LivingEntity.class::cast)
+                         .collect(Collectors.toSet());
+             }
+             final Point currentPos = pos;
+diff --git a/src/main/java/net/minestom/server/entity/ai/GoalSelector.java b/src/main/java/net/minestom/server/entity/ai/GoalSelector.java
+index e89698ad47e1e9255754832857d3e0b2cb0aa88b..5c1720fd51d7bdf2acdf6674c40dc7cff2a7b80e 100644
+--- a/src/main/java/net/minestom/server/entity/ai/GoalSelector.java
++++ b/src/main/java/net/minestom/server/entity/ai/GoalSelector.java
+@@ -12,7 +12,7 @@ public abstract class GoalSelector {
+     private WeakReference<EntityAIGroup> aiGroupWeakReference;
+     protected EntityCreature entityCreature;
+ 
+-    public GoalSelector(@NotNull EntityCreature entityCreature) {
++    protected GoalSelector(@NotNull EntityCreature entityCreature) {
+         this.entityCreature = entityCreature;
+     }
+ 
 diff --git a/src/main/java/net/minestom/server/entity/metadata/EntityMeta.java b/src/main/java/net/minestom/server/entity/metadata/EntityMeta.java
 index 449b16bbbc863703e293606d3253d2b7c4f64078..c7f382df4b3826f68362170b0f4b8069a76b2f03 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/EntityMeta.java
@@ -156,7 +249,7 @@ index ff56fa14539db30131f595d12cdce19b0dad7515..e6fc1c21d674e0e852cb4cdce4f90bbc
      public BeeMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
          super(entity, metadata);
 diff --git a/src/main/java/net/minestom/server/entity/metadata/animal/FoxMeta.java b/src/main/java/net/minestom/server/entity/metadata/animal/FoxMeta.java
-index 56e78d07664c0f7c49fda12a0de5ab2250863e72..fded09d40b9d99f459b413385d940f72775d27db 100644
+index 56e78d07664c0f7c49fda12a0de5ab2250863e72..c95c2cbcc15a11c1d6ed27baa974de345ba892de 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/animal/FoxMeta.java
 +++ b/src/main/java/net/minestom/server/entity/metadata/animal/FoxMeta.java
 @@ -11,13 +11,13 @@ public class FoxMeta extends AnimalMeta {
@@ -180,6 +273,50 @@ index 56e78d07664c0f7c49fda12a0de5ab2250863e72..fded09d40b9d99f459b413385d940f72
  
      public FoxMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
          super(entity, metadata);
+@@ -110,7 +110,7 @@ public class FoxMeta extends AnimalMeta {
+         RED,
+         SNOW;
+ 
+-        private final static Type[] VALUES = values();
++        private static final Type[] VALUES = values();
+     }
+ 
+ }
+diff --git a/src/main/java/net/minestom/server/entity/metadata/animal/HorseMeta.java b/src/main/java/net/minestom/server/entity/metadata/animal/HorseMeta.java
+index b228164c4089328587b54e8d243c5585804fd2ec..940b77543aad8e73aeeb0727941fa57fbc0a39b4 100644
+--- a/src/main/java/net/minestom/server/entity/metadata/animal/HorseMeta.java
++++ b/src/main/java/net/minestom/server/entity/metadata/animal/HorseMeta.java
+@@ -68,7 +68,7 @@ public class HorseMeta extends AbstractHorseMeta {
+         WHITE_DOTS,
+         BLACK_DOTS;
+ 
+-        private final static Marking[] VALUES = values();
++        private static final Marking[] VALUES = values();
+     }
+ 
+     public enum Color {
+@@ -80,7 +80,7 @@ public class HorseMeta extends AbstractHorseMeta {
+         GRAY,
+         DARK_BROWN;
+ 
+-        private final static Color[] VALUES = values();
++        private static final Color[] VALUES = values();
+     }
+ 
+ }
+diff --git a/src/main/java/net/minestom/server/entity/metadata/animal/LlamaMeta.java b/src/main/java/net/minestom/server/entity/metadata/animal/LlamaMeta.java
+index dd9a4dba47357d3877a22489e3ecfca8c2cf2ca7..a9b74a5b87d094847bed5d69cb604a7224a0079b 100644
+--- a/src/main/java/net/minestom/server/entity/metadata/animal/LlamaMeta.java
++++ b/src/main/java/net/minestom/server/entity/metadata/animal/LlamaMeta.java
+@@ -42,7 +42,7 @@ public class LlamaMeta extends ChestedHorseMeta {
+         BROWN,
+         GRAY;
+ 
+-        private final static Variant[] VALUES = values();
++        private static final Variant[] VALUES = values();
+     }
+ 
+ }
 diff --git a/src/main/java/net/minestom/server/entity/metadata/animal/PandaMeta.java b/src/main/java/net/minestom/server/entity/metadata/animal/PandaMeta.java
 index ae5641d210b87217d2bdf84ebfc0381cf7fc0f2c..7d7d4abeb9db2a137f5d7f4f8e85a688e7d1e8ad 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/animal/PandaMeta.java
@@ -229,6 +366,32 @@ index d2115dfb2371d79fe16e907a5a2e19ed7b27d73b..a114f62f6ee88e399ebbbfe95191c63b
  
      protected AbstractArrowMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
          super(entity, metadata);
+diff --git a/src/main/java/net/minestom/server/entity/metadata/display/AbstractDisplayMeta.java b/src/main/java/net/minestom/server/entity/metadata/display/AbstractDisplayMeta.java
+index fce02b850183964a964b9e342ae5ab0acf4648b0..76747449e0d1e410b35e30bb364310a46f0c0710 100644
+--- a/src/main/java/net/minestom/server/entity/metadata/display/AbstractDisplayMeta.java
++++ b/src/main/java/net/minestom/server/entity/metadata/display/AbstractDisplayMeta.java
+@@ -137,7 +137,6 @@ public class AbstractDisplayMeta extends EntityMeta {
+         HORIZONTAL,
+         CENTER;
+ 
+-        private final static BillboardConstraints[] VALUES = values();
++        private static final BillboardConstraints[] VALUES = values();
+     }
+-
+ }
+diff --git a/src/main/java/net/minestom/server/entity/metadata/display/ItemDisplayMeta.java b/src/main/java/net/minestom/server/entity/metadata/display/ItemDisplayMeta.java
+index f574b37d77df167e5dfebc4eb479ce49dfd049c2..9528acea84ce6c19ae5715185f8c62e436a2e987 100644
+--- a/src/main/java/net/minestom/server/entity/metadata/display/ItemDisplayMeta.java
++++ b/src/main/java/net/minestom/server/entity/metadata/display/ItemDisplayMeta.java
+@@ -42,7 +42,7 @@ public class ItemDisplayMeta extends AbstractDisplayMeta {
+         GROUND,
+         FIXED;
+ 
+-        private final static DisplayContext[] VALUES = values();
++        private static final DisplayContext[] VALUES = values();
+ 
+     }
+ 
 diff --git a/src/main/java/net/minestom/server/entity/metadata/golem/IronGolemMeta.java b/src/main/java/net/minestom/server/entity/metadata/golem/IronGolemMeta.java
 index 9bbab19dceff737cac3c69738125e5b9d604057c..6e90878166490f01f81e1e178136faff79288da6 100644
 --- a/src/main/java/net/minestom/server/entity/metadata/golem/IronGolemMeta.java
@@ -302,6 +465,190 @@ index 3203cdc0c07ffd9338a798ac26efd64b6eadf28a..292b2c0e20e4eddb11679f529460420b
  
      public ArmorStandMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
          super(entity, metadata);
+diff --git a/src/main/java/net/minestom/server/entity/metadata/other/EnderDragonMeta.java b/src/main/java/net/minestom/server/entity/metadata/other/EnderDragonMeta.java
+index 7a9e49231bfe9b8f576e46f56ba22897a5e9a433..383fd9a0af6de3397097566eb8a1486f7b8ce658 100644
+--- a/src/main/java/net/minestom/server/entity/metadata/other/EnderDragonMeta.java
++++ b/src/main/java/net/minestom/server/entity/metadata/other/EnderDragonMeta.java
+@@ -35,7 +35,7 @@ public class EnderDragonMeta extends MobMeta {
+         FLYING_TO_THE_PORTAL_TO_DIE,
+         HOVERING_WITHOUT_AI;
+ 
+-        private final static Phase[] VALUES = values();
++        private static final Phase[] VALUES = values();
+     }
+ 
+ }
+diff --git a/src/main/java/net/minestom/server/entity/metadata/water/AxolotlMeta.java b/src/main/java/net/minestom/server/entity/metadata/water/AxolotlMeta.java
+index f162eb7de22edc949b17a89fcff4477bf1c3c0cf..af421c0aa1fddc76155af9ee92a7823f9967c7de 100644
+--- a/src/main/java/net/minestom/server/entity/metadata/water/AxolotlMeta.java
++++ b/src/main/java/net/minestom/server/entity/metadata/water/AxolotlMeta.java
+@@ -44,6 +44,6 @@ public class AxolotlMeta extends AnimalMeta {
+         CYAN,
+         BLUE;
+ 
+-        private final static AxolotlMeta.Variant[] VALUES = values();
++        private static final AxolotlMeta.Variant[] VALUES = values();
+     }
+ }
+diff --git a/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java b/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
+index 1239990db6444176ad3fd83365e1ad010d367890..a68e8b3b2b4c5ac4608c84fa8865a5c2ffab50b7 100644
+--- a/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
++++ b/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
+@@ -59,12 +59,12 @@ public final class DiscoveredExtension {
+     transient LoadStatus loadStatus = LoadStatus.LOAD_SUCCESS;
+ 
+     /** The original jar this is from. */
+-    transient private File originalJar;
++    private transient File originalJar;
+ 
+-    transient private Path dataDirectory;
++    private transient Path dataDirectory;
+ 
+     /** The class loader that powers it. */
+-    transient private ExtensionClassLoader classLoader;
++    private transient ExtensionClassLoader classLoader;
+ 
+     @NotNull
+     public String getName() {
+diff --git a/src/main/java/net/minestom/server/extensions/ExtensionManager.java b/src/main/java/net/minestom/server/extensions/ExtensionManager.java
+index d664544c89eda8f4d4051dceeb7d8ee002ad33ac..667ed1f44fc8e2abf28fca492e87cb9b3292aa51 100644
+--- a/src/main/java/net/minestom/server/extensions/ExtensionManager.java
++++ b/src/main/java/net/minestom/server/extensions/ExtensionManager.java
+@@ -24,12 +24,10 @@ import java.util.zip.ZipFile;
+ 
+ public class ExtensionManager {
+ 
+-    public final static Logger LOGGER = LoggerFactory.getLogger(ExtensionManager.class);
+-
+-    public final static String INDEV_CLASSES_FOLDER = "minestom.extension.indevfolder.classes";
+-    public final static String INDEV_RESOURCES_FOLDER = "minestom.extension.indevfolder.resources";
+-    private final static Gson GSON = new Gson();
+-
++    public static final Logger LOGGER = LoggerFactory.getLogger(ExtensionManager.class);
++    public static final String INDEV_CLASSES_FOLDER = "minestom.extension.indevfolder.classes";
++    public static final String INDEV_RESOURCES_FOLDER = "minestom.extension.indevfolder.resources";
++    private static final Gson GSON = new Gson();
+     private final ServerProcess serverProcess;
+ 
+     // LinkedHashMaps are HashMaps that preserve order
+diff --git a/src/main/java/net/minestom/server/extras/bungee/BungeeCordProxy.java b/src/main/java/net/minestom/server/extras/bungee/BungeeCordProxy.java
+index 82884558daa9497aa4eafd429e053c43867667df..cb3f1333df0b6ef53c1cf0f7563c811beda17ff2 100644
+--- a/src/main/java/net/minestom/server/extras/bungee/BungeeCordProxy.java
++++ b/src/main/java/net/minestom/server/extras/bungee/BungeeCordProxy.java
+@@ -1,7 +1,5 @@
+ package net.minestom.server.extras.bungee;
+ 
+-import net.kyori.adventure.text.Component;
+-import net.kyori.adventure.text.format.NamedTextColor;
+ import org.jetbrains.annotations.NotNull;
+ import org.jetbrains.annotations.Nullable;
+ 
+diff --git a/src/main/java/net/minestom/server/instance/Explosion.java b/src/main/java/net/minestom/server/instance/Explosion.java
+index 186be7a1da3202d2c25422e723b153baf3acf3f9..cf13e4a2851fb31c2cb76ba253f33de16a124ba6 100644
+--- a/src/main/java/net/minestom/server/instance/Explosion.java
++++ b/src/main/java/net/minestom/server/instance/Explosion.java
+@@ -19,7 +19,7 @@ public abstract class Explosion {
+     private final float centerZ;
+     private final float strength;
+ 
+-    public Explosion(float centerX, float centerY, float centerZ, float strength) {
++    protected Explosion(float centerX, float centerY, float centerZ, float strength) {
+         this.centerX = centerX;
+         this.centerY = centerY;
+         this.centerZ = centerZ;
+diff --git a/src/main/java/net/minestom/server/instance/block/BlockManager.java b/src/main/java/net/minestom/server/instance/block/BlockManager.java
+index fd0243002b94167e1ba18c2c13a9705149933754..46d1baf7c462d98be25f18170c63b5edeebdea59 100644
+--- a/src/main/java/net/minestom/server/instance/block/BlockManager.java
++++ b/src/main/java/net/minestom/server/instance/block/BlockManager.java
+@@ -17,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap;
+ import java.util.function.Supplier;
+ 
+ public final class BlockManager {
+-    private final static Logger LOGGER = LoggerFactory.getLogger(BlockManager.class);
++    private static final Logger LOGGER = LoggerFactory.getLogger(BlockManager.class);
+     // Namespace -> handler supplier
+     private final Map<String, Supplier<BlockHandler>> blockHandlerMap = new ConcurrentHashMap<>();
+     // block id -> block placement rule
+diff --git a/src/main/java/net/minestom/server/instance/block/rule/BlockPlacementRule.java b/src/main/java/net/minestom/server/instance/block/rule/BlockPlacementRule.java
+index cb354931affb1364983728eb0946124fd390277c..c72d346c22dfa342e7700788c7ac5fb7ebbe5bda 100644
+--- a/src/main/java/net/minestom/server/instance/block/rule/BlockPlacementRule.java
++++ b/src/main/java/net/minestom/server/instance/block/rule/BlockPlacementRule.java
+@@ -11,7 +11,7 @@ import org.jetbrains.annotations.Nullable;
+ public abstract class BlockPlacementRule {
+     private final Block block;
+ 
+-    public BlockPlacementRule(@NotNull Block block) {
++    BlockPlacementRule(@NotNull Block block) {
+         this.block = block;
+     }
+ 
+diff --git a/src/main/java/net/minestom/server/inventory/AbstractInventory.java b/src/main/java/net/minestom/server/inventory/AbstractInventory.java
+index 99cfc2fb0d8d7c6da959a93dfe21ce28405956a7..21d13deaf3b4aa93725579394a82ddc3e1483e23 100644
+--- a/src/main/java/net/minestom/server/inventory/AbstractInventory.java
++++ b/src/main/java/net/minestom/server/inventory/AbstractInventory.java
+@@ -23,7 +23,7 @@ import java.util.function.UnaryOperator;
+ /**
+  * Represents an inventory where items can be modified/retrieved.
+  */
+-public sealed abstract class AbstractInventory implements InventoryClickHandler, Taggable
++public abstract sealed class AbstractInventory implements InventoryClickHandler, Taggable
+         permits Inventory, PlayerInventory {
+ 
+     private static final VarHandle ITEM_UPDATER = MethodHandles.arrayElementVarHandle(ItemStack[].class);
+diff --git a/src/main/java/net/minestom/server/listener/AdvancementTabListener.java b/src/main/java/net/minestom/server/listener/AdvancementTabListener.java
+index 3a8edbd121b8da1ee970ecdc106955d76508f514..a27c3f10dbd60190260e66012242f1c09b6c16d5 100644
+--- a/src/main/java/net/minestom/server/listener/AdvancementTabListener.java
++++ b/src/main/java/net/minestom/server/listener/AdvancementTabListener.java
+@@ -7,6 +7,8 @@ import net.minestom.server.network.packet.client.play.ClientAdvancementTabPacket
+ 
+ public class AdvancementTabListener {
+ 
++    private AdvancementTabListener() {}
++
+     public static void listener(ClientAdvancementTabPacket packet, Player player) {
+         final String tabIdentifier = packet.tabIdentifier();
+         if (tabIdentifier != null) {
+diff --git a/src/main/java/net/minestom/server/listener/AnimationListener.java b/src/main/java/net/minestom/server/listener/AnimationListener.java
+index 42e249c73869e7c819a177f3144869c10bbe820a..11186e9470d129fefed2fb5f47dc736d180e6321 100644
+--- a/src/main/java/net/minestom/server/listener/AnimationListener.java
++++ b/src/main/java/net/minestom/server/listener/AnimationListener.java
+@@ -8,6 +8,8 @@ import net.minestom.server.network.packet.client.play.ClientAnimationPacket;
+ 
+ public class AnimationListener {
+ 
++    private AnimationListener() { }
++
+     public static void animationListener(ClientAnimationPacket packet, Player player) {
+         final Player.Hand hand = packet.hand();
+         final ItemStack itemStack = player.getItemInHand(hand);
+diff --git a/src/main/java/net/minestom/server/monitoring/BenchmarkManager.java b/src/main/java/net/minestom/server/monitoring/BenchmarkManager.java
+index 84c502629a38bc45f60dbf650eaf1b094d1d0df0..09970b507b49f85185b693ad8efe19e50491038c 100644
+--- a/src/main/java/net/minestom/server/monitoring/BenchmarkManager.java
++++ b/src/main/java/net/minestom/server/monitoring/BenchmarkManager.java
+@@ -34,7 +34,7 @@ import static net.minestom.server.MinecraftServer.THREAD_NAME_TICK_SCHEDULER;
+  * Be aware that this is not the most accurate method, you should use a proper java profiler depending on your needs.
+  */
+ public final class BenchmarkManager {
+-    private final static Logger LOGGER = LoggerFactory.getLogger(BenchmarkManager.class);
++    private static final Logger LOGGER = LoggerFactory.getLogger(BenchmarkManager.class);
+     private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
+     private static final List<String> THREADS = new ArrayList<>();
+ 
+diff --git a/src/main/java/net/minestom/server/thread/Acquirable.java b/src/main/java/net/minestom/server/thread/Acquirable.java
+index 4730006416bd9c4a7f1ff291feddb83c9ffedd6d..48336a9e3f5190431dd4e4b392fc83cf668b69d7 100644
+--- a/src/main/java/net/minestom/server/thread/Acquirable.java
++++ b/src/main/java/net/minestom/server/thread/Acquirable.java
+@@ -26,8 +26,8 @@ public sealed interface Acquirable<T> permits AcquirableImpl {
+         if (currentThread instanceof TickThread) {
+             return ((TickThread) currentThread).entries().stream()
+                     .flatMap(partitionEntry -> partitionEntry.elements().stream())
+-                    .filter(tickable -> tickable instanceof Entity)
+-                    .map(tickable -> (Entity) tickable);
++                    .filter(Entity.class::isInstance)
++                    .map(Entity.class::cast);
+         }
+         return Stream.empty();
+     }
 diff --git a/src/test/java/net/minestom/server/InsideTest.java b/src/test/java/net/minestom/server/InsideTest.java
 index 4fd8bc46ba32abc852398872bf8b63a30617408e..33c65cc23c0982d2e37eb12e40d844562bf85380 100644
 --- a/src/test/java/net/minestom/server/InsideTest.java
@@ -1446,7 +1793,7 @@ index e65c400d089c91d3bdb36a7555da35480b07e529..f224f1128b5667433a1de0fae4cec962
  
          assertArg(arg, "word1", "word1");
 diff --git a/src/test/java/net/minestom/server/command/CommandConditionTest.java b/src/test/java/net/minestom/server/command/CommandConditionTest.java
-index f7450b020c91807984e83b004774c916621d152f..362761f1da55b0a50e79959add8cb2f4cbd4dd5f 100644
+index f7450b020c91807984e83b004774c916621d152f..f76f113a161c315badfdec9ef5932dbf4a461e40 100644
 --- a/src/test/java/net/minestom/server/command/CommandConditionTest.java
 +++ b/src/test/java/net/minestom/server/command/CommandConditionTest.java
 @@ -13,10 +13,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
@@ -1459,6 +1806,24 @@ index f7450b020c91807984e83b004774c916621d152f..362761f1da55b0a50e79959add8cb2f4
      @Test
 -    public void mainCondition() {
 +    void mainCondition() {
+         var dispatcher = new CommandDispatcher();
+         assertNull(dispatcher.findCommand("name"));
+         var sender = new Sender();
+@@ -39,7 +39,7 @@ public class CommandConditionTest {
+     }
+ 
+     @Test
+-    public void subCondition() {
++    void subCondition() {
+         var dispatcher = new CommandDispatcher();
+         assertNull(dispatcher.findCommand("name"));
+         var sender = new Sender();
+@@ -83,7 +83,7 @@ public class CommandConditionTest {
+     }
+ 
+     @Test
+-    public void subConditionOverride() {
++    void subConditionOverride() {
          var dispatcher = new CommandDispatcher();
          assertNull(dispatcher.findCommand("name"));
          var sender = new Sender();
@@ -3065,10 +3430,10 @@ index 40038cf6f257e058e79ffb8eacdcf96ca1e61685..6074de4b7fc26017f615bf08503dd010
          var p1 = env.createPlayer(instance, new Pos(0, 42, 0));
          var p2 = env.createPlayer(instance, new Pos(0, 42, 0));
 diff --git a/src/test/java/net/minestom/server/entity/GameModeTest.java b/src/test/java/net/minestom/server/entity/GameModeTest.java
-index 2d7ea85dd0764cf052efa3ced47bab698c6c3aa4..4f00aa0e8ccdfd8a46152a6cb06b2cfb4f5729a7 100644
+index 2d7ea85dd0764cf052efa3ced47bab698c6c3aa4..f249cac8065fe61c163c03573b1ad2430bd4c262 100644
 --- a/src/test/java/net/minestom/server/entity/GameModeTest.java
 +++ b/src/test/java/net/minestom/server/entity/GameModeTest.java
-@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
+@@ -4,18 +4,18 @@ import org.junit.jupiter.api.Test;
  
  import static org.junit.jupiter.api.Assertions.assertEquals;
  
@@ -3077,11 +3442,15 @@ index 2d7ea85dd0764cf052efa3ced47bab698c6c3aa4..4f00aa0e8ccdfd8a46152a6cb06b2cfb
  
      @Test
 -    public void toId() {
+-        assertEquals(GameMode.SURVIVAL.id(), 0);
+-        assertEquals(GameMode.CREATIVE.id(), 1);
+-        assertEquals(GameMode.ADVENTURE.id(), 2);
+-        assertEquals(GameMode.SPECTATOR.id(), 3);
 +    void toId() {
-         assertEquals(GameMode.SURVIVAL.id(), 0);
-         assertEquals(GameMode.CREATIVE.id(), 1);
-         assertEquals(GameMode.ADVENTURE.id(), 2);
-@@ -15,7 +15,7 @@ public class GameModeTest {
++        assertEquals(0, GameMode.SURVIVAL.id());
++        assertEquals(1, GameMode.CREATIVE.id());
++        assertEquals(2, GameMode.ADVENTURE.id());
++        assertEquals(3, GameMode.SPECTATOR.id());
      }
  
      @Test

--- a/minestom-patches/0015-Update-java-keyword-usage.patch
+++ b/minestom-patches/0015-Update-java-keyword-usage.patch
@@ -612,15 +612,12 @@ index fd0243002b94167e1ba18c2c13a9705149933754..d19f1c5043208e841be40d1b4cffdcbe
      private final Map<String, Supplier<BlockHandler>> blockHandlerMap = new ConcurrentHashMap<>();
      // block id -> block placement rule
 diff --git a/src/main/java/net/minestom/server/instance/block/rule/BlockPlacementRule.java b/src/main/java/net/minestom/server/instance/block/rule/BlockPlacementRule.java
-index cb354931affb1364983728eb0946124fd390277c..e33450545966402c40a935962e2c7d0bb1ee5e98 100644
+index cb354931affb1364983728eb0946124fd390277c..b4a96fd127ff3ed819768c8a52e3f9cd217665ed 100644
 --- a/src/main/java/net/minestom/server/instance/block/rule/BlockPlacementRule.java
 +++ b/src/main/java/net/minestom/server/instance/block/rule/BlockPlacementRule.java
-@@ -11,9 +11,9 @@ import org.jetbrains.annotations.Nullable;
- public abstract class BlockPlacementRule {
-     private final Block block;
+@@ -13,7 +13,7 @@ public abstract class BlockPlacementRule {
  
--    public BlockPlacementRule(@NotNull Block block) {
-+    BlockPlacementRule(@NotNull Block block) {
+     public BlockPlacementRule(@NotNull Block block) {
          this.block = block;
 -    }
 +    }  //Microtus - update java keyword usage

--- a/minestom-patches/0016-Update-java-keyword-usage.patch
+++ b/minestom-patches/0016-Update-java-keyword-usage.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Update java keyword usage
 
 
 diff --git a/src/main/java/net/minestom/server/adventure/AdventurePacketConvertor.java b/src/main/java/net/minestom/server/adventure/AdventurePacketConvertor.java
-index 04244d43a556e33b5ce9cb4cf727433f976af35b..4c8de4b9f8f48d59555c7118b46dcc0206466f3d 100644
+index 2d9fe8a7a8ebb0d6ef5af7ece430d769c158c164..26af86e8b53e2af54c6cee272d2f7aad17be0912 100644
 --- a/src/main/java/net/minestom/server/adventure/AdventurePacketConvertor.java
 +++ b/src/main/java/net/minestom/server/adventure/AdventurePacketConvertor.java
-@@ -46,6 +46,8 @@ public class AdventurePacketConvertor {
+@@ -45,6 +45,8 @@ public class AdventurePacketConvertor {
          NAMED_TEXT_COLOR_ID_MAP.put(NamedTextColor.WHITE, 15);
      }
  


### PR DESCRIPTION
## Proposed changes

The codebase of `Minestom` infrequently uses different combinations of Java keywords that do not strictly adhere to coding conventions. While these variations do not impede the code or hinder the compilation process, code analysis tools may detect these clashes each time they occur. Additionally, the test files include the `public` keyword, which is unnecessary when using `JUnit 5`. This pull request addresses and improves the usage of Java keywords in most instances.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...