### PR TITLE
Improve BlockFace usage to avoid unnecessary object creation

### DIFF
--- a/src/main/java/net/minestom/server/collision/ShapeImpl.java
+++ b/src/main/java/net/minestom/server/collision/ShapeImpl.java
@@ -208,7 +208,7 @@ public record ShapeImpl(CollisionData collisionData, LightData lightData) implem
         }
 
         byte fullCollisionFaces = 0;
-        for (BlockFace f : BlockFace.values()) {
+        for (BlockFace f : BlockFace.getValues()) {
             final byte res = isFaceCovered(computeOcclusionSet(f, collisionBoundingBoxes));
             fullCollisionFaces |= ((res == 2) ? 0b1 : 0b0) << (byte) f.ordinal();
         }
@@ -219,7 +219,7 @@ public record ShapeImpl(CollisionData collisionData, LightData lightData) implem
     private static LightData lightData(List<BoundingBox> occlusionBoundingBoxes, int lightEmission) {
         byte fullFaces = 0;
         byte airFaces = 0;
-        for (BlockFace f : BlockFace.values()) {
+        for (BlockFace f : BlockFace.getValues()) {
             final byte res = isFaceCovered(computeOcclusionSet(f, occlusionBoundingBoxes));
             fullFaces |= ((res == 2) ? 0b1 : 0b0) << (byte) f.ordinal();
             airFaces |= ((res == 0) ? 0b1 : 0b0) << (byte) f.ordinal();

--- a/src/main/java/net/minestom/server/instance/block/BlockFace.java
+++ b/src/main/java/net/minestom/server/instance/block/BlockFace.java
@@ -3,7 +3,13 @@ package net.minestom.server.instance.block;
 import net.minestom.server.utils.Direction;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * The enumeration contains all faces which a block can have in the game.
+ * It's possible that specific blocks doesn't have all faces
+ * @version 1.0.1
+ */
 public enum BlockFace {
+
     BOTTOM(Direction.DOWN),
     TOP(Direction.UP),
     NORTH(Direction.NORTH),
@@ -11,13 +17,25 @@ public enum BlockFace {
     WEST(Direction.WEST),
     EAST(Direction.EAST);
 
+    private static final BlockFace[] VALUES = values();
+
     private final Direction direction;
 
-    BlockFace(Direction direction) {
+    /**
+     * Creates a new enum entry
+     *
+     * @param direction the direction for the entry
+     */
+    BlockFace(@NotNull Direction direction) {
         this.direction = direction;
     }
 
-    public Direction toDirection() {
+    /**
+     * Returns the {@link Direction} which correspond with the face.
+     *
+     * @return the given direction
+     */
+    public @NotNull Direction toDirection() {
         return direction;
     }
 
@@ -76,5 +94,13 @@ public enum BlockFace {
             case WEST -> WEST;
             case EAST -> EAST;
         };
+    }
+
+    /**
+     * Returns the static accessor which caches all entries from the values call.
+     * @return the given array
+     */
+    public static @NotNull BlockFace[] getValues() {
+        return VALUES;
     }
 }

--- a/src/main/java/net/minestom/server/instance/light/BlockLight.java
+++ b/src/main/java/net/minestom/server/instance/light/BlockLight.java
@@ -52,7 +52,7 @@ final class BlockLight implements Light {
         ShortArrayFIFOQueue lightSources = new ShortArrayFIFOQueue();
 
         for (int i = 0; i < neighbors.length; i++) {
-            final BlockFace face = BlockFace.values()[i];
+            final BlockFace face = BlockFace.getValues()[i];
             Point neighborSection = neighbors[i];
             if (neighborSection == null) continue;
 
@@ -203,7 +203,7 @@ final class BlockLight implements Light {
         for (int i = 0; i < neighbors.length; i++) {
             final Point neighbor = neighbors[i];
             if (neighbor == null) continue;
-            final BlockFace face = BlockFace.values()[i];
+            final BlockFace face = BlockFace.getValues()[i];
             if (!LightCompute.compareBorders(content, contentPropagation, contentPropagationTemp, face)) {
                 toUpdate.add(neighbor);
             }

--- a/src/main/java/net/minestom/server/instance/light/Light.java
+++ b/src/main/java/net/minestom/server/instance/light/Light.java
@@ -51,8 +51,10 @@ public interface Light {
         final int chunkX = chunk.getChunkX();
         final int chunkZ = chunk.getChunkZ();
 
-        Point[] links = new Vec[BlockFace.values().length];
-        for (BlockFace face : BlockFace.values()) {
+        final BlockFace[] faces = BlockFace.getValues();
+
+        Point[] links = new Vec[faces.length];
+        for (BlockFace face : faces) {
             final Direction direction = face.toDirection();
             final int x = chunkX + direction.normalX();
             final int z = chunkZ + direction.normalZ();

--- a/src/main/java/net/minestom/server/instance/light/SkyLight.java
+++ b/src/main/java/net/minestom/server/instance/light/SkyLight.java
@@ -54,7 +54,7 @@ final class SkyLight implements Light {
         ShortArrayFIFOQueue lightSources = new ShortArrayFIFOQueue();
 
         for (int i = 0; i < neighbors.length; i++) {
-            final BlockFace face = BlockFace.values()[i];
+            final BlockFace face = BlockFace.getValues()[i];
             Point neighborSection = neighbors[i];
             if (neighborSection == null) continue;
 
@@ -225,7 +225,7 @@ final class SkyLight implements Light {
         for (int i = 0; i < neighbors.length; i++) {
             final Point neighbor = neighbors[i];
             if (neighbor == null) continue;
-            final BlockFace face = BlockFace.values()[i];
+            final BlockFace face = BlockFace.getValues()[i];
             if (!LightCompute.compareBorders(content, contentPropagation, contentPropagationTemp, face)) {
                 toUpdate.add(neighbor);
             }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerDiggingPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerDiggingPacket.java
@@ -12,7 +12,7 @@ public record ClientPlayerDiggingPacket(@NotNull Status status, @NotNull Point b
                                         @NotNull BlockFace blockFace, int sequence) implements ClientPacket {
     public ClientPlayerDiggingPacket(@NotNull NetworkBuffer reader) {
         this(reader.readEnum(Status.class), reader.read(BLOCK_POSITION),
-                BlockFace.values()[reader.read(BYTE)], reader.read(VAR_INT));
+                BlockFace.getValues()[reader.read(BYTE)], reader.read(VAR_INT));
     }
 
     @Override

--- a/src/test/java/net/minestom/server/instance/light/BlockIsOccludedTest.java
+++ b/src/test/java/net/minestom/server/instance/light/BlockIsOccludedTest.java
@@ -15,7 +15,7 @@ class BlockIsOccludedTest {
     void blockAir() {
         Shape airBlock = Block.AIR.registry().collisionShape();
         
-        for (BlockFace face : BlockFace.values()) {
+        for (BlockFace face : BlockFace.getValues()) {
             assertFalse(airBlock.isOccluded(airBlock, face));
         }
     }
@@ -25,7 +25,7 @@ class BlockIsOccludedTest {
         Shape shape = Block.LANTERN.registry().collisionShape();
         Shape airBlock = Block.AIR.registry().collisionShape();
 
-        for (BlockFace face : BlockFace.values()) {
+        for (BlockFace face : BlockFace.getValues()) {
             assertFalse(shape.isOccluded(airBlock, face));
         }
     }
@@ -35,7 +35,7 @@ class BlockIsOccludedTest {
         Shape shape = Block.SPRUCE_LEAVES.registry().collisionShape();
         Shape airBlock = Block.AIR.registry().collisionShape();
 
-        for (BlockFace face : BlockFace.values()) {
+        for (BlockFace face : BlockFace.getValues()) {
             assertFalse(shape.isOccluded(airBlock, face));
         }
     }
@@ -45,7 +45,7 @@ class BlockIsOccludedTest {
         Shape shape = Block.CAULDRON.registry().collisionShape();
         Shape airBlock = Block.AIR.registry().collisionShape();
 
-        for (BlockFace face : BlockFace.values()) {
+        for (BlockFace face : BlockFace.getValues()) {
             assertFalse(shape.isOccluded(airBlock, face));
         }
     }
@@ -114,7 +114,7 @@ class BlockIsOccludedTest {
         Shape shape = Block.STONE.registry().collisionShape();
         Shape airBlock = Block.AIR.registry().collisionShape();
 
-        for (BlockFace face : BlockFace.values()) {
+        for (BlockFace face : BlockFace.getValues()) {
             assertTrue(shape.isOccluded(airBlock, face));
         }
     }


### PR DESCRIPTION
The `BlockFace` enumeration defines all possible faces a block can have, regardless of whether each face is used by a particular block. However, the usage of the .values method can be optimized. In Java, each time this method is called, a new array reference containing all enumeration entries is created, even though the entries themselves are the same. This can be avoided by caching the result of the method and providing a getter for the cached array. This way, the project can use the cached result without generating new references each time.

While this change may seem like a micro-optimization, it has a positive impact on performance. By using a performance profiler like YourKit or the profiler in IntelliJ, you can observe that in some cases, execution time is reduced compared to before the changes were applied. It is also worth noting that the `.values` method is frequently used in light calculations, which are generally heavy operations. In this specific case, the optimization helps reduce execution time slightly.