### PR TITLE
Implement a way to override the prediction of start slot for inventory at shiftclick

### DIFF
--- a/src/main/java/net/minestom/server/inventory/AbstractInventory.java
+++ b/src/main/java/net/minestom/server/inventory/AbstractInventory.java
@@ -1,5 +1,6 @@
 package net.minestom.server.inventory;
 
+import net.minestom.server.entity.Player;
 import net.minestom.server.event.EventDispatcher;
 import net.minestom.server.event.inventory.InventoryItemChangeEvent;
 import net.minestom.server.event.inventory.PlayerInventoryItemChangeEvent;
@@ -55,6 +56,33 @@ public abstract sealed class AbstractInventory implements InventoryClickHandler,
                 "Inventory does not have the slot " + slot);
         safeItemInsert(slot, itemStack);
     }
+
+
+    // Microtus - fix shift click for inventory
+    /**
+     * Gets the slot for a shift click operation.
+     * <p>
+     * This is used to determine where the item should be placed when shift clicking.
+     *
+     * @param index the slot index
+     * @return the slot where the item should be placed when shift clicking
+     */
+    int getStartSlotForShiftClick(int index, Player player) {
+        return 0;
+    }
+
+    /**
+     * Gets the slot for a double click operation.
+     * <p>
+     * This is used to determine where the item should be placed when double-clicking.
+     *
+     * @param index the slot index
+     * @return the slot where the item should be placed when double-clicking
+     */
+    int getStartSlotForDoubleClick(int index, Player player) {
+        return 0;
+    }
+    // Microtus - fix shift click for inventory
 
     /**
      * Inserts safely an item into the inventory.

--- a/src/main/java/net/minestom/server/inventory/Inventory.java
+++ b/src/main/java/net/minestom/server/inventory/Inventory.java
@@ -246,7 +246,7 @@ public non-sealed class Inventory extends AbstractInventory implements Viewable 
         final InventoryClickResult clickResult = clickProcessor.shiftClick(
                 isInWindow ? this : playerInventory,
                 isInWindow ? playerInventory : this,
-                getStartSlotForShiftClick(slot, player), isInWindow ? playerInventory.getInnerSize() : getInnerSize(), 1, // Microtus - fix shift click for inventory
+                getStartSlotForShiftClick(clickSlot, player), isInWindow ? playerInventory.getInnerSize() : getInnerSize(), 1, // Microtus - fix shift click for inventory
                 player, clickSlot, clicked, cursor, button); // Microtus
         if (clickResult.isCancel()) {
             updateAll(player);

--- a/src/main/java/net/minestom/server/inventory/Inventory.java
+++ b/src/main/java/net/minestom/server/inventory/Inventory.java
@@ -246,7 +246,7 @@ public non-sealed class Inventory extends AbstractInventory implements Viewable 
         final InventoryClickResult clickResult = clickProcessor.shiftClick(
                 isInWindow ? this : playerInventory,
                 isInWindow ? playerInventory : this,
-                0, isInWindow ? playerInventory.getInnerSize() : getInnerSize(), 1,
+                getStartSlotForShiftClick(slot, player), isInWindow ? playerInventory.getInnerSize() : getInnerSize(), 1, // Microtus - fix shift click for inventory
                 player, clickSlot, clicked, cursor, button); // Microtus
         if (clickResult.isCancel()) {
             updateAll(player);
@@ -261,6 +261,29 @@ public non-sealed class Inventory extends AbstractInventory implements Viewable 
         playerInventory.setCursorItem(clickResult.getCursor());
         return true;
     }
+
+    // Microtus - fix shift click for inventory
+    @Override
+    int getStartSlotForShiftClick(int index, Player player) {
+        if (index == 0) {
+            return 9;
+        }
+        if (index >= 1 && index < 5) {
+            return 9;
+        }
+        // TODO: Add armor slot support
+        if (index >= 5 && index < 9) {
+            return 9;
+        }
+        if (index >= 9 && index < 36) {
+            return 36;
+        }
+        if (index >= 36 && index < 45) {
+            return 9;
+        }
+        return 9;
+    }
+    // Microtus - fix shift click for inventory
 
     @Override
     public boolean changeHeld(@NotNull Player player, int slot, int key) {
@@ -352,7 +375,7 @@ public non-sealed class Inventory extends AbstractInventory implements Viewable 
                 ItemStack.AIR;
         final ItemStack cursor = playerInventory.getCursorItem();
         final InventoryClickResult clickResult = clickProcessor.doubleClick(isInWindow ? this : playerInventory,
-                this, player, clickSlot, clicked, cursor);
+                this, player, clickSlot, clicked, cursor, getStartSlotForDoubleClick(slot, player)); // Microtus - fix shift click for inventory
         if (clickResult.isCancel()) {
             updateAll(player);
             return false;

--- a/src/main/java/net/minestom/server/inventory/PlayerInventory.java
+++ b/src/main/java/net/minestom/server/inventory/PlayerInventory.java
@@ -273,7 +273,8 @@ public non-sealed class PlayerInventory extends AbstractInventory implements Equ
         final int convertedSlot = convertPlayerInventorySlot(slot, OFFSET);
         final ItemStack cursor = getCursorItem();
         final ItemStack clicked = getItemStack(convertedSlot);
-        final InventoryClickResult clickResult = clickProcessor.doubleClick(this, this, player, convertedSlot, clicked, cursor);
+        final InventoryClickResult clickResult = clickProcessor.doubleClick(this, this, player, convertedSlot, clicked, cursor, getStartSlotForDoubleClick(slot, player));
+         // Microtus - fix shift click for inventory
         if (clickResult.isCancel()) {
             update();
             return false;

--- a/src/main/java/net/minestom/server/inventory/click/InventoryClickProcessor.java
+++ b/src/main/java/net/minestom/server/inventory/click/InventoryClickProcessor.java
@@ -289,7 +289,7 @@ public final class InventoryClickProcessor {
     }
 
     public @NotNull InventoryClickResult doubleClick(@NotNull AbstractInventory clickedInventory, @NotNull AbstractInventory inventory, @NotNull Player player, int slot,
-                                                     @NotNull ItemStack clicked, @NotNull ItemStack cursor) {
+                                                     @NotNull ItemStack clicked, @NotNull ItemStack cursor, int startSlot) { // Microtus - fix shift click for inventory
         InventoryClickResult clickResult = startCondition(player, clickedInventory, slot, ClickType.START_DOUBLE_CLICK, clicked, cursor);
         if (clickResult.isCancel()) return clickResult;
         if (cursor.isAir()) return clickResult.cancelled();
@@ -307,7 +307,7 @@ public final class InventoryClickProcessor {
                     return false;
                 final InventoryClickResult result = startCondition(player, inv, index, ClickType.DOUBLE_CLICK, itemStack, cursor);
                 return !result.isCancel();
-            });
+            }, startSlot, inventory.getInnerSize(), 1); // Microtus - fix shift click for inventory
             final ItemStack itemResult = pair.left();
             var itemChangesMap = pair.right();
             itemChangesMap.forEach((Integer s, ItemStack itemStack) -> {


### PR DESCRIPTION
## Proposed changes

This pr fixes possible client predictions of shift click/quick move

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [X] I have read the CONTRIBUTING.md
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...