### PR TITLE
Add utility method to verify active effects on an entity

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -1395,6 +1395,14 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     }
 
     /**
+     * Returns an indicator if the entity currently has any given effects.
+     * @return true if the entity has any effects, false otherwise
+     */
+    public boolean hasEffects() {
+        return !this.effects.isEmpty();
+    }
+
+    /**
      * Gets the TimedPotion of the specified effect.
      *
      * @param effect the effect type

--- a/src/test/java/net/minestom/server/entity/EntityEffectIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/EntityEffectIntegrationTest.java
@@ -1,0 +1,131 @@
+package net.minestom.server.entity;
+
+import net.minestom.server.instance.Instance;
+import net.minestom.server.potion.Potion;
+import net.minestom.server.potion.PotionEffect;
+import net.minestom.server.potion.TimedPotion;
+import net.minestom.testing.Env;
+import net.minestom.testing.extension.MicrotusExtension;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MicrotusExtension.class)
+public class EntityEffectIntegrationTest {
+
+    private static final Potion TEST_POTION = new Potion(PotionEffect.SPEED, (byte) 1, 1000);
+
+    @Test
+    void testEffectAdd(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        assertFalse(player.hasEffects());
+
+        player.addEffect(TEST_POTION);
+
+        assertTrue(player.hasEffects());
+        assertTrue(player.hasEffect(TEST_POTION.effect()));
+
+        assertFalse(player.getActiveEffects().isEmpty());
+
+        env.destroyInstance(instance, true);
+    }
+
+    @Test
+    void testEffectRemove(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        assertFalse(player.hasEffects());
+
+        player.addEffect(TEST_POTION);
+
+        assertTrue(player.hasEffects());
+
+        player.removeEffect(PotionEffect.ABSORPTION);
+        assertTrue(player.hasEffects());
+
+        player.removeEffect(TEST_POTION.effect());
+        assertFalse(player.hasEffects());
+
+        env.destroyInstance(instance, true);
+    }
+
+    @Test
+    void testClearEffectFromPlayer(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        assertFalse(player.hasEffects());
+
+        player.addEffect(TEST_POTION);
+
+        assertTrue(player.hasEffects());
+
+        player.clearEffects();
+        assertFalse(player.hasEffects());
+
+        env.destroyInstance(instance, true);
+    }
+
+    @Test
+    void testPotionGetWhichIsNotPresent(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        assertFalse(player.hasEffects());
+
+        TimedPotion potion = player.getEffect(PotionEffect.DARKNESS);
+        assertNull(potion);
+
+        env.destroyInstance(instance, true);
+    }
+
+    @Test
+    void testPotionGet(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        assertFalse(player.hasEffects());
+
+        player.addEffect(TEST_POTION);
+
+        TimedPotion potion = player.getEffect(PotionEffect.SPEED);
+        assertNotNull(potion);
+
+        env.destroyInstance(instance, true);
+    }
+
+    @Test
+    void testPotionLevelGet(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        assertFalse(player.hasEffects());
+
+        player.addEffect(new Potion(PotionEffect.ABSORPTION, (byte) 2, 1000));
+
+        int level = player.getEffectLevel(PotionEffect.ABSORPTION);
+        assertEquals(2, level);
+
+        env.destroyInstance(instance, true);
+    }
+
+    @DisplayName("Test negative potion level get, when the potion is not present")
+    @Test
+    void testNegativePotionLevelGet(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        assertFalse(player.hasEffects());
+
+        int level = player.getEffectLevel(PotionEffect.DARKNESS);
+        assertEquals(-1, level);
+
+        env.destroyInstance(instance, true);
+    }
+}

--- a/src/test/java/net/minestom/server/entity/EntityEffectIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/EntityEffectIntegrationTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MicrotusExtension.class)
-public class EntityEffectIntegrationTest {
+class EntityEffectIntegrationTest {
 
     private static final Potion TEST_POTION = new Potion(PotionEffect.SPEED, (byte) 1, 1000);
 


### PR DESCRIPTION
## Proposed changes

The entity class includes methods to add, remove, or retrieve potions, as well as access other relevant data associated with each potion. It also allows for clearing each effect applied to the entity. However, it currently lacks a direct way to check if any effect is active.

While it’s possible to check for effects using the existing method that retrieves all effects from an entity, the newly added shorthand method simplifies this check, reducing line complexity and improving code readability.

To enhance the maintainability of the project, new tests have been added to validate this method, along with additional test cases for other related functionalities.

~~**Note** If you want to verify the changes, you need to comment out the `GAME_EVENTS` enum entry in the `Tag` class otherwise the test in general will fail (that behaviour should be fixed in the future)~~

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)