### PR TITLE
Add connect method which use a default position

### DIFF
--- a/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
@@ -23,8 +23,6 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;

--- a/src/test/java/net/minestom/server/instance/WeatherTest.java
+++ b/src/test/java/net/minestom/server/instance/WeatherTest.java
@@ -1,9 +1,11 @@
 package net.minestom.server.instance;
 
 import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.Player;
 import net.minestom.server.network.packet.server.play.ChangeGameStatePacket;
 import net.minestom.testing.Env;
 import net.minestom.testing.extension.MicrotusExtension;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -14,11 +16,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @ExtendWith(MicrotusExtension.class)
 class WeatherTest {
-    @Test
-    void weatherTest(Env env) {
-        var instance = env.createFlatInstance();
 
-        // Defaults
+    @Test
+    void testWeatherDefaults(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
         Weather weather = instance.getWeather();
         assertFalse(weather.isRaining());
         assertEquals(0, weather.rainLevel());
@@ -27,20 +28,29 @@ class WeatherTest {
         instance.setWeather(new Weather(1, 0.5f), 1);
         instance.tick(0);
 
+        env.destroyInstance(instance);
+    }
+
+    @Test
+    void testWeatherSendOnJoin(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+
         // Weather sent on instance join
         var connection = env.createConnection();
-        var tracker = connection.trackIncoming(ChangeGameStatePacket.class);
-        connection.connect(instance, new Pos(0, 0, 0)).join();
+        var tracker = connection.trackIncoming(ChangeGameStatePacket.class)
+                ;
+        Player player = connection.connect(instance).join();
+        assertEquals(Pos.ZERO, player.getPosition());
         tracker.assertCount(4);
         List<ChangeGameStatePacket> packets = tracker.collect();
-        var state = packets.get(0);
+        var state = packets.getFirst();
         assertEquals(ChangeGameStatePacket.Reason.BEGIN_RAINING, state.reason());
 
         state = packets.get(1);
         assertEquals(ChangeGameStatePacket.Reason.RAIN_LEVEL_CHANGE, state.reason());
         assertEquals(1, state.value());
 
-        state = packets.get(2);
+        state = packets.getLast();
         assertEquals(ChangeGameStatePacket.Reason.THUNDER_LEVEL_CHANGE, state.reason());
         assertEquals(0.5f, state.value());
 
@@ -48,7 +58,7 @@ class WeatherTest {
         var tracker2 = connection.trackIncoming(ChangeGameStatePacket.class);
         instance.setWeather(new Weather(0, 0), 2);
         instance.tick(0);
-        state = tracker2.collect().get(0);
+        state = tracker2.collect().getFirst();
         assertEquals(ChangeGameStatePacket.Reason.RAIN_LEVEL_CHANGE, state.reason());
         assertEquals(0.5f, state.value());
     }

--- a/src/test/java/net/minestom/server/instance/WeatherTest.java
+++ b/src/test/java/net/minestom/server/instance/WeatherTest.java
@@ -37,8 +37,7 @@ class WeatherTest {
 
         // Weather sent on instance join
         var connection = env.createConnection();
-        var tracker = connection.trackIncoming(ChangeGameStatePacket.class)
-                ;
+        var tracker = connection.trackIncoming(ChangeGameStatePacket.class);
         Player player = connection.connect(instance).join();
         assertEquals(Pos.ZERO, player.getPosition());
         tracker.assertCount(4);

--- a/src/test/java/net/minestom/server/instance/WeatherTest.java
+++ b/src/test/java/net/minestom/server/instance/WeatherTest.java
@@ -25,15 +25,15 @@ class WeatherTest {
         assertEquals(0, weather.rainLevel());
         assertEquals(0, weather.thunderLevel());
 
-        instance.setWeather(new Weather(1, 0.5f), 1);
-        instance.tick(0);
-
         env.destroyInstance(instance);
     }
 
     @Test
     void testWeatherSendOnJoin(@NotNull Env env) {
         Instance instance = env.createFlatInstance();
+
+        instance.setWeather(new Weather(1, 0.5f), 1);
+        instance.tick(0);
 
         // Weather sent on instance join
         var connection = env.createConnection();
@@ -50,7 +50,7 @@ class WeatherTest {
         assertEquals(ChangeGameStatePacket.Reason.RAIN_LEVEL_CHANGE, state.reason());
         assertEquals(1, state.value());
 
-        state = packets.getLast();
+        state = packets.get(2);
         assertEquals(ChangeGameStatePacket.Reason.THUNDER_LEVEL_CHANGE, state.reason());
         assertEquals(0.5f, state.value());
 

--- a/testing/src/main/java/net/minestom/testing/TestConnection.java
+++ b/testing/src/main/java/net/minestom/testing/TestConnection.java
@@ -11,6 +11,9 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * Represents a connection to a test server.
+ *
+ * @version 1.1.0
+ * @since 1.0.0
  */
 public interface TestConnection {
 
@@ -30,6 +33,7 @@ public interface TestConnection {
      *    }
      * }
      * }</pre>
+     *
      * @param provider the custom player provider
      */
     void setCustomPlayerProvider(@NotNull PlayerProvider provider);
@@ -42,6 +46,16 @@ public interface TestConnection {
      * @return a future that completes when the player is connected
      */
     @NotNull CompletableFuture<@NotNull Player> connect(@NotNull Instance instance, @NotNull Pos pos);
+
+    /**
+     * Connects a player to the server at position (0, 0, 0).
+     *
+     * @param instance the instance to spawn the player in
+     * @return a future that completes when the player is connected
+     */
+    default @NotNull CompletableFuture<@NotNull Player> connect(@NotNull Instance instance) {
+        return this.connect(instance, Pos.ZERO);
+    }
 
     /**
      * Tracks incoming packets of a specific type.


### PR DESCRIPTION
## Proposed changes

The `TestConnection` class provides a method for connecting to the test server, which takes an `Instance` and a `Pos` as parameters. To enhance usability, this pull request introduces a new method that defaults to `Pos.ZERO` as the spawn position, simplifying test creation when the specific position is not critical.

The original method with two parameters remains unchanged, and its logic is unchanged too.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)