### PR TITLE
Fix wrong mapped meta tags for the client and via version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,7 @@ tasks {
             addStringOption("-release", "21")
             // Links to external javadocs
             links("https://docs.oracle.com/en/java/javase/21/docs/api/")
-            links("https://jd.adventure.kyori.net/api/${libs.versions.adventure.get()}/")
+            links("https://jd.advntr.dev/api/${libs.versions.adventure.get()}/")
         }
     }
     withType<Zip> {

--- a/src/main/java/net/minestom/server/game/GameEventImpl.java
+++ b/src/main/java/net/minestom/server/game/GameEventImpl.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 record GameEventImpl(Registry.GameEventEntry registry, NamespaceID namespace, int id) implements GameEvent {
     private static final AtomicInteger INDEX = new AtomicInteger();
-    private static final Registry.Container<GameEvent> CONTAINER = Registry.createStaticContainer(Registry.Resource.GAMEPLAY_TAGS, GameEventImpl::createImpl);
+    private static final Registry.Container<GameEvent> CONTAINER = Registry.createStaticContainer(Registry.Resource.GAME_EVENTS, GameEventImpl::createImpl);
 
     /**
      * Creates a new {@link GameEventImpl} with the given namespace and properties.
@@ -36,7 +36,7 @@ record GameEventImpl(Registry.GameEventEntry registry, NamespaceID namespace, in
      * @param registry the registry
      */
     private GameEventImpl(Registry.GameEventEntry registry) {
-        this(registry, registry.namespace(), INDEX.getAndIncrement());
+        this(registry, registry.namespace(), registry.main().getInt("id"));
     }
 
     /**

--- a/src/main/java/net/minestom/server/gamedata/tags/Tag.java
+++ b/src/main/java/net/minestom/server/gamedata/tags/Tag.java
@@ -12,14 +12,12 @@ import net.minestom.server.registry.DynamicRegistry;
 import net.minestom.server.registry.ProtocolObject;
 import net.minestom.server.registry.Registry;
 import net.minestom.server.utils.NamespaceID;
-import net.minestom.server.world.biome.Biome;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;

--- a/src/main/java/net/minestom/server/gamedata/tags/Tag.java
+++ b/src/main/java/net/minestom/server/gamedata/tags/Tag.java
@@ -12,6 +12,7 @@ import net.minestom.server.registry.DynamicRegistry;
 import net.minestom.server.registry.ProtocolObject;
 import net.minestom.server.registry.Registry;
 import net.minestom.server.utils.NamespaceID;
+import net.minestom.server.world.biome.Biome;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -96,10 +97,12 @@ public final class Tag implements ProtocolObject, Keyed {
                 name -> Optional.ofNullable(Material.fromNamespaceId(name)).map(Material::id)),
         FLUIDS("minecraft:fluid", Registry.Resource.FLUID_TAGS,
                 name -> Optional.ofNullable(Fluid.fromNamespaceId(name)).map(Fluid::id)),
+        BIOMES("minecraft:worldgen/biome", Registry.Resource.BIOME_TAGS,
+                name -> Optional.of(DynamicRegistry.Key.of(name)).map(DynamicRegistry.Key::namespace).map(MinecraftServer.getBiomeRegistry()::getId)),
         ENTITY_TYPES("minecraft:entity_type", Registry.Resource.ENTITY_TYPE_TAGS,
                 name -> Optional.ofNullable(EntityType.fromNamespaceId(name)).map(EntityType::id)),
         GAME_EVENTS("minecraft:game_event", Registry.Resource.GAMEPLAY_TAGS,
-                name -> Optional.ofNullable(EntityType.fromNamespaceId(name)).map(EntityType::id)),
+                name -> Optional.ofNullable(GameEvent.fromNamespaceId(name)).map(GameEvent::id)),
         SOUND_EVENTS("minecraft:sound_event", null, null), // Seems not to be included in server data
         POTION_EFFECTS("minecraft:sound_event", null, null), // Seems not to be included in server data
 

--- a/src/main/java/net/minestom/server/gamedata/tags/Tag.java
+++ b/src/main/java/net/minestom/server/gamedata/tags/Tag.java
@@ -90,25 +90,24 @@ public final class Tag implements ProtocolObject, Keyed {
 
     public enum BasicType {
         BLOCKS("minecraft:block", Registry.Resource.BLOCK_TAGS,
-                name -> Optional.ofNullable(Block.fromNamespaceId(name)).map(Block::id)),
+                blockName -> Optional.ofNullable(Block.fromNamespaceId(blockName)).map(Block::id)),
         ITEMS("minecraft:item", Registry.Resource.ITEM_TAGS,
-                name -> Optional.ofNullable(Material.fromNamespaceId(name)).map(Material::id)),
+                itemName -> Optional.ofNullable(Material.fromNamespaceId(itemName)).map(Material::id)),
         FLUIDS("minecraft:fluid", Registry.Resource.FLUID_TAGS,
-                name -> Optional.ofNullable(Fluid.fromNamespaceId(name)).map(Fluid::id)),
+                fluidName -> Optional.ofNullable(Fluid.fromNamespaceId(fluidName)).map(Fluid::id)),
         BIOMES("minecraft:worldgen/biome", Registry.Resource.BIOME_TAGS,
-                name -> Optional.of(DynamicRegistry.Key.of(name)).map(DynamicRegistry.Key::namespace).map(MinecraftServer.getBiomeRegistry()::getId)),
+                biomeName -> Optional.of(DynamicRegistry.Key.of(biomeName)).map(DynamicRegistry.Key::namespace).map(MinecraftServer.getBiomeRegistry()::getId)),
         ENTITY_TYPES("minecraft:entity_type", Registry.Resource.ENTITY_TYPE_TAGS,
-                name -> Optional.ofNullable(EntityType.fromNamespaceId(name)).map(EntityType::id)),
+                entityName -> Optional.ofNullable(EntityType.fromNamespaceId(entityName)).map(EntityType::id)),
         GAME_EVENTS("minecraft:game_event", Registry.Resource.GAMEPLAY_TAGS,
-                name -> Optional.ofNullable(GameEvent.fromNamespaceId(name)).map(GameEvent::id)),
+                eventName -> Optional.ofNullable(GameEvent.fromNamespaceId(eventName)).map(GameEvent::id)),
         SOUND_EVENTS("minecraft:sound_event", null, null), // Seems not to be included in server data
         POTION_EFFECTS("minecraft:sound_event", null, null), // Seems not to be included in server data
-
         //todo this is cursed. it does not update as the registry changes. Fix later.
         ENCHANTMENTS("minecraft:enchantment", Registry.Resource.ENCHANTMENT_TAGS,
-                name -> Optional.of(DynamicRegistry.Key.of(name)).map(DynamicRegistry.Key::namespace).map(MinecraftServer.getEnchantmentRegistry()::getId)),;
+                enchName -> Optional.of(DynamicRegistry.Key.of(enchName)).map(DynamicRegistry.Key::namespace).map(MinecraftServer.getEnchantmentRegistry()::getId)),;
 
-        private final static BasicType[] VALUES = values();
+        private static final BasicType[] VALUES = values();
         private final String identifier;
         private final Registry.Resource resource;
         private final Function<String, Optional<Integer>> function;

--- a/src/main/java/net/minestom/server/registry/Registry.java
+++ b/src/main/java/net/minestom/server/registry/Registry.java
@@ -245,6 +245,8 @@ public final class Registry {
         ENTITY_TYPE_TAGS("tags/entity_type.json"),
         FLUID_TAGS("tags/fluid.json"),
         GAMEPLAY_TAGS("tags/game_event.json"),
+        GAME_EVENTS("game_events.json"),
+        BIOME_TAGS("tags/biome.json"),
         ITEM_TAGS("tags/item.json"),
         ENCHANTMENT_TAGS("tags/enchantment.json"),
         DIMENSION_TYPES("dimension_types.json"),
@@ -562,7 +564,7 @@ public final class Registry {
         }
     }
 
-    public static final record GameEventEntry(NamespaceID namespace, Properties main, Properties custom) implements Entry {
+    public record GameEventEntry(NamespaceID namespace, Properties main, Properties custom) implements Entry {
         public GameEventEntry(String namespace, Properties main, Properties custom) {
             this(NamespaceID.from(namespace), main, custom);
         }


### PR DESCRIPTION
## Proposed changes

This PR fixes some small isues with 1.21.4 client and via version.

Fixes https://github.com/ViaVersion/ViaVersion/issues/4241


## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [X] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

## Further comments

Since 1.21.3 the client checks very persicily which tags are send and which are not. 

In some cases the upstream forgot the tags or mapped wrong for the client. Also we found out, Velocity don't display such errors in the console only in the log, but that behavior can maybe only our problem because our "Cloud"-Solution. 