### PR TITLE
Enhance instance and player handling in the test module

### DIFF
--- a/src/test/java/net/minestom/server/instance/InstancePlayerIntegrationTest.java
+++ b/src/test/java/net/minestom/server/instance/InstancePlayerIntegrationTest.java
@@ -1,0 +1,48 @@
+package net.minestom.server.instance;
+
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.Player;
+import net.minestom.testing.Env;
+import net.minestom.testing.extension.MicrotusExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MicrotusExtension.class)
+public class InstancePlayerIntegrationTest {
+
+    @Test
+    void testInstanceDestroyWithPlayersInside(Env env) {
+        Instance instance = env.createFlatInstance();
+        for (int i = 0; i < 3; i++) {
+            // Default position is Pos.ZERO
+            env.createPlayer(instance);
+        }
+
+        assertFalse(instance.getPlayers().isEmpty());
+        for (Player player : instance.getPlayers()) {
+            assertEquals(Pos.ZERO, player.getPosition());
+        }
+        assertDoesNotThrow(() -> env.destroyInstance(instance, true));
+        assertTrue(instance.getPlayers().isEmpty());
+    }
+
+    @Test
+    void testInstanceDestroyWithExceptionThrow(Env env) {
+        Instance instance = env.createFlatInstance();
+        for (int i = 0; i < 3; i++) {
+            // Default position is Pos.ZERO
+            env.createPlayer(instance);
+        }
+        assertFalse(instance.getPlayers().isEmpty());
+        assertThrows(
+                IllegalStateException.class,
+                () -> env.destroyInstance(instance),
+                "You cannot unregister an instance with players inside."
+        );
+        assertFalse(instance.getPlayers().isEmpty());
+        env.destroyInstance(instance, true);
+        assertTrue(instance.getPlayers().isEmpty());
+    }
+}

--- a/testing/src/main/java/net/minestom/testing/Env.java
+++ b/testing/src/main/java/net/minestom/testing/Env.java
@@ -8,25 +8,93 @@ import net.minestom.server.event.EventFilter;
 import net.minestom.server.instance.IChunkLoader;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.Duration;
 import java.util.function.BooleanSupplier;
 
+/**
+ * The {@code Env} class facilitates the creation of tests (e.g., JUnit tests) that interact directly
+ * with the server. It provides a simple way to set up a test environment where server
+ * components like players, instances, and other entities can be created and manipulated.
+ *
+ * <p>This class is particularly useful for testing code that interacts with server components, which would
+ * otherwise require the use of a mocking framework. By using this class, developers can create more realistic
+ * tests that involve actual server behavior, without needing to mock every component.
+ *
+ * <p>The {@code Env} class provides utility methods to:
+ * <ul>
+ *   <li>Create new object references for {@link net.minestom.server.entity.Player Player}</li>
+ *   <li>Initialize and manipulate server {@link net.minestom.server.instance.Instance Instances}</li>
+ *   <li>Simulate server events and other interactions</li>
+ * </ul>
+ *
+ * <p>This class is intended for use in unit tests, integration tests, and other testing scenarios where
+ * interaction with a live server environment is necessary.
+ *
+ * @version 1.0.1
+ * @since 1.0.0
+ */
 public interface Env {
+
+    /**
+     * Creates a new instance of {@link Env} with the given {@link ServerProcess}.
+     *
+     * @param process the process to use
+     * @return a new instance of {@link Env}
+     */
+    @Contract(value = "_ -> new", pure = true)
+    static @NotNull Env createInstance(@NotNull ServerProcess process) {
+        return new EnvImpl(process);
+    }
+
+    /**
+     * Gets the {@link ServerProcess} used by this environment.
+     *
+     * @return the server process
+     */
     @NotNull ServerProcess process();
 
+    /**
+     * Creates a new {@link TestConnection} which can be used in the test environment.
+     *
+     * @return the created connection
+     */
     @NotNull TestConnection createConnection();
 
+    /**
+     * Tracks a specific event type in the test environment.
+     *
+     * @param eventType the event type to track
+     * @param <E>       the event type
+     * @return the {@link Collector} instance to use
+     */
     <E extends Event, H> @NotNull Collector<E> trackEvent(@NotNull Class<E> eventType, @NotNull EventFilter<? super E, H> filter, @NotNull H actor);
 
+    /**
+     * Listen for a specific event type in the test environment.
+     *
+     * @param eventType the event type to listen for
+     * @param <E>       the event type
+     * @return the {@link FlexibleListener} instance to use
+     */
     <E extends Event> @NotNull FlexibleListener<E> listen(@NotNull Class<E> eventType);
 
+    /**
+     * Ticks the {@link ServerProcess} which is involved into the env instance.
+     */
     default void tick() {
         process().ticker().tick(System.nanoTime());
     }
 
-    default boolean tickWhile(BooleanSupplier condition, Duration timeout) {
+    /**
+     * Ticks the {@link ServerProcess} until the given condition is met.
+     *
+     * @param condition the condition to check
+     */
+    default boolean tickWhile(@NotNull BooleanSupplier condition, @Nullable Duration timeout) {
         var ticker = process().ticker();
         final long start = System.nanoTime();
         while (condition.getAsBoolean()) {
@@ -39,31 +107,75 @@ public interface Env {
         return true;
     }
 
+    /**
+     * Creates a new instance of an {@link Player} which can be used in the test environment.
+     *
+     * @param instance the instance to spawn the player in
+     * @param pos      the position to spawn the player at
+     * @return the created player
+     */
     default @NotNull Player createPlayer(@NotNull Instance instance, @NotNull Pos pos) {
         return createConnection().connect(instance, pos).join();
     }
 
+    /**
+     * Creates a new instance of an {@link Player} which can be used in the test environment.
+     *
+     * @param instance the instance to spawn the player in
+     * @return the created player
+     */
+    default @NotNull Player createPlayer(@NotNull Instance instance) {
+        return createPlayer(instance, Pos.ZERO);
+    }
+
+    /**
+     * Creates a new {@link Instance} which contains only one layer of stone blocks.
+     *
+     * @return the created instance
+     */
     default @NotNull Instance createFlatInstance() {
         return createFlatInstance(null);
     }
 
-    default @NotNull Instance createFlatInstance(IChunkLoader chunkLoader) {
+    /**
+     * Creates a new {@link Instance} which contains only one layer of stone blocks.
+     *
+     * @param chunkLoader the chunk loader to use for the instance
+     * @return the created instance
+     */
+    default @NotNull Instance createFlatInstance(@Nullable IChunkLoader chunkLoader) {
         var instance = process().instance().createInstanceContainer(chunkLoader);
         instance.setGenerator(unit -> unit.modifier().fillHeight(0, 40, Block.STONE));
         return instance;
     }
 
-    default void destroyInstance(Instance instance) {
+    /**
+     * Destroys the given {@link Instance} from the test environment.
+     * Note: This method does not remove players from the instance.
+     *
+     * @param instance the instance to destroy
+     */
+    default void destroyInstance(@NotNull Instance instance) {
+        destroyInstance(instance, false);
+    }
+
+    /**
+     * Destroys the given {@link Instance} from the test environment.
+     *
+     * @param instance       the instance to destroy
+     * @param cleanUpPlayers whether to remove players from the instance
+     */
+    default void destroyInstance(@NotNull Instance instance, boolean cleanUpPlayers) {
+        if (cleanUpPlayers && !instance.getPlayers().isEmpty()) {
+            instance.getPlayers().forEach(Player::remove);
+        }
         process().instance().unregisterInstance(instance);
     }
 
     /**
      * Cleanup the test environment
+     *
      * @since 1.4.1
      */
     void cleanup();
-
-    static Env createInstance(ServerProcess process) {
-        return new EnvImpl(process);
-    }
 }


### PR DESCRIPTION
## Proposed changes

The Minestom testing module allows for the creation of tests that interact with specific parts of the server. However, its handling has some issues. For example, when you unregister an instance with players in it an exception is thrown. The players are not unregistered by default. Additionally, when creating a player, a position is required even in cases where it is unnecessary; a default value should be used instead.

This pull request aims to achieve the following goals:

Add a player creation method that does not require a position, using a default value instead.
Modify the instance unregistration method to include an option to remove all players from the instance, preventing an exception from being thrown.

**Note**: This pull request does not break existing tests. The new methods are additions that do not change existing behavior. Users can choose to remove players from an instance or specify a specific position when creating a player.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)