### PR TITLE
Add some tests and remove assert.

### DIFF
--- a/src/main/java/net/minestom/server/utils/NamespaceID.java
+++ b/src/main/java/net/minestom/server/utils/NamespaceID.java
@@ -2,6 +2,7 @@ package net.minestom.server.utils;
 
 import net.kyori.adventure.key.Key;
 import org.intellij.lang.annotations.Pattern;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
@@ -9,11 +10,21 @@ import java.util.Objects;
 /**
  * Represents a namespaced ID
  * https://minecraft.wiki/w/Namespaced_ID
+ * @deprecated Use {@link Key} instead!
  */
+@Deprecated
 public record NamespaceID(@NotNull String domain, @NotNull String path) implements CharSequence, Key {
-    private static final String LEGAL_LETTERS = "[0123456789abcdefghijklmnopqrstuvwxyz_-]+";
-    private static final String LEGAL_PATH_LETTERS = "[0123456789abcdefghijklmnopqrstuvwxyz./_-]+";
+    private static final java.util.regex.Pattern LEGAL_LETTERS = java.util.regex.Pattern.compile("[a-z0-9_-]+");
+    private static final java.util.regex.Pattern LEGAL_PATH_LETTERS = java.util.regex.Pattern.compile("[0-9a-z./_-]+");
 
+    /**
+     * Creates a new {@link NamespaceID} from the given namespace
+     * @param namespace the namespace
+     * @return a new {@link NamespaceID}
+     * @deprecated Use {@link Key#key(String)} instead!
+     * @throws IllegalArgumentException if the domain or path contains illegal characters
+     */
+    @Contract("_ -> new")
     public static @NotNull NamespaceID from(@NotNull String namespace) {
         final int index = namespace.indexOf(Key.DEFAULT_SEPARATOR);
         final String domain;
@@ -28,20 +39,39 @@ public record NamespaceID(@NotNull String domain, @NotNull String path) implemen
         return new NamespaceID(domain, path);
     }
 
+    /**
+     * Creates a new {@link NamespaceID} from the given domain and path
+     * @param domain the domain
+     * @param path the path
+     * @return a new {@link NamespaceID}
+     * @deprecated Use {@link Key#key(String, String)} instead!
+     * @throws IllegalArgumentException if the domain or path contains illegal characters
+     */
+    @Contract("_, _ -> new")
     public static @NotNull NamespaceID from(@NotNull String domain, @NotNull String path) {
         return new NamespaceID(domain, path);
     }
 
+    /**
+     * Creates a new {@link NamespaceID} from the given key
+     * @param key the key
+     * @return a new {@link NamespaceID}
+     * @deprecated Use {@link Key#namespace()} and {@link Key#value()} instead!
+     * @throws IllegalArgumentException if the domain or path contains illegal characters
+     */
+    @Deprecated
+    @Contract("_ -> new")
     public static @NotNull NamespaceID from(@NotNull Key key) {
         return new NamespaceID(key.namespace(), key.value());
     }
 
     public NamespaceID {
-        domain = domain.intern();
-        path = path.intern();
-        assert !domain.contains(".") && !domain.contains("/") : "Domain cannot contain a dot nor a slash character (" + asString() + ")";
-        assert domain.matches(LEGAL_LETTERS) : "Illegal character in domain (" + asString() + "). Must match " + LEGAL_LETTERS;
-        assert path.matches(LEGAL_PATH_LETTERS) : "Illegal character in path (" + asString() + "). Must match " + LEGAL_PATH_LETTERS;
+        if (!LEGAL_LETTERS.matcher(domain).matches()) {
+            throw new IllegalArgumentException("Illegal character in domain. Must match " + LEGAL_LETTERS);
+        }
+        if (!LEGAL_PATH_LETTERS.matcher(path).matches()) {
+            throw new IllegalArgumentException("Illegal character in path. Must match " + LEGAL_PATH_LETTERS);
+        }
     }
 
     @Override

--- a/src/test/java/net/minestom/server/utils/NamespaceIDTest.java
+++ b/src/test/java/net/minestom/server/utils/NamespaceIDTest.java
@@ -4,6 +4,7 @@ import net.kyori.adventure.key.Key;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class NamespaceIDTest {
 
@@ -39,49 +40,49 @@ class NamespaceIDTest {
 
     @Test
     void atMostOneColon() {
-        assertThrows(AssertionError.class, () -> NamespaceID.from("minecraft:block:wool"));
+        assertThrows(IllegalArgumentException.class, () -> NamespaceID.from("minecraft:block:wool"));
     }
 
     @Test
     void noSlashInDomain() {
-        assertThrows(AssertionError.class, () -> NamespaceID.from("minecraft/java_edition:any"));
+        assertThrows(IllegalArgumentException.class, () -> NamespaceID.from("minecraft/java_edition:any"));
     }
 
     @Test
     void noDotInDomain() {
-        assertThrows(AssertionError.class, () -> NamespaceID.from("minecraft.java:game"));
+        assertThrows(IllegalArgumentException.class, () -> NamespaceID.from("minecraft.java:game"));
     }
 
     @Test
     void noUppercase() {
-        assertThrows(AssertionError.class, () -> NamespaceID.from("Minecraft:any"));
-        assertThrows(AssertionError.class, () -> NamespaceID.from("minecraft:Any"));
+        assertThrows(IllegalArgumentException.class, () -> NamespaceID.from("Minecraft:any"));
+        assertThrows(IllegalArgumentException.class, () -> NamespaceID.from("minecraft:Any"));
     }
 
     @Test
     void noSpace() {
-        assertThrows(AssertionError.class, () -> NamespaceID.from("minecraft:a n y"));
+        assertThrows(IllegalArgumentException.class, () -> NamespaceID.from("minecraft:a n y"));
     }
 
     @Test
     void onlyLatinLowercase() {
-        assertThrows(AssertionError.class, () -> NamespaceID.from("Minecraft:voilà"));
-        assertThrows(AssertionError.class, () -> NamespaceID.from("minecraft:où_ça"));
-        assertThrows(AssertionError.class, () -> NamespaceID.from("minecraft:schrödingers_var"));
+        assertThrows(IllegalArgumentException.class, () -> NamespaceID.from("Minecraft:voilà"));
+        assertThrows(IllegalArgumentException.class, () -> NamespaceID.from("minecraft:où_ça"));
+        assertThrows(IllegalArgumentException.class, () -> NamespaceID.from("minecraft:schrödingers_var"));
     }
 
     @Test
     void numbersAllowed() {
-        NamespaceID.from("0xc1:468786471");
+        assertDoesNotThrow(() -> NamespaceID.from("0xc1:468786471"));
     }
 
     @Test
     void dotAllowedInPath() {
-        NamespaceID.from("minecraft:ambient.cave");
+        assertDoesNotThrow(() -> NamespaceID.from("minecraft:ambient.cave"));
     }
 
     @Test
     void slashAllowedInPath() {
-        NamespaceID.from("minecraft:textures/blocks/dirt.png");
+        assertDoesNotThrow(() -> NamespaceID.from("minecraft:textures/blocks/dirt.png"));
     }
 }


### PR DESCRIPTION
This improves the handling of Namespace Keys in Minestom. Assert is misbehavior in that case and should never in production code. In 99% of cases, the assert will never match because of the default Java behaviour. 
Check out following tutorial to understand why assert is not triggering: https://www.baeldung.com/java-assert