### PR TITLE
Add support for MiniMessage

### DIFF
--- a/minestom-patches/0001-Rework-gradle-management.patch
+++ b/minestom-patches/0001-Rework-gradle-management.patch
@@ -172,7 +172,7 @@ index 60b18683dd01e7f349f7f22465db2bde969c9690..5f8acd515579c6356296929cbe512ed1
  
  dependencies {
 diff --git a/gradle/libs.versions.toml b/gradle/libs.versions.toml
-index b3da234609fcb6f3ab1866a2fc806719b29f97f2..4de407f8a09adb19c1a787f6cc06c2278ce4e0fe 100644
+index b3da234609fcb6f3ab1866a2fc806719b29f97f2..62ce19b6a9435b70ef3bc53d9cdb47e5fe728960 100644
 --- a/gradle/libs.versions.toml
 +++ b/gradle/libs.versions.toml
 @@ -3,29 +3,29 @@ metadata.format.version = "1.1"
@@ -235,7 +235,15 @@ index b3da234609fcb6f3ab1866a2fc806719b29f97f2..4de407f8a09adb19c1a787f6cc06c227
  
  [libraries]
  
-@@ -59,7 +59,7 @@ kotlin-stdlib-jdk8 = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk
+@@ -51,6 +51,7 @@ adventure-serializer-gson = { group = "net.kyori", name = "adventure-text-serial
+ adventure-serializer-legacy = { group = "net.kyori", name = "adventure-text-serializer-legacy", version.ref = "adventure" }
+ adventure-serializer-plain = { group = "net.kyori", name = "adventure-text-serializer-plain", version.ref = "adventure" }
+ adventure-text-logger-slf4j = { group = "net.kyori", name = "adventure-text-logger-slf4j", version.ref = "adventure" }
++adventure-mini-message = { group = "net.kyori", name = "adventure-text-minimessage", version.ref = "adventure" }
+ 
+ # Kotlin
+ kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
+@@ -59,7 +60,7 @@ kotlin-stdlib-jdk8 = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk
  # Miscellaneous
  hydrazine = { group = "com.github.MadMartian", name = "hydrazine-path-finding", version.ref = "hydrazine" }
  dependencyGetter = { group = "com.github.Minestom", name = "DependencyGetter", version.ref = "dependencyGetter" }
@@ -244,7 +252,14 @@ index b3da234609fcb6f3ab1866a2fc806719b29f97f2..4de407f8a09adb19c1a787f6cc06c227
  jetbrainsAnnotations = { group = "org.jetbrains", name = "annotations", version.ref = "jetbrainsAnnotations" }
  
  # Logging
-@@ -110,4 +110,4 @@ terminal = ["jline", "jline-jansi"]
+@@ -104,10 +105,10 @@ jcstress-core = { group = "org.openjdk.jcstress", name = "jcstress-core", versio
+ 
+ kotlin = ["kotlin-stdlib-jdk8", "kotlin-reflect"]
+ flare = ["flare", "flare-fastutil"]
+-adventure = ["adventure-api", "adventure-serializer-gson", "adventure-serializer-legacy", "adventure-serializer-plain", "adventure-text-logger-slf4j"]
++adventure = ["adventure-api", "adventure-mini-message", "adventure-serializer-gson", "adventure-serializer-legacy", "adventure-serializer-plain", "adventure-text-logger-slf4j"]
+ logging = ["tinylog-api", "tinylog-impl", "tinylog-slf4j"]
+ terminal = ["jline", "jline-jansi"]
  
  [plugins]
  

--- a/minestom-patches/0016-Add-bstats-support-and-integration.patch
+++ b/minestom-patches/0016-Add-bstats-support-and-integration.patch
@@ -18,7 +18,7 @@ index 22f62e8000f5417a8e22ab8d5591ca5f613c3323..5afbe3d8420c9c82b81443748ea39328
  }
  
 diff --git a/gradle/libs.versions.toml b/gradle/libs.versions.toml
-index 4de407f8a09adb19c1a787f6cc06c2278ce4e0fe..16dab6542ac2c681dad630c6f11790b8aa4bc4a2 100644
+index 62ce19b6a9435b70ef3bc53d9cdb47e5fe728960..761ea39d71296076fb7586d804cdc7805611008d 100644
 --- a/gradle/libs.versions.toml
 +++ b/gradle/libs.versions.toml
 @@ -42,6 +42,9 @@ jcstress = "0.16"
@@ -31,7 +31,7 @@ index 4de407f8a09adb19c1a787f6cc06c2278ce4e0fe..16dab6542ac2c681dad630c6f11790b8
  [libraries]
  
  # Important Dependencies
-@@ -100,6 +103,9 @@ jmh-annotationprocessor = { group = "org.openjdk.jmh", name = "jmh-generator-ann
+@@ -101,6 +104,9 @@ jmh-annotationprocessor = { group = "org.openjdk.jmh", name = "jmh-generator-ann
  # JCStress
  jcstress-core = { group = "org.openjdk.jcstress", name = "jcstress-core", version.ref = "jcstress" }
  


### PR DESCRIPTION
## Proposed changes

Minestom does not include or shade the `MiniMessage` dependency from `Adventure`. While this is typically not a major issue, it can be inconvenient when you specifically want to use it. In such cases, you need to include the library manually for each project, which is not very convenient.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...