### PR TITLE
Add flag to modify the maximum amount of usable ServerLinks

### DIFF
--- a/src/main/java/net/minestom/server/ServerFlag.java
+++ b/src/main/java/net/minestom/server/ServerFlag.java
@@ -27,6 +27,7 @@ public final class ServerFlag {
     public static final int POOLED_BUFFER_SIZE = intProperty("minestom.pooled-buffer-size", 262_143);
     public static final int SEND_LIGHT_AFTER_BLOCK_PLACEMENT_DELAY = intProperty("minestom.send-light-after-block-placement-delay", 100);
     public static final long LOGIN_PLUGIN_MESSAGE_TIMEOUT = longProperty("minestom.login-plugin-message-timeout", 5_000);
+    public static final int SERVER_LINK_AMOUNT = intProperty("minestom.server-link-amount", 100);
 
     // Network rate limiting
     public static final int PLAYER_PACKET_PER_TICK = intProperty("minestom.packet-per-tick", 50);

--- a/src/main/java/net/minestom/server/network/packet/server/common/ServerLinksPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/common/ServerLinksPacket.java
@@ -1,6 +1,7 @@
 package net.minestom.server.network.packet.server.common;
 
 import net.kyori.adventure.text.Component;
+import net.minestom.server.ServerFlag;
 import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
@@ -11,7 +12,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public record ServerLinksPacket(@NotNull List<Entry> entries) implements ServerPacket.Configuration, ServerPacket.Play {
-    private static final int MAX_ENTRIES = 100;
 
     public ServerLinksPacket {
         entries = List.copyOf(entries);
@@ -64,7 +64,7 @@ public record ServerLinksPacket(@NotNull List<Entry> entries) implements ServerP
                 }
             }
         };
-        public static final NetworkBuffer.Type<List<Entry>> LIST_NETWORK_TYPE = NETWORK_TYPE.list(MAX_ENTRIES);
+        public static final NetworkBuffer.Type<List<Entry>> LIST_NETWORK_TYPE = NETWORK_TYPE.list(ServerFlag.SERVER_LINK_AMOUNT);
 
         public Entry {
             Check.argCondition(knownType == null && customType == null, "One of knownType and customType must be present");


### PR DESCRIPTION
## Proposed changes

The current maximum number of `ServerLinks` supported by the server is hardcoded into the specific packet structure. While this behavior is generally not an issue, it becomes problematic if a situation arises where a different limit is required, as it's not possible to adjust it. This pull request introduces a flag in the `ServerFlag` class, which can now be modified through a parameter.

Closes #83 

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
